### PR TITLE
Fix staff nav overlap and system question config visibility

### DIFF
--- a/app/admin/configuration/QuestionsTab.tsx
+++ b/app/admin/configuration/QuestionsTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { User, UserRole, Team } from "@/lib/models/User";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { ApplicationQuestion, ApplicationQuestionsConfig } from "@/lib/models/Config";
 import { Plus, Trash2, Save, ChevronUp, ChevronDown, ChevronRight, Loader2, Clock, Info } from "lucide-react";
 import toast from "react-hot-toast";
@@ -17,6 +18,17 @@ const teamColors: Record<string, string> = {
 };
 
 const optionStyle = { backgroundColor: "#0c1218", color: "white" };
+
+// Canonical system list (unique names, alphabetical) with the teams each
+// appears on. Question storage is keyed by bare system name, so a name shared
+// across teams (e.g. Aerodynamics) is one question list for all of them.
+const SYSTEM_TEAMS = new Map<string, Team[]>();
+Object.values(Team).forEach((team) => {
+  TEAM_SYSTEMS[team].forEach(({ value }) => {
+    SYSTEM_TEAMS.set(value, [...(SYSTEM_TEAMS.get(value) || []), team]);
+  });
+});
+const ALL_SYSTEMS = [...SYSTEM_TEAMS.keys()].sort((a, b) => a.localeCompare(b));
 
 export function QuestionsTab({ userData }: QuestionsTabProps) {
   const [config, setConfig] = useState<ApplicationQuestionsConfig | null>(null);
@@ -412,7 +424,8 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
     scope: "common" | "team" | "system",
     key: string,
     canEdit: boolean,
-    color?: string
+    color?: string,
+    subtitle?: string
   ) => {
     const isExpanded = expandedSections[key] ?? false;
 
@@ -438,6 +451,9 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
             }
             <span className="font-montserrat text-[14px] font-semibold text-white/80">{title}</span>
             <span className="text-[12px] font-urbanist text-white/25">({questions.length} questions)</span>
+            {subtitle && (
+              <span className="text-[12px] font-urbanist text-white/25">{subtitle}</span>
+            )}
           </div>
           {canEdit && (
             <span
@@ -577,32 +593,43 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
         })}
       </div>
 
-      {/* System Questions */}
-      {config.systemQuestions && Object.keys(config.systemQuestions).length > 0 && (
-        <div className="space-y-4">
-          <h3
-            className="text-[11px] font-semibold tracking-widest uppercase"
-            style={{ color: "var(--lhr-gray-blue)" }}
-          >
-            System-Specific Questions
-          </h3>
-          {Object.entries(config.systemQuestions).map(([system, questions]) => {
-            if (!isAdmin && system !== userSystem && questions.length === 0) return null;
+      {/* System Questions — every canonical system renders (questions are
+          created lazily on first save), plus any stored key that no longer
+          matches a current system so its questions stay reachable. */}
+      <div className="space-y-4">
+        <h3
+          className="text-[11px] font-semibold tracking-widest uppercase"
+          style={{ color: "var(--lhr-gray-blue)" }}
+        >
+          System-Specific Questions
+        </h3>
+        {[
+          ...ALL_SYSTEMS,
+          ...Object.keys(config.systemQuestions || {})
+            .filter((k) => !SYSTEM_TEAMS.has(k))
+            .sort(),
+        ].map((system) => {
+          const questions = config.systemQuestions?.[system] || [];
+          if (!isAdmin && system !== userSystem && questions.length === 0) return null;
+          const systemTeams = SYSTEM_TEAMS.get(system);
 
-            return (
-              <div key={system}>
-                {renderSection(
-                  `${system} System`,
-                  questions,
-                  "system",
-                  system,
-                  canEditSystem(system)
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
+          return (
+            <div key={system}>
+              {renderSection(
+                `${system} System`,
+                questions,
+                "system",
+                system,
+                canEditSystem(system),
+                undefined,
+                systemTeams
+                  ? `applies to: ${systemTeams.join(", ")}`
+                  : "not in any current team"
+              )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -63,6 +63,10 @@ export default async function Header() {
     ? ADMIN_NAV.filter((item) => !item.restrictTo || item.restrictTo.includes(userRole!))
     : [];
 
+  // Staff carry both nav groups (~11 links), which only fits inline at 2xl+;
+  // below that they use the hamburger so the links never overlap the controls.
+  const desktopBreakpoint: 'lg' | '2xl' = isStaff ? '2xl' : 'lg';
+
   return (
     <header
       className="fixed top-0 left-0 right-0 z-50 transition-colors duration-300"
@@ -78,8 +82,10 @@ export default async function Header() {
         <Link href={logoHref} className="flex items-center gap-3 shrink-0">
           <LogoLockup size="sm" />
           {isStaff && (
+            // Hidden once the inline admin links appear at 2xl — redundant there,
+            // and the width matters at exactly the breakpoint.
             <span
-              className="hidden sm:inline-block text-[11px] font-semibold tracking-widest uppercase px-2 py-0.5 rounded"
+              className="hidden sm:inline-block 2xl:hidden text-[11px] font-semibold tracking-widest uppercase px-2 py-0.5 rounded"
               style={{
                 color: 'var(--pub-chip-blue-ink)',
                 backgroundColor: 'var(--pub-chip-blue-bg)',
@@ -92,7 +98,11 @@ export default async function Header() {
         </Link>
 
         {/* Nav links */}
-        <nav className="hidden lg:flex items-center gap-0.5 flex-1 min-w-0">
+        <nav
+          className={`${
+            desktopBreakpoint === '2xl' ? 'hidden 2xl:flex' : 'hidden lg:flex'
+          } items-center gap-0.5 flex-1 min-w-0`}
+        >
           {PUBLIC_NAV.map((link) => (
             <Link
               key={link.href}
@@ -159,6 +169,7 @@ export default async function Header() {
             publicNav={PUBLIC_NAV}
             adminNav={adminNavItems.map(({ href, label }) => ({ href, label }))}
             showApplyCta={!isStaff}
+            desktopBreakpoint={desktopBreakpoint}
           />
         </div>
         </HeaderUiProvider>

--- a/components/HeaderMobileMenu.tsx
+++ b/components/HeaderMobileMenu.tsx
@@ -12,11 +12,16 @@ export function HeaderMobileMenu({
   publicNav,
   adminNav,
   showApplyCta,
+  desktopBreakpoint = "lg",
 }: {
   publicNav: MobileNavItem[];
   adminNav: MobileNavItem[];
   showApplyCta: boolean;
+  /** Breakpoint at which the inline desktop nav takes over (staff need 2xl). */
+  desktopBreakpoint?: "lg" | "2xl";
 }) {
+  // Full literals so Tailwind's scanner generates both variants.
+  const hiddenAtDesktop = desktopBreakpoint === "2xl" ? "2xl:hidden" : "lg:hidden";
   const { openPanel, setOpenPanel } = useHeaderUi();
   const open = openPanel === "menu";
   const setOpen = (next: boolean) => setOpenPanel(next ? "menu" : null);
@@ -56,7 +61,7 @@ export function HeaderMobileMenu({
         aria-label={open ? "Close menu" : "Open menu"}
         aria-expanded={open}
         onClick={() => setOpen(!open)}
-        className="lg:hidden w-9 h-9 rounded-md flex items-center justify-center text-[var(--pub-text-2)] hover:text-[var(--pub-heading)] hover:bg-[var(--pub-surface-2)] transition-colors duration-200 cursor-pointer"
+        className={`${hiddenAtDesktop} w-9 h-9 rounded-md flex items-center justify-center text-[var(--pub-text-2)] hover:text-[var(--pub-heading)] hover:bg-[var(--pub-surface-2)] transition-colors duration-200 cursor-pointer`}
       >
         <span className="relative w-[18px] h-[18px] block" aria-hidden="true">
           <Menu
@@ -79,13 +84,13 @@ export function HeaderMobileMenu({
             type="button"
             aria-label="Close menu"
             onClick={() => setOpen(false)}
-            className="lg:hidden fixed inset-0 top-16 z-40 animate-fade-in"
+            className={`${hiddenAtDesktop} fixed inset-0 top-16 z-40 animate-fade-in`}
             style={{ backgroundColor: "var(--pub-scrim)", animationDuration: "0.15s" }}
           />
 
           {/* Panel */}
           <div
-            className="lg:hidden fixed left-0 right-0 top-16 z-50 max-h-[calc(100vh-4rem)] overflow-y-auto animate-fade-slide-down"
+            className={`${hiddenAtDesktop} fixed left-0 right-0 top-16 z-50 max-h-[calc(100vh-4rem)] overflow-y-auto animate-fade-slide-down`}
             style={{
               background: "var(--pub-menu-bg)",
               backdropFilter: "blur(20px) saturate(1.4)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Stop `next dev` from re-appending its agent-rules block to CLAUDE.md.
+  agentRules: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Staff got both nav groups inline at 1024px+, which overflowed and overlapped the header controls on most laptops. Staff now get the inline nav only at 1536px+ and the hamburger below that. Non-staff unchanged.
- The system questions section on the config tab only showed systems that already had saved questions (just Operations), so it looked out of sync with the teams page. It now lists every system, each showing which teams it applies to.
- Also stops next dev from re-appending its agent rules block to CLAUDE.md.