### PR TITLE
Add Firebase emulator setup for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env — every value here is required unless marked optional.
+
+# Firebase Admin SDK (service account). The private key may be pasted with
+# real newlines, "\n" escapes, or surrounding quotes — all are accepted.
+FIREBASE_PROJECT_ID=lhr-recruiting-2026
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@lhr-recruiting-2026.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+
+# AWS SES (transactional email)
+AWS_SES_REGION=us-east-1
+AWS_SES_ACCESS_KEY_ID=
+AWS_SES_SECRET_ACCESS_KEY=
+AWS_SES_FROM_EMAIL=no-reply@lhrrecruiting.org
+REPLY_TO_EMAIL=
+
+# PostHog (analytics + error monitoring; exceptions are only captured in production)
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Local Firebase emulators — see README "Local development against the Firebase
+# emulators". Set ALL of these together or none of them; never in a deployment.
+# FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
+# FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+# FIREBASE_STORAGE_EMULATOR_HOST=127.0.0.1:9199
+# NEXT_PUBLIC_FIREBASE_EMULATOR=1

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ gha-creds-*.json
 # git worktrees / subagent-driven-development workspace
 .worktrees/
 .superpowers/
+
+# firebase emulators
+firebase-debug.log
+firestore-debug.log
+ui-debug.log
+.firebase/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) to view the site.
 
+### Local development against the Firebase emulators
+
+Without this, `npm run dev` needs a real service-account key and reads/writes
+live recruiting data. The emulator suite gives you a throwaway copy instead.
+
+Requires **JDK 21 or newer** on your PATH (`brew install openjdk@21` on macOS,
+Temurin 21 on Windows) — `firebase-tools` refuses older Java.
+
+1. Copy `.env.example` to `.env` and uncomment the emulator block (both
+   `FIRESTORE_EMULATOR_HOST` and `FIREBASE_AUTH_EMULATOR_HOST` are required
+   together; with only one set the other service would talk to production).
+2. `npm run emulators` — terminal 1. Emulator UI at http://localhost:4000.
+3. `npm run seed` — terminal 2, once. Creates `admin@utexas.edu`,
+   `applicant@utexas.edu`, and an open recruiting cycle.
+4. `npm run dev`, then sign in at `/auth/login` — the Google popup becomes the
+   emulator's fake account picker; enter one of the seeded addresses.
+
+Switching between the emulator and production in the same browser leaves a
+stale session cookie behind — sign out first, or you will see "invalid
+signature" errors until you do.
+
 ## Project Structure
 
 ```

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "emulators": {
+    "auth": { "port": 9099 },
+    "firestore": { "port": 8080 },
+    "storage": { "port": 9199 },
+    "ui": { "enabled": true, "port": 4000 },
+    "singleProjectMode": true
+  },
+  "firestore": { "rules": "firestore.rules" },
+  "storage": { "rules": "storage.rules" }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+// ponytail: emulator-only. All data access goes through the Admin SDK, which
+// bypasses rules; the client SDK only does auth. Prod rules live in the console.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} { allow read, write: if false; }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,5 @@
 rules_version = '2';
-// ponytail: emulator-only. All data access goes through the Admin SDK, which
+// NOTE: emulator-only. All data access goes through the Admin SDK, which
 // bypasses rules; the client SDK only does auth. Prod rules live in the console.
 service cloud.firestore {
   match /databases/{database}/documents {

--- a/lib/firebase/admin.ts
+++ b/lib/firebase/admin.ts
@@ -4,11 +4,23 @@ import { getAuth, Auth } from "firebase-admin/auth";
 
 // Don't re-initialize
 if (!firebase.apps.length) {
-  if (process.env.FIRESTORE_EMULATOR_HOST) {
-    // Local emulator suite: the SDK picks the emulators up from
-    // FIRESTORE_EMULATOR_HOST / FIREBASE_AUTH_EMULATOR_HOST and needs no
-    // credentials. Never set these in a deployed environment.
-    console.warn(`Firebase admin using emulators (${process.env.FIRESTORE_EMULATOR_HOST})`);
+  const firestoreEmulator = process.env.FIRESTORE_EMULATOR_HOST;
+  const authEmulator = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+  if (firestoreEmulator || authEmulator) {
+    // Local emulator suite: the SDK picks the emulators up from these two
+    // variables and needs no credentials. They must be set together — with
+    // only one set, the other service silently talks to production.
+    if (!firestoreEmulator || !authEmulator) {
+      throw new Error(
+        "Set FIRESTORE_EMULATOR_HOST and FIREBASE_AUTH_EMULATOR_HOST together (or neither); with one missing, the other service would hit production"
+      );
+    }
+    // A stray emulator variable in a deployment must fail loudly rather than
+    // point production at 127.0.0.1.
+    if (process.env.VERCEL) {
+      throw new Error("Firebase emulator variables are set in a Vercel environment — remove them");
+    }
+    console.warn(`Firebase admin using emulators (firestore ${firestoreEmulator}, auth ${authEmulator})`);
     firebase.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "lhr-recruiting-2026" });
   } else if (process.env.FIREBASE_PROJECT_ID && process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
     firebase.initializeApp({

--- a/lib/firebase/admin.ts
+++ b/lib/firebase/admin.ts
@@ -4,7 +4,13 @@ import { getAuth, Auth } from "firebase-admin/auth";
 
 // Don't re-initialize
 if (!firebase.apps.length) {
-  if (process.env.FIREBASE_PROJECT_ID && process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
+  if (process.env.FIRESTORE_EMULATOR_HOST) {
+    // Local emulator suite: the SDK picks the emulators up from
+    // FIRESTORE_EMULATOR_HOST / FIREBASE_AUTH_EMULATOR_HOST and needs no
+    // credentials. Never set these in a deployed environment.
+    console.warn(`Firebase admin using emulators (${process.env.FIRESTORE_EMULATOR_HOST})`);
+    firebase.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "lhr-recruiting-2026" });
+  } else if (process.env.FIREBASE_PROJECT_ID && process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
     firebase.initializeApp({
       credential: firebase.credential.cert({
         clientEmail: process.env.FIREBASE_CLIENT_EMAIL,

--- a/lib/firebase/client.ts
+++ b/lib/firebase/client.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
+import { getAuth, connectAuthEmulator } from "firebase/auth";
+import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
+import { getStorage, connectStorageEmulator } from "firebase/storage";
 
 export const firebaseConfig = {
   apiKey: "AIzaSyCrOMNWkTf4zhW4Prmma-UT0ebYGGnrcdM",
@@ -20,3 +20,12 @@ export const firebaseClientApp = initializeApp(firebaseConfig);
 export const auth = getAuth(firebaseClientApp);
 export const db = getFirestore(firebaseClientApp);
 export const storage = getStorage(firebaseClientApp);
+
+// Local emulator suite. Set NEXT_PUBLIC_FIREBASE_EMULATOR=1 in .env alongside
+// the server-side FIRESTORE_EMULATOR_HOST — both halves must point at the
+// emulator or the Google sign-in popup mints a token the server can't verify.
+if (process.env.NEXT_PUBLIC_FIREBASE_EMULATOR === "1") {
+  connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
+  connectFirestoreEmulator(db, "127.0.0.1", 8080);
+  connectStorageEmulator(storage, "127.0.0.1", 9199);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "start": "next start"
+    "start": "next start",
+    "emulators": "npx -y firebase-tools emulators:start --project lhr-recruiting-2026",
+    "seed": "node scripts/seed-emulator.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1032.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "emulators": "npx -y firebase-tools emulators:start --project lhr-recruiting-2026",
+    "emulators": "npx -y firebase-tools@15 emulators:start --project lhr-recruiting-2026",
     "seed": "node scripts/seed-emulator.mjs"
   },
   "dependencies": {

--- a/scripts/seed-emulator.mjs
+++ b/scripts/seed-emulator.mjs
@@ -1,0 +1,60 @@
+/**
+ * Seed the local emulator with just enough to click through the app:
+ * one admin, one applicant, and an open recruiting cycle. Every other config
+ * doc has a hardcoded default in lib/firebase/config.ts, so leaving them empty
+ * is the same as seeding them.
+ *
+ * Usage:  npm run seed        (emulators must already be running)
+ */
+import * as dotenv from "dotenv";
+import admin from "firebase-admin";
+
+dotenv.config();
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("Refusing to run: FIRESTORE_EMULATOR_HOST is not set. This script only seeds the emulator.");
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "lhr-recruiting-2026" });
+const db = admin.firestore();
+const auth = admin.auth();
+
+// Passwords are for the emulator's built-in login form only — the app itself
+// uses the Google popup, where the emulator lets you invent an account.
+const USERS = [
+  { uid: "seed-admin", email: "admin@utexas.edu", name: "Seed Admin", role: "admin" },
+  { uid: "seed-applicant", email: "applicant@utexas.edu", name: "Seed Applicant", role: "applicant" },
+];
+
+for (const u of USERS) {
+  await auth.importUsers([{
+    uid: u.uid,
+    email: u.email,
+    emailVerified: true,
+    displayName: u.name,
+    providerData: [{ uid: u.email, email: u.email, displayName: u.name, providerId: "google.com" }],
+  }]);
+  await db.doc(`users/${u.uid}`).set({
+    uid: u.uid,
+    email: u.email,
+    name: u.name,
+    role: u.role,
+    blacklisted: false,
+    applications: [],
+    phoneNumber: null,
+    isMember: false,
+  }, { merge: true });
+  console.log(`user  ${u.email.padEnd(24)} ${u.role}`);
+}
+
+await db.doc("config/recruiting").set({
+  currentStep: "open",
+  renegEnabled: true,
+  updatedAt: new Date(),
+  updatedBy: "seed",
+}, { merge: true });
+console.log("config/recruiting -> open");
+
+console.log("\nDone. Sign in at /auth/login with the Google popup and pick one of the seeded emails.");
+process.exit(0);

--- a/scripts/seed-emulator.mjs
+++ b/scripts/seed-emulator.mjs
@@ -11,8 +11,11 @@ import admin from "firebase-admin";
 
 dotenv.config();
 
-if (!process.env.FIRESTORE_EMULATOR_HOST) {
-  console.error("Refusing to run: FIRESTORE_EMULATOR_HOST is not set. This script only seeds the emulator.");
+if (!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+  console.error(
+    "Refusing to run: FIRESTORE_EMULATOR_HOST and FIREBASE_AUTH_EMULATOR_HOST must both be set. " +
+      "This script only seeds the emulator, and with either one missing that service would be production."
+  );
   process.exit(1);
 }
 

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,7 @@
+rules_version = '2';
+// ponytail: emulator-only — see firestore.rules.
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} { allow read, write: if false; }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,5 +1,5 @@
 rules_version = '2';
-// ponytail: emulator-only — see firestore.rules.
+// NOTE: emulator-only — see firestore.rules.
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} { allow read, write: if false; }


### PR DESCRIPTION
Local dev currently has no safe mode. Every route goes through the Admin SDK, so without credentials `npm run dev` returns 500 on every page — including the public marketing ones. The only way to run the app was to point a real service account key at `lhr-recruiting-2026`, which means local development reads and writes live recruiting data.

This wires up the emulator suite so that stops being the only option.

## What's here

- **`firebase.json`** — auth (9099), firestore (8080), storage (9199), UI (4000).
- **`firestore.rules` / `storage.rules`** — deny-all. All real access goes through the Admin SDK, which bypasses rules anyway, and the client SDK is only used for Google sign-in. Production rules stay in the console; these exist because the emulator requires a rules file.
- **`lib/firebase/admin.ts`** — a first branch that initializes without credentials when `FIRESTORE_EMULATOR_HOST` is set. The production path and the loud throw when nothing is configured are untouched.
- **`lib/firebase/client.ts`** — connects the browser SDK to the emulators behind `NEXT_PUBLIC_FIREBASE_EMULATOR`. Both halves have to be set together or the sign-in popup mints a token the server can't verify.
- **`scripts/seed-emulator.mjs`** — one admin, one applicant, and an open recruiting cycle. Everything else already has a hardcoded default in `lib/firebase/config.ts`, so seeding it would be redundant.
- **`npm run emulators` / `npm run seed`**.

## Getting started

```bash
npm run emulators   # terminal 1
npm run seed        # terminal 2, once
npm run dev
```

Sign in at `/auth/login` through the normal Google popup — the auth emulator shows a fake account picker where you enter one of the seeded addresses. They're `@utexas.edu` because `app/api/auth/session/route.ts` only admits that domain plus four specific gmails.

Requires a JRE for the Firestore emulator (`jre-openjdk-headless` on Arch, `default-jre` on Debian). The auth emulator is pure Node.

## Two choices worth flagging

**`npx -y firebase-tools` instead of a devDependency.** `bun.lock` and `package-lock.json` are both committed and CLAUDE.md says to keep them in sync; adding a devDep desyncs them unless whoever runs it has both package managers. npx costs a few seconds on first run and nothing after.

**The seed script hard-refuses to run without `FIRESTORE_EMULATOR_HOST`.** It's the same shape as `wipe-cycle-data.mjs`, which does talk to production, and I didn't want a copy-paste of the wrong script to write test users into the real project.

## Not included

`.env` is gitignored, so nothing here configures itself. The emulator variables you need:

```
FIREBASE_PROJECT_ID=lhr-recruiting-2026
FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
FIREBASE_STORAGE_EMULATOR_HOST=127.0.0.1:9199
NEXT_PUBLIC_FIREBASE_EMULATOR=1
```

Might be worth committing a `.env.example` in a follow-up — right now the required variables are only discoverable by grepping for `process.env`.

Verified with `npm run build`. Not yet run end to end against the emulators — the machine I set this up on is missing a JRE, so the wiring is reviewed but unexercised. Worth one person confirming sign-in works before anyone relies on it, since `createSessionCookie` against the auth emulator is the one piece I'd least want to be wrong about.

https://claude.ai/code/session_017SPJDwPKht9wedNLhWfpHa