### PR TITLE
Keep expected auth denials and client noise out of error monitoring

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,7 +26,7 @@ const ADMIN_NAV: AdminNavItem[] = [
   { href: '/admin/applications', label: 'Applicants' },
   { href: '/admin/users', label: 'Users', restrictTo: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB] },
   { href: '/admin/configuration', label: 'Configuration' },
-  { href: '/admin/settings', label: 'Settings' },
+  { href: '/admin/settings', label: 'Settings', restrictTo: [UserRole.ADMIN] },
 ];
 
 const STAFF_ROLES = new Set<UserRole>([

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,6 +3,25 @@ import posthog from "posthog-js";
 const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
 const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
 
+// Exceptions raised by code that is not ours, each of which was filing its
+// own GitHub issue through PostHog's integration: the JavaScript bridges that
+// in-app browsers (Instagram, LinkedIn) inject on Android and iOS, and
+// Next.js complaining when a tab loaded before a deploy navigates after it.
+const IGNORED_EXCEPTION_PATTERNS = [
+  /Error invoking postMessage/, // Android WebView bridge
+  /window\.webkit\.messageHandlers/, // iOS WKWebView bridge
+  /router state header was sent but could not be parsed/, // Next.js deploy skew
+];
+
+function isIgnoredException(properties: Record<string, unknown> | undefined): boolean {
+  const list = (properties?.$exception_list as Array<{ type?: string; value?: string }> | undefined) ?? [];
+  const text = [
+    ...list.map((e) => `${e.type ?? ""} ${e.value ?? ""}`),
+    String(properties?.$exception_message ?? ""),
+  ].join(" ");
+  return IGNORED_EXCEPTION_PATTERNS.some((re) => re.test(text));
+}
+
 if (!token || !host) {
   if (process.env.NODE_ENV !== "production") {
     throw new Error(
@@ -18,6 +37,10 @@ if (!token || !host) {
     // hiccups, hydration warnings, work-in-progress crashes) would drown
     // real error monitoring.
     capture_exceptions: process.env.NODE_ENV === "production",
+    before_send: (event) => {
+      if (event?.event === "$exception" && isIgnoredException(event.properties)) return null;
+      return event;
+    },
     debug: process.env.NODE_ENV === "development",
   });
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -20,6 +20,25 @@ import { captureServerException } from "@/lib/posthog/server";
  */
 const base = pino();
 
+/**
+ * Expected auth denials reach logger.error because every route's catch block
+ * logs before mapping the error to a 401/403: guards throwing Unauthorized /
+ * Forbidden, and Firebase session cookies expiring or being revoked (the
+ * guards re-throw those as plain Errors, so only the message survives). They
+ * are not incidents, and PostHog files a GitHub issue per exception, so they
+ * are logged at warn and kept out of error monitoring.
+ */
+function isExpectedAuthDenial(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: string }).code;
+  if (code === "auth/session-cookie-expired" || code === "auth/session-cookie-revoked") return true;
+  return (
+    err.message === "Unauthorized" ||
+    err.message.startsWith("Forbidden") ||
+    /Firebase (ID token|session cookie) has (expired|been revoked)/.test(err.message)
+  );
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function extractError(first: any): { err: unknown; context: Record<string, unknown> } {
   if (first instanceof Error) return { err: first, context: {} };
@@ -37,11 +56,17 @@ export const logger = {
   info: (...args: any[]) => (base.info as any)(...args),
   warn: (...args: any[]) => (base.warn as any)(...args),
   error: (...args: any[]) => {
+    const [first, message] = args;
+    const { err, context } = extractError(first);
+
+    if (isExpectedAuthDenial(err)) {
+      (base.warn as any)(...args);
+      return;
+    }
+
     (base.error as any)(...args);
 
     try {
-      const [first, message] = args;
-      const { err, context } = extractError(first);
       const msg = typeof message === "string" ? message : undefined;
 
       captureServerException(err ?? new Error(msg ?? "Server error"), {


### PR DESCRIPTION
- Expected 401/403s (guards throwing Unauthorized/Forbidden, Firebase session cookies expiring) were logged at error level by every route's catch block and shipped to PostHog, which files a GitHub issue per exception (#12, #14, #19, #38). The shared logger now logs those at warn and skips the PostHog tee — one change instead of 25 route files.
- The browser SDK now drops exceptions raised by code that isn't ours: in-app browser (Instagram/LinkedIn) bridge errors on Android and iOS, and Next.js's stale-router-state complaint after a deploy (#33–#36).
- Settings nav link is admin-only — every action on that page already required admin, so non-admin staff saw a page where every button 403'd.