### PR TITLE
Fix system questions team keying and isolation

### DIFF
--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -26,6 +26,7 @@ import { User, UserRole, Team } from "@/lib/models/User";
 import { TEAM_SYSTEMS, SystemOption } from "@/lib/models/teamQuestions";
 import { Note, ReviewTask } from "@/lib/models/ApplicationExtras";
 import { ApplicationQuestion, RecruitingStep } from "@/lib/models/Config";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { getCommonAnswer, COMMON_FIELDS_SHOWN_ELSEWHERE } from "@/lib/utils/formAnswers";
 import { useApplications } from "./ApplicationsContext";
 import { useApplicationsLayout } from "./ApplicationsLayoutContext";
@@ -738,7 +739,8 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
 
               {/* System-specific answers, grouped by the system that asked. */}
               {(selectedApp.preferredSystems || []).map((system) => {
-                const questions = systemQuestions[system] || [];
+                const key = generateTeamSystemKey(selectedApp.team, system);
+                const questions = systemQuestions[key] || systemQuestions[system] || [];
                 const answered = questions.filter(
                   (q) => (selectedApp.formData.customAnswers || {})[q.id]
                 );

--- a/app/admin/configuration/QuestionsTab.tsx
+++ b/app/admin/configuration/QuestionsTab.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { User, UserRole, Team } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { ApplicationQuestion, ApplicationQuestionsConfig } from "@/lib/models/Config";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { Plus, Trash2, Save, ChevronUp, ChevronDown, ChevronRight, Loader2, Clock, Info } from "lucide-react";
 import toast from "react-hot-toast";
 
@@ -19,16 +20,23 @@ const teamColors: Record<string, string> = {
 
 const optionStyle = { backgroundColor: "#0c1218", color: "white" };
 
-// Canonical system list (unique names, alphabetical) with the teams each
-// appears on. Question storage is keyed by bare system name, so a name shared
-// across teams (e.g. Aerodynamics) is one question list for all of them.
-const SYSTEM_TEAMS = new Map<string, Team[]>();
+interface TeamSystemPair {
+  team: Team;
+  system: string;
+  key: string;
+}
+
+// Build list of all team + system pairs
+const ALL_TEAM_SYSTEM_PAIRS: TeamSystemPair[] = [];
 Object.values(Team).forEach((team) => {
-  TEAM_SYSTEMS[team].forEach(({ value }) => {
-    SYSTEM_TEAMS.set(value, [...(SYSTEM_TEAMS.get(value) || []), team]);
+  TEAM_SYSTEMS[team].forEach(({ value: system }) => {
+    ALL_TEAM_SYSTEM_PAIRS.push({
+      team,
+      system,
+      key: generateTeamSystemKey(team, system),
+    });
   });
 });
-const ALL_SYSTEMS = [...SYSTEM_TEAMS.keys()].sort((a, b) => a.localeCompare(b));
 
 export function QuestionsTab({ userData }: QuestionsTabProps) {
   const [config, setConfig] = useState<ApplicationQuestionsConfig | null>(null);
@@ -53,14 +61,30 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
       const res = await fetch("/api/admin/config/questions");
       if (!res.ok) throw new Error("Failed to fetch questions");
       const data = await res.json();
-      setConfig(data.config);
+
+      if (data.config) {
+        const normalizedConfig = { ...data.config };
+        if (normalizedConfig.systemQuestions) {
+          const sysQ = { ...normalizedConfig.systemQuestions };
+          ALL_TEAM_SYSTEM_PAIRS.forEach(({ system, key }) => {
+            if (sysQ[key] === undefined && sysQ[system] !== undefined) {
+              sysQ[key] = sysQ[system];
+            }
+          });
+          normalizedConfig.systemQuestions = sysQ;
+        }
+        setConfig(normalizedConfig);
+      } else {
+        setConfig(data.config);
+      }
 
       const defaultExpanded: Record<string, boolean> = { common: isAdmin };
       if (isTeamCaptain && userTeam) {
         defaultExpanded[userTeam] = true;
       }
-      if (isSystemLead && userSystem) {
-        defaultExpanded[userSystem] = true;
+      if (isSystemLead && userTeam && userSystem) {
+        const userKey = generateTeamSystemKey(userTeam, userSystem);
+        defaultExpanded[userKey] = true;
       }
       if (isAdmin) {
         Object.values(Team).forEach(team => {
@@ -82,7 +106,8 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
 
   const canEditCommon = isAdmin;
   const canEditTeam = (team: string) => isAdmin || (isTeamCaptain && team === userTeam);
-  const canEditSystem = (system: string) => isAdmin || (isSystemLead && system === userSystem);
+  const canEditSystemPair = (team: string, system: string) =>
+    isAdmin || (isSystemLead && team === userTeam && system === userSystem);
 
   const updateQuestion = (
     scope: "common" | "team" | "system",
@@ -203,7 +228,12 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
     });
   };
 
-  const saveSection = async (scope: "common" | "team" | "system", key?: string) => {
+  const saveSection = async (
+    scope: "common" | "team" | "system",
+    key?: string,
+    teamContext?: Team,
+    systemContext?: string
+  ) => {
     if (!config) return;
     setSaving(true);
 
@@ -216,8 +246,13 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
         body.team = key;
         body.questions = config.teamQuestions[key] || [];
       } else if (scope === "system" && key) {
-        body.system = key;
-        body.questions = config.systemQuestions?.[key] || [];
+        body.team = teamContext;
+        body.system = systemContext || key;
+        const pair = ALL_TEAM_SYSTEM_PAIRS.find((p) => p.key === key);
+        body.questions =
+          config.systemQuestions?.[key] ||
+          (config.systemQuestions?.[key] === undefined && pair ? config.systemQuestions?.[pair.system] : []) ||
+          [];
       }
 
       const res = await fetch("/api/admin/config/questions", {
@@ -484,7 +519,10 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
                   Add Question
                 </button>
                 <button
-                  onClick={() => saveSection(scope, key)}
+                  onClick={() => {
+                    const pair = ALL_TEAM_SYSTEM_PAIRS.find((p) => p.key === key);
+                    saveSection(scope, key, pair?.team, pair?.system);
+                  }}
                   disabled={saving}
                   className="flex items-center gap-2 px-4 py-2 rounded-lg text-[13px] font-semibold transition-all disabled:opacity-50"
                   style={{ backgroundColor: "var(--lhr-blue)", color: "white" }}
@@ -549,7 +587,7 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
               <>You can edit questions for your team: <strong>{userTeam}</strong></>
             )}
             {isSystemLead && (
-              <>You can edit system-specific questions for: <strong>{userSystem}</strong></>
+              <>You can edit system-specific questions for: <strong>{userTeam} — {userSystem}</strong></>
             )}
           </span>
         </div>
@@ -593,9 +631,7 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
         })}
       </div>
 
-      {/* System Questions — every canonical system renders (questions are
-          created lazily on first save), plus any stored key that no longer
-          matches a current system so its questions stay reachable. */}
+      {/* System Questions — grouped by Team and System */}
       <div className="space-y-4">
         <h3
           className="text-[11px] font-semibold tracking-widest uppercase"
@@ -603,28 +639,25 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
         >
           System-Specific Questions
         </h3>
-        {[
-          ...ALL_SYSTEMS,
-          ...Object.keys(config.systemQuestions || {})
-            .filter((k) => !SYSTEM_TEAMS.has(k))
-            .sort(),
-        ].map((system) => {
-          const questions = config.systemQuestions?.[system] || [];
-          if (!isAdmin && system !== userSystem && questions.length === 0) return null;
-          const systemTeams = SYSTEM_TEAMS.get(system);
+        {ALL_TEAM_SYSTEM_PAIRS.map(({ team, system, key }) => {
+          // Fall back to legacy bare system name if composite key has no questions yet
+          const questions =
+            config.systemQuestions?.[key] ||
+            (config.systemQuestions?.[key] === undefined ? config.systemQuestions?.[system] : []) ||
+            [];
+
+          const canEdit = canEditSystemPair(team, system);
+          if (!isAdmin && !canEdit && questions.length === 0) return null;
 
           return (
-            <div key={system}>
+            <div key={key}>
               {renderSection(
-                `${system} System`,
+                `${team} — ${system}`,
                 questions,
                 "system",
-                system,
-                canEditSystem(system),
-                undefined,
-                systemTeams
-                  ? `applies to: ${systemTeams.join(", ")}`
-                  : "not in any current team"
+                key,
+                canEdit,
+                teamColors[team]
               )}
             </div>
           );

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -6,6 +6,7 @@ import { Application } from "@/lib/models/Application";
 import { ScorecardSubmission } from "@/lib/models/Scorecard";
 import { Note } from "@/lib/models/ApplicationExtras";
 import { getApplicationQuestions } from "@/lib/firebase/config";
+import { getSystemQuestionKeyLabel } from "@/lib/models/teamQuestions";
 import { logger } from "@/lib/logger";
 
 
@@ -195,8 +196,8 @@ export async function POST(request: NextRequest) {
         customAnswerLabels = Object.fromEntries([
           ...questionsConfig.commonQuestions.map((q) => [q.id, q.label]),
           ...Object.entries(questionsConfig.systemQuestions || {}).flatMap(
-            ([system, questions]) =>
-              (questions || []).map((q) => [q.id, `${q.label} (${system})`])
+            ([systemKey, questions]) =>
+              (questions || []).map((q) => [q.id, `${q.label} (${getSystemQuestionKeyLabel(systemKey)})`])
           ),
         ]);
       } catch (err) {

--- a/app/api/admin/config/questions/route.ts
+++ b/app/api/admin/config/questions/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/firebase/config";
 import { UserRole, Team } from "@/lib/models/User";
 import { ApplicationQuestion } from "@/lib/models/Config";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
 
 
@@ -88,10 +89,10 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden: Can only edit your own team's questions" }, { status: 403 });
     }
 
-    // System Lead can only update their own system's questions
+    // System Lead can only update their own system's questions (must match their team AND system)
     if (userRole === UserRole.SYSTEM_LEAD) {
-      if (scope === "system" && system === userSystem) {
-        await updateSystemQuestions(system, questions, uid);
+      if (scope === "system" && system === userSystem && userTeam && (!team || team === userTeam)) {
+        await updateSystemQuestions(system, questions, uid, userTeam);
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own system's questions" }, { status: 403 });
@@ -140,7 +141,7 @@ async function handleUpdate(
       break;
     case "system":
       if (!data.system || !data.questions) throw new Error("System and questions required for 'system' scope");
-      await updateSystemQuestions(data.system, data.questions, adminId);
+      await updateSystemQuestions(data.system, data.questions, adminId, data.team);
       break;
   }
 }

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -13,6 +13,7 @@ import { TEAM_SYSTEMS, TEAM_INFO } from "@/lib/models/teamQuestions";
 import { isNamedCommonField } from "@/lib/utils/formAnswers";
 import { BRAND_TEAM_COLORS, getBrandTeamInk } from "@/lib/teamColors";
 import { ApplicationQuestion, RecruitingStep } from "@/lib/models/Config";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { routes } from "@/lib/routes";
 import { useApplications } from "@/hooks/useApplications";
 import ApplicationsNotOpenNotice from "@/components/ApplicationsNotOpenNotice";
@@ -316,10 +317,13 @@ export default function TeamApplicationPage() {
   const isEditingSubmitted = application?.status === ApplicationStatus.SUBMITTED;
 
   // System questions for the systems this applicant actually ranked, in rank
-  // order. Deselecting a system hides its questions (previous answers are kept
-  // but no longer required).
+  // order. Looks up composite key (e.g., "electric-aerodynamics") with fallback to bare system name.
   const activeSystemQuestions = formData.preferredSystems
-    .map((system) => ({ system, questions: systemQuestions[system] || [] }))
+    .map((system) => {
+      const key = team ? generateTeamSystemKey(team, system) : system;
+      const questions = systemQuestions[key] || systemQuestions[system] || [];
+      return { system, questions };
+    })
     .filter(({ questions }) => questions.length > 0);
 
   // Answers to questions with no named field — system questions and any common

--- a/lib/firebase/config.ts
+++ b/lib/firebase/config.ts
@@ -2,6 +2,7 @@ import { adminDb } from "./admin";
 import { RecruitingConfig, RecruitingStep, Announcement, ApplicationQuestionsConfig, ApplicationQuestion, TeamsConfig, TeamDescription, SubsystemDescription, AboutPageConfig, AboutSection, DashboardConfig, DashboardDeadline, DashboardResource, FaqConfig, FaqItem, ContactPageConfig, ContactChannel } from "@/lib/models/Config";
 import { COMMON_QUESTIONS, TEAM_QUESTIONS } from "@/lib/models/teamQuestions";
 import { Team, ElectricSystem, SolarSystem, CombustionSystem } from "@/lib/models/User";
+import { generateTeamSystemKey } from "./utils";
 import { EmailTemplatesConfig, EmailTemplate, DEFAULT_EMAIL_TEMPLATES } from "@/lib/models/EmailTemplate";
 
 const CONFIG_COLLECTION = "config";
@@ -234,20 +235,24 @@ export async function updateCommonQuestions(
 }
 
 /**
- * Update questions for a specific system (optional feature)
+ * Update questions for a specific system (optional feature).
+ * Can accept composite key (e.g., "electric-aerodynamics") or team + system.
  */
 export async function updateSystemQuestions(
-  system: string,
+  systemKeyOrName: string,
   questions: ApplicationQuestion[],
-  adminId: string
+  adminId: string,
+  team?: string
 ): Promise<void> {
   const currentConfig = await getApplicationQuestions();
+
+  const key = team ? generateTeamSystemKey(team, systemKeyOrName) : systemKeyOrName;
 
   const data = stripUndefined({
     ...currentConfig,
     systemQuestions: {
       ...(currentConfig.systemQuestions || {}),
-      [system]: cleanQuestions(questions),
+      [key]: cleanQuestions(questions),
     },
     updatedAt: new Date(),
     updatedBy: adminId,

--- a/lib/firebase/utils.ts
+++ b/lib/firebase/utils.ts
@@ -1,9 +1,31 @@
 /**
+ * Slugify a team name for document IDs or config keys.
+ * Lowercases and collapses spaces to hyphens (e.g., "Electric" -> "electric").
+ */
+export function slugifyTeam(team: string | undefined | null): string {
+  if (!team) return '';
+  return team.toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
  * Slugify a system name for use in Firestore document IDs or field names.
  * Lowercases, drops ampersands, and collapses spaces/slashes to hyphens —
  * e.g. "Vehicle Modeling & Software" → "vehicle-modeling-software",
  * "Sim/Val" → "sim-val". Ampersands must not reach doc IDs or URL params.
  */
-export function slugifySystem(name: string): string {
+export function slugifySystem(name: string | undefined | null): string {
+  if (!name) return '';
   return name.toLowerCase().replace(/&/g, '').replace(/[\s/]+/g, '-');
+}
+
+/**
+ * Generate a composite key for a team and system combo.
+ * Format: {teamSlug}-{systemSlug} (e.g., "electric-aerodynamics").
+ */
+export function generateTeamSystemKey(team: string | undefined | null, system: string | undefined | null): string {
+  const t = slugifyTeam(team);
+  const s = slugifySystem(system);
+  if (!t) return s;
+  if (!s) return t;
+  return `${t}-${s}`;
 }

--- a/lib/models/teamQuestions.ts
+++ b/lib/models/teamQuestions.ts
@@ -1,5 +1,6 @@
 import { Team, ElectricSystem, SolarSystem, CombustionSystem } from "./User";
 import { TEAM_COLORS } from "@/lib/teamColors";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 
 export interface TeamQuestion {
   id: string;
@@ -30,6 +31,20 @@ export const TEAM_SYSTEMS: Record<Team, SystemOption[]> = {
     label: sys,
   })),
 };
+
+/**
+ * Human-readable label for a systemQuestions key (composite "{team}-{system}"
+ * or a legacy bare system name). Falls back to the raw key for orphaned/
+ * unrecognized keys so callers never render "undefined".
+ */
+export function getSystemQuestionKeyLabel(key: string): string {
+  for (const team of Object.values(Team)) {
+    for (const { value: system } of TEAM_SYSTEMS[team]) {
+      if (generateTeamSystemKey(team, system) === key) return `${team} — ${system}`;
+    }
+  }
+  return key;
+}
 
 // Team-specific questions
 export const TEAM_QUESTIONS: Record<Team, TeamQuestion[]> = {


### PR DESCRIPTION
Key system-specific application questions by composite team-system keys (`{teamSlug}-{systemSlug}`) to avoid collisions across teams sharing system names, enforce team+system access control for system leads, and maintain backward compatibility for existing legacy bare-system question keys.

---
*PR created automatically by Jules for task [3641168284694255250](https://jules.google.com/task/3641168284694255250) started by @dhairs*