### PR TITLE
Inline admin links with a Site menu for staff

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import { LogoutButton } from './LogoutButton';
 import { ThemeToggle } from '@/app/admin/_components/ThemeToggle';
 import { HeaderMobileMenu } from './HeaderMobileMenu';
 import { HeaderUiProvider } from './HeaderUi';
+import { HeaderSiteMenu } from './HeaderSiteMenu';
 import { cookies } from 'next/headers';
 import { adminAuth } from '@/lib/firebase/admin';
 import { getUser } from '@/lib/firebase/users';
@@ -63,9 +64,10 @@ export default async function Header() {
     ? ADMIN_NAV.filter((item) => !item.restrictTo || item.restrictTo.includes(userRole!))
     : [];
 
-  // Staff carry both nav groups (~11 links), which only fits inline at 2xl+;
-  // below that they use the hamburger so the links never overlap the controls.
-  const desktopBreakpoint: 'lg' | '2xl' = isStaff ? '2xl' : 'lg';
+  // Staff get the admin links inline with the public pages folded into a
+  // "Site" menu; that row needs ~1130px worst case, so it appears at xl+ and
+  // the hamburger covers narrower viewports. Non-staff fit at lg.
+  const desktopBreakpoint: 'lg' | 'xl' = isStaff ? 'xl' : 'lg';
 
   return (
     <header
@@ -77,15 +79,16 @@ export default async function Header() {
         borderBottom: '1px solid var(--pub-nav-border)',
       }}
     >
+      <HeaderUiProvider>
       <div className="container mx-auto px-6 md:px-10 max-w-[1600px] h-16 flex items-center justify-between gap-6">
         {/* Logo lockup — full color on light, white variant on dark (brand rule) */}
         <Link href={logoHref} className="flex items-center gap-3 shrink-0">
           <LogoLockup size="sm" />
           {isStaff && (
-            // Hidden once the inline admin links appear at 2xl — redundant there,
+            // Hidden once the inline admin links appear at xl — redundant there,
             // and the width matters at exactly the breakpoint.
             <span
-              className="hidden sm:inline-block 2xl:hidden text-[11px] font-semibold tracking-widest uppercase px-2 py-0.5 rounded"
+              className="hidden sm:inline-block xl:hidden text-[11px] font-semibold tracking-widest uppercase px-2 py-0.5 rounded"
               style={{
                 color: 'var(--pub-chip-blue-ink)',
                 backgroundColor: 'var(--pub-chip-blue-bg)',
@@ -100,18 +103,22 @@ export default async function Header() {
         {/* Nav links */}
         <nav
           className={`${
-            desktopBreakpoint === '2xl' ? 'hidden 2xl:flex' : 'hidden lg:flex'
+            desktopBreakpoint === 'xl' ? 'hidden xl:flex' : 'hidden lg:flex'
           } items-center gap-0.5 flex-1 min-w-0`}
         >
-          {PUBLIC_NAV.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="relative px-3.5 py-1.5 text-[15px] font-semibold text-[var(--pub-text-2)] hover:text-[var(--pub-heading)] transition-colors duration-200 rounded-md hover:bg-[var(--pub-surface-2)]"
-            >
-              {link.label}
-            </Link>
-          ))}
+          {isStaff ? (
+            <HeaderSiteMenu links={PUBLIC_NAV} />
+          ) : (
+            PUBLIC_NAV.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="relative px-3.5 py-1.5 text-[15px] font-semibold text-[var(--pub-text-2)] hover:text-[var(--pub-heading)] transition-colors duration-200 rounded-md hover:bg-[var(--pub-surface-2)]"
+              >
+                {link.label}
+              </Link>
+            ))
+          )}
 
           {adminNavItems.length > 0 && (
             <>
@@ -134,7 +141,6 @@ export default async function Header() {
         </nav>
 
         {/* Right side — controls + auth */}
-        <HeaderUiProvider>
         <div className="flex items-center gap-2 sm:gap-3 shrink-0">
           <LogoutButton />
           <ThemeToggle />
@@ -172,8 +178,8 @@ export default async function Header() {
             desktopBreakpoint={desktopBreakpoint}
           />
         </div>
-        </HeaderUiProvider>
       </div>
+      </HeaderUiProvider>
     </header>
   );
 }

--- a/components/HeaderMobileMenu.tsx
+++ b/components/HeaderMobileMenu.tsx
@@ -17,11 +17,11 @@ export function HeaderMobileMenu({
   publicNav: MobileNavItem[];
   adminNav: MobileNavItem[];
   showApplyCta: boolean;
-  /** Breakpoint at which the inline desktop nav takes over (staff need 2xl). */
-  desktopBreakpoint?: "lg" | "2xl";
+  /** Breakpoint at which the inline desktop nav takes over (staff need xl). */
+  desktopBreakpoint?: "lg" | "xl";
 }) {
   // Full literals so Tailwind's scanner generates both variants.
-  const hiddenAtDesktop = desktopBreakpoint === "2xl" ? "2xl:hidden" : "lg:hidden";
+  const hiddenAtDesktop = desktopBreakpoint === "xl" ? "xl:hidden" : "lg:hidden";
   const { openPanel, setOpenPanel } = useHeaderUi();
   const open = openPanel === "menu";
   const setOpen = (next: boolean) => setOpenPanel(next ? "menu" : null);

--- a/components/HeaderSiteMenu.tsx
+++ b/components/HeaderSiteMenu.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef } from "react";
+import { ChevronDown } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useHeaderUi } from "./HeaderUi";
+
+export type SiteMenuLink = { href: string; label: string };
+
+/**
+ * Desktop "Site" dropdown for staff: the public pages fold in here so the
+ * admin links get the inline nav row. Shares HeaderUi so only one header
+ * panel (this, the profile menu, the hamburger) is ever open at a time.
+ */
+export function HeaderSiteMenu({ links }: { links: SiteMenuLink[] }) {
+  const { openPanel, setOpenPanel } = useHeaderUi();
+  const open = openPanel === "site";
+  const pathname = usePathname();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Close whenever the route changes.
+  useEffect(() => {
+    if (open) setOpenPanel(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // Click outside or Escape closes; Escape also returns focus to the trigger.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpenPanel(null);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpenPanel(null);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, setOpenPanel]);
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpenPanel(open ? null : "site")}
+        className={`relative flex items-center gap-1 px-3.5 py-1.5 text-[15px] font-semibold transition-colors duration-200 rounded-md cursor-pointer hover:text-[var(--pub-heading)] hover:bg-[var(--pub-surface-2)] ${
+          open ? "text-[var(--pub-heading)] bg-[var(--pub-surface-2)]" : "text-[var(--pub-text-2)]"
+        }`}
+      >
+        Site
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute left-0 mt-2 w-48 rounded-lg py-2 z-50 overflow-hidden animate-fade-slide-down"
+          style={{
+            backgroundColor: "var(--pub-menu-bg)",
+            border: "1px solid var(--pub-menu-border)",
+            boxShadow: "var(--pub-shadow)",
+          }}
+        >
+          {links.map((link) => {
+            const isActive =
+              link.href === "/" ? pathname === "/" : (pathname?.startsWith(link.href) ?? false);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                role="menuitem"
+                onClick={() => setOpenPanel(null)}
+                className={`block px-4 py-2 text-[13px] font-medium transition-colors duration-150 hover:bg-[var(--pub-surface-2)] ${
+                  isActive ? "" : "text-[var(--pub-text-2)] hover:text-[var(--pub-heading)]"
+                }`}
+                style={isActive ? { color: "var(--status-warn-ink)" } : undefined}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/HeaderUi.tsx
+++ b/components/HeaderUi.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, ReactNode } from "react";
 
-type Panel = "menu" | "profile" | null;
+type Panel = "menu" | "profile" | "site" | null;
 
 interface HeaderUiContextValue {
   openPanel: Panel;


### PR DESCRIPTION
- Staff were getting the hamburger on normal desktops (1536px and below) because the full public + admin link row only fit at very wide widths.
- Staff now see the admin links inline with the public pages folded into a "Site" dropdown. Shows from 1280px up, so it covers every common desktop.
- Dropdown matches the account menu styling, closes on click-away / Escape / navigation, and only one header menu can be open at a time.
- Non-staff nav is unchanged.