### PR TITLE
Critical fixes before applications open

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # Local Firebase emulators — see README "Local development against the Firebase
 # emulators". Set ALL of these together or none of them; never in a deployment.
+# In emulator mode the app ignores FIREBASE_PROJECT_ID and uses demo-lhr-recruiting.
 # FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 # FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 # FIREBASE_STORAGE_EMULATOR_HOST=127.0.0.1:9199

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "lhr-recruiting-2026"
+    "default": "demo-lhr-recruiting"
   }
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Temurin 21 on Windows) — `firebase-tools` refuses older Java.
 1. Copy `.env.example` to `.env` and uncomment the emulator block (both
    `FIRESTORE_EMULATOR_HOST` and `FIREBASE_AUTH_EMULATOR_HOST` are required
    together; with only one set the other service would talk to production).
+   The emulators run under the project id `demo-lhr-recruiting`, which the
+   Firebase CLI refuses to deploy to — `firebase deploy` from this repo can
+   never touch production.
 2. `npm run emulators` — terminal 1. Emulator UI at http://localhost:4000.
 3. `npm run seed` — terminal 2, once. Creates `admin@utexas.edu`,
    `applicant@utexas.edu`, and an open recruiting cycle.

--- a/app/admin/settings/layout.tsx
+++ b/app/admin/settings/layout.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { requireRoles } from "@/lib/auth/guard";
+import { UserRole } from "@/lib/models/User";
+
+// Every action on the Settings page (recruiting step, email triggers, reneg
+// switch, announcement, fake-data seeding) is admin-only server-side. The nav
+// link is admin-only too, but the URL is not — gate the page itself so
+// non-admin staff never see a page where every button 403s.
+export default async function AdminSettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  try {
+    await requireRoles([UserRole.ADMIN]);
+  } catch {
+    redirect("/admin/dashboard");
+  }
+
+  return <>{children}</>;
+}

--- a/app/api/admin/applications/seed/route.ts
+++ b/app/api/admin/applications/seed/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { requireAdmin } from "@/lib/auth/guard";
 import { getRecruitingConfig } from "@/lib/firebase/config";
 import { RecruitingStep } from "@/lib/models/Config";
@@ -234,7 +235,11 @@ export async function POST() {
       message: `Created ${count} fake applications with associated user accounts`,
     });
   } catch (error) {
-    console.error("Error seeding applications:", error);
+    // The guard throws for non-admins; report it as a 403, not a 500.
+    if (error instanceof Error && (error.message === "Unauthorized" || error.message.startsWith("Forbidden"))) {
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
+    }
+    logger.error({ err: error }, "Error seeding applications");
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to seed applications" },
       { status: 500 }
@@ -303,7 +308,11 @@ export async function DELETE() {
       message: `Cleaned up ${deletedUsers} fake users and ${deletedApplications} fake applications`,
     });
   } catch (error) {
-    console.error("Error cleaning up fake data:", error);
+    // The guard throws for non-admins; report it as a 403, not a 500.
+    if (error instanceof Error && (error.message === "Unauthorized" || error.message.startsWith("Forbidden"))) {
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
+    }
+    logger.error({ err: error }, "Error cleaning up fake data");
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to clean up fake data" },
       { status: 500 }

--- a/app/api/admin/applications/seed/route.ts
+++ b/app/api/admin/applications/seed/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
-import { requireStaff } from "@/lib/auth/guard";
+import { requireAdmin } from "@/lib/auth/guard";
+import { getRecruitingConfig } from "@/lib/firebase/config";
+import { RecruitingStep } from "@/lib/models/Config";
 import { adminDb } from "@/lib/firebase/admin";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, ElectricSystem, SolarSystem, CombustionSystem } from "@/lib/models/User";
@@ -151,7 +153,17 @@ function generateFakeApplication(userId: string, name: string, email: string) {
 
 export async function POST() {
   try {
-    await requireStaff();
+    await requireAdmin();
+
+    // This writes 1000 applications and 1000 users into whatever project the
+    // server is pointed at. Only before the cycle opens, and only for admins.
+    const config = await getRecruitingConfig();
+    if (config.currentStep !== RecruitingStep.PRE_OPEN) {
+      return NextResponse.json(
+        { error: "Fake data can only be generated before the cycle opens" },
+        { status: 403 }
+      );
+    }
 
 
     const count = 1000;
@@ -233,7 +245,7 @@ export async function POST() {
 // DELETE endpoint to clean up fake data
 export async function DELETE() {
   try {
-    await requireStaff();
+    await requireAdmin();
 
 
     // Find and delete all fake users and their applications

--- a/app/api/admin/config/teams/route.ts
+++ b/app/api/admin/config/teams/route.ts
@@ -58,8 +58,13 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "Invalid team" }, { status: 400 });
     }
 
-    // Validate description
-    if (typeof description !== "string" || description.trim() === "") {
+    // Validate the payload for the scope actually being saved: the rejection
+    // message scope carries no description.
+    if (scope === "rejectionMessage") {
+      if (typeof rejectionMessage !== "string") {
+        return NextResponse.json({ error: "Rejection message must be a string" }, { status: 400 });
+      }
+    } else if (typeof description !== "string" || description.trim() === "") {
       return NextResponse.json({ error: "Description is required" }, { status: 400 });
     }
 

--- a/app/api/admin/users/[uid]/route.ts
+++ b/app/api/admin/users/[uid]/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireStaff } from "@/lib/auth/guard";
-import { updateUser } from "@/lib/firebase/users";
-import { UserRole } from "@/lib/models/User";
+import { updateUser, getUser } from "@/lib/firebase/users";
+import { UserRole, Team } from "@/lib/models/User";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "@/lib/logger";
 
@@ -20,8 +21,9 @@ export async function PATCH(
   // verified the session cookie, allowing any authenticated user
   // (including applicants) to mutate other users' team/system/isMember.
   let currentUser;
+  let callerUid = "";
   try {
-    ({ user: currentUser } = await requireStaff());
+    ({ uid: callerUid, user: currentUser } = await requireStaff());
   } catch {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -36,6 +38,41 @@ export async function PATCH(
     const { uid: targetUid } = await params;
 
     const updateData: Record<string, unknown> = {};
+
+    // Every scoping check in the app keys off memberProfile.team, so this
+    // field is an access-control boundary, not a profile detail. Captains may
+    // manage their own team's roster only: users already on their team, or
+    // users with no team yet, and never themselves or a move to another team.
+    const isAdmin = currentUser?.role === UserRole.ADMIN;
+    if (!isAdmin) {
+      const captainTeam = currentUser?.memberProfile?.team;
+      if (!captainTeam) {
+        return NextResponse.json({ error: "Your account has no team assigned" }, { status: 403 });
+      }
+      if (targetUid === callerUid) {
+        return NextResponse.json({ error: "You cannot change your own membership" }, { status: 403 });
+      }
+      const target = await getUser(targetUid);
+      if (!target) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+      const targetTeam = target.memberProfile?.team;
+      if (targetTeam && targetTeam !== captainTeam) {
+        return NextResponse.json({ error: "You can only manage users on your own team" }, { status: 403 });
+      }
+      if (team && team !== captainTeam) {
+        return NextResponse.json({ error: "You cannot move users to another team" }, { status: 403 });
+      }
+    }
+
+    if (team) {
+      if (!Object.values(Team).includes(team)) {
+        return NextResponse.json({ error: "Invalid team" }, { status: 400 });
+      }
+      if (system && !TEAM_SYSTEMS[team as Team].some((s) => s.value === system)) {
+        return NextResponse.json({ error: `Invalid system for team ${team}` }, { status: 400 });
+      }
+    }
 
     if (role) {
       // Only Admins can update roles

--- a/app/api/applications/[id]/commit/route.ts
+++ b/app/api/applications/[id]/commit/route.ts
@@ -5,7 +5,8 @@ import { sendCommitmentNotificationToLeads } from "@/lib/email/send";
 import { adminAuth } from "@/lib/firebase/admin";
 import { appCache } from "@/lib/utils/appCache";
 import { getRecruitingConfig } from "@/lib/firebase/config";
-import { sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
+import { getUserVisibleStatus, sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
+import { ApplicationStatus } from "@/lib/models/Application";
 import { logger } from "@/lib/logger";
 
 export async function POST(
@@ -34,7 +35,19 @@ export async function POST(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
+    if (typeof accepted !== "boolean") {
+      return NextResponse.json({ error: "accepted must be true or false" }, { status: 400 });
+    }
+
+    // Decisions are masked until their release day, but the raw status is
+    // written the moment staff decide. Gate on what the applicant is allowed
+    // to see, so an acceptance made during trial_workday cannot be acted on,
+    // or probed for, before it is released. This also covers day-2/3 offers
+    // on day 1 and declines.
     const config = await getRecruitingConfig();
+    if (getUserVisibleStatus(application, config.currentStep) !== ApplicationStatus.ACCEPTED) {
+      return NextResponse.json({ error: "There is no offer to respond to right now" }, { status: 400 });
+    }
 
     const updatedApplication = await respondToCommitment(applicationId, accepted, reason);
     if (!updatedApplication) {
@@ -79,8 +92,13 @@ export async function POST(
       application: sanitizeApplicationForApplicant(updatedApplication, config.currentStep),
     });
   } catch (error) {
+    // Past the gate, a thrown Error is a rule the applicant can act on (reneg
+    // window closed, already committed elsewhere) — surface it as a 400.
+    if (error instanceof Error) {
+      logger.warn({ err: error }, "Commitment refused");
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     logger.error({ err: error }, "Failed to process commitment");
-    const message = error instanceof Error ? error.message : "Internal server error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/app/api/applications/[id]/commit/route.ts
+++ b/app/api/applications/[id]/commit/route.ts
@@ -4,6 +4,9 @@ import { getSystemLeads } from "@/lib/firebase/users";
 import { sendCommitmentNotificationToLeads } from "@/lib/email/send";
 import { adminAuth } from "@/lib/firebase/admin";
 import { appCache } from "@/lib/utils/appCache";
+import { getRecruitingConfig } from "@/lib/firebase/config";
+import { sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
+import { logger } from "@/lib/logger";
 
 export async function POST(
   req: NextRequest,
@@ -19,7 +22,7 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const decodedToken = await adminAuth.verifySessionCookie(sessionCookie);
+    const decodedToken = await adminAuth.verifySessionCookie(sessionCookie, true);
     const userId = decodedToken.uid;
 
     const application = await getApplication(applicationId);
@@ -30,6 +33,8 @@ export async function POST(
     if (application.userId !== userId) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+
+    const config = await getRecruitingConfig();
 
     const updatedApplication = await respondToCommitment(applicationId, accepted, reason);
     if (!updatedApplication) {
@@ -68,9 +73,14 @@ export async function POST(
       leadEmails
     });
 
-    return NextResponse.json({ application: updatedApplication });
-  } catch (error: any) {
-    console.error("Error in commitment API:", error);
-    return NextResponse.json({ error: error.message || "Internal server error" }, { status: 500 });
+    // Never return the raw document to the applicant — respondToCommitment
+    // spreads the whole Firestore doc, decisions and ratings included.
+    return NextResponse.json({
+      application: sanitizeApplicationForApplicant(updatedApplication, config.currentStep),
+    });
+  } catch (error) {
+    logger.error({ err: error }, "Failed to process commitment");
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -10,6 +10,7 @@ import { getRecruitingConfig, getApplicationQuestions } from "@/lib/firebase/con
 import { RecruitingStep } from "@/lib/models/Config";
 import { getUserVisibleStatus, sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
 import { sanitizeIncomingFormData } from "@/lib/utils/formAnswers";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { logger } from "@/lib/logger";
 
 
@@ -155,12 +156,37 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // must not be able to write arbitrary fields into it.
     const formData = body.formData ? sanitizeIncomingFormData(body.formData) : undefined;
 
-    // Validate preferred systems limit (max 3)
-    if (preferredSystems && Array.isArray(preferredSystems) && preferredSystems.length > 3) {
-      return NextResponse.json(
-        { error: "You can select a maximum of 3 preferred systems" },
-        { status: 400 }
-      );
+    // preferredSystems drives reviewer visibility (array-contains queries) and
+    // several .map/.join call sites, so it must be a real array of this team's
+    // systems: a string or object here white-screens the applicant dashboard
+    // and the staff detail view, and an off-team name hides the applicant
+    // from every reviewer. An empty array is allowed (clearing the ranking).
+    if (preferredSystems !== undefined) {
+      const teamSystems = (TEAM_SYSTEMS[existingApplication.team] || []).map((s) => s.value);
+      const valid =
+        Array.isArray(preferredSystems) &&
+        preferredSystems.length <= 3 &&
+        new Set(preferredSystems).size === preferredSystems.length &&
+        preferredSystems.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
+      if (!valid) {
+        return NextResponse.json(
+          { error: "Preferred systems must be up to 3 distinct systems from your team" },
+          { status: 400 }
+        );
+      }
+    }
+
+    // A submission with no ranked system is invisible to every system lead and
+    // reviewer, so it cannot be reviewed. The form enforces this client-side;
+    // this is the backstop for a stale cached form or a hand-rolled request.
+    if (status === ApplicationStatus.SUBMITTED) {
+      const finalSystems = preferredSystems ?? existingApplication.preferredSystems ?? [];
+      if (finalSystems.length === 0) {
+        return NextResponse.json(
+          { error: "Rank at least one system before submitting" },
+          { status: 400 }
+        );
+      }
     }
 
     // Validate word counts when submitting
@@ -221,7 +247,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       // Update all provided fields
       const updates: Record<string, unknown> = {};
       if (formData) updates.formData = { ...existingApplication.formData, ...formData };
-      if (preferredSystems) updates.preferredSystems = preferredSystems;
+      if (preferredSystems !== undefined) updates.preferredSystems = preferredSystems;
       const nextStatus = status || (alreadySubmitted ? ApplicationStatus.SUBMITTED : undefined);
       if (nextStatus) updates.status = nextStatus;
 

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -101,12 +101,10 @@ export async function POST(request: NextRequest) {
 
     // Applicants who already have an application should still be able to
     // reopen it after applications close - only block creating a new one.
+    const config = await getRecruitingConfig();
     const existingApplication = await getUserApplicationForTeam(uid, team as Team);
-    if (!existingApplication) {
-      const config = await getRecruitingConfig();
-      if (config.currentStep !== RecruitingStep.OPEN) {
-        return NextResponse.json({ error: "Applications are closed" }, { status: 403 });
-      }
+    if (!existingApplication && config.currentStep !== RecruitingStep.OPEN) {
+      return NextResponse.json({ error: "Applications are closed" }, { status: 403 });
     }
 
     // Fetch user profile to get name/email for denormalization
@@ -120,7 +118,13 @@ export async function POST(request: NextRequest) {
       team: team as Team,
     });
 
-    return NextResponse.json({ application }, { status: 201 });
+    // The apply page calls this on every visit, so for an existing application
+    // this is a read of the full document by its owner — same rule as GET:
+    // nothing applicant-facing leaves unsanitized.
+    return NextResponse.json(
+      { application: sanitizeApplicationForApplicant(application, config.currentStep) },
+      { status: 201 }
+    );
   } catch (error) {
     logger.error({ err: error }, "Failed to create application");
     return NextResponse.json(

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -290,7 +290,7 @@ export default function TeamApplicationPage() {
               teamQuestions: cleanedTeamQuestions,
               customAnswers: cleanedCustomAnswers,
             },
-            preferredSystems: data.preferredSystems.length > 0 ? data.preferredSystems : undefined,
+            preferredSystems: data.preferredSystems,
           }),
         });
 
@@ -692,8 +692,75 @@ export default function TeamApplicationPage() {
     );
   }
 
+  const isOpen = recruitingStep === RecruitingStep.OPEN;
+
+  // --- Could not load (or create) the application ---
+  // Rendered before the submitted state: with `application` null, the check
+  // below used to fall through to "Application Submitted" on any error,
+  // including the 403 a returning visitor gets once applications close.
+  if (error || !application) {
+    return (
+      <main className="min-h-screen pt-24 pb-20" style={{ background: "var(--pub-bg)" }}>
+        <div className="container mx-auto px-4 max-w-2xl text-center">
+          <div
+            className="rounded-2xl p-8 sm:p-10"
+            style={{ backgroundColor: "var(--pub-surface)", border: "1px solid var(--pub-border)" }}
+          >
+            <h1 className="text-2xl font-bold mb-3" style={{ color: "var(--pub-heading)" }}>
+              {isOpen ? "Something went wrong" : "Applications are closed"}
+            </h1>
+            <p className="font-urbanist text-[15px] mb-6" style={{ color: "var(--pub-text-2)" }}>
+              {isOpen
+                ? error || "We couldn't load your application. Please refresh and try again."
+                : "The application window for this cycle has closed. If you already applied, your application is on your dashboard."}
+            </p>
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center justify-center h-10 px-5 rounded-lg text-[14px] font-semibold"
+              style={{ backgroundColor: "var(--pub-cta)", color: "var(--pub-cta-ink)" }}
+            >
+              Go to dashboard
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  // --- Draft after close ---
+  // The form would render and every save would 403 with a generic message.
+  if (!isOpen && application.status === ApplicationStatus.IN_PROGRESS) {
+    return (
+      <main className="min-h-screen pt-24 pb-20" style={{ background: "var(--pub-bg)" }}>
+        <div className="container mx-auto px-4 max-w-2xl text-center">
+          <div
+            className="rounded-2xl p-8 sm:p-10"
+            style={{ backgroundColor: "var(--pub-surface)", border: "1px solid var(--pub-border)" }}
+          >
+            <h1 className="text-2xl font-bold mb-3" style={{ color: "var(--pub-heading)" }}>
+              Applications are closed
+            </h1>
+            <p className="font-urbanist text-[15px] mb-6" style={{ color: "var(--pub-text-2)" }}>
+              This application was not submitted before the window closed, so it can no longer be edited or submitted.
+            </p>
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center justify-center h-10 px-5 rounded-lg text-[14px] font-semibold"
+              style={{ backgroundColor: "var(--pub-cta)", color: "var(--pub-cta-ink)" }}
+            >
+              Go to dashboard
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
   // --- Already submitted state ---
-  if (application?.status !== ApplicationStatus.IN_PROGRESS) {
+  // While applications are open a submitted application stays editable (the
+  // form below switches to its "changes save automatically" mode); this
+  // screen is for everything after the window closes.
+  if (application.status !== ApplicationStatus.IN_PROGRESS && !(isOpen && application.status === ApplicationStatus.SUBMITTED)) {
     return (
       <main className="min-h-screen pt-24 pb-20" style={{ background: "var(--pub-bg)" }}>
         <div className="container mx-auto px-4 max-w-2xl text-center">

--- a/app/dashboard/applications/[id]/page.tsx
+++ b/app/dashboard/applications/[id]/page.tsx
@@ -102,7 +102,9 @@ function getStatusInfo(status: ApplicationStatus): { title: string; description:
 
 // Check if interview scheduling is blocked (after trial release)
 function isSchedulingBlocked(step: RecruitingStep | null): boolean {
-  if (!step) return false;
+  // Unknown step (loading or failed fetch) hides the signup link rather than
+  // showing it — the link is live and external.
+  if (!step) return true;
   const blockedSteps = [
     RecruitingStep.CLOSE_INTERVIEWS,
     RecruitingStep.RELEASE_TRIAL,

--- a/hooks/useConfig.ts
+++ b/hooks/useConfig.ts
@@ -2,30 +2,32 @@ import useSWR from "swr";
 import { RecruitingStep } from "@/lib/models/Config";
 import { authFetcher } from "@/lib/auth/fetcher";
 
-interface ConfigResponse {
-  config: {
-    currentStep: RecruitingStep;
-  };
+interface ApplicationsStepResponse {
+  step: RecruitingStep;
 }
 
 /**
- * Hook to fetch the recruiting configuration.
- * Data is cached and revalidated on focus/reconnect.
+ * Hook to fetch the current recruiting step for applicant-facing pages.
+ *
+ * Reads the `step` that /api/applications already returns (there is no
+ * standalone config route for applicants), sharing SWR's cache with
+ * useApplications. `recruitingStep` is null only while loading or on error —
+ * callers gate on it and must fail closed.
  */
 export function useConfig() {
-  const { data, error, isLoading } = useSWR<ConfigResponse>(
-    "/api/config",
+  const { data, error, isLoading } = useSWR<ApplicationsStepResponse>(
+    "/api/applications",
     authFetcher,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-      dedupingInterval: 300000, // 5min dedup — config rarely changes mid-session
+      dedupingInterval: 300000, // 5min dedup — the step rarely changes mid-session
     }
   );
 
   return {
-    config: data?.config ?? null,
-    recruitingStep: data?.config?.currentStep ?? null,
+    config: data ? { currentStep: data.step } : null,
+    recruitingStep: data?.step ?? null,
     isLoading,
     error,
   };

--- a/lib/firebase/admin.ts
+++ b/lib/firebase/admin.ts
@@ -1,6 +1,7 @@
 import firebase from "firebase-admin";
 import { getFirestore, Firestore } from "firebase-admin/firestore";
 import { getAuth, Auth } from "firebase-admin/auth";
+import { EMULATOR_PROJECT_ID } from "./emulator";
 
 // Don't re-initialize
 if (!firebase.apps.length) {
@@ -21,7 +22,7 @@ if (!firebase.apps.length) {
       throw new Error("Firebase emulator variables are set in a Vercel environment — remove them");
     }
     console.warn(`Firebase admin using emulators (firestore ${firestoreEmulator}, auth ${authEmulator})`);
-    firebase.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "lhr-recruiting-2026" });
+    firebase.initializeApp({ projectId: EMULATOR_PROJECT_ID });
   } else if (process.env.FIREBASE_PROJECT_ID && process.env.FIREBASE_CLIENT_EMAIL && process.env.FIREBASE_PRIVATE_KEY) {
     firebase.initializeApp({
       credential: firebase.credential.cert({

--- a/lib/firebase/client.ts
+++ b/lib/firebase/client.ts
@@ -4,11 +4,16 @@ import { initializeApp } from "firebase/app";
 import { getAuth, connectAuthEmulator } from "firebase/auth";
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
 import { getStorage, connectStorageEmulator } from "firebase/storage";
+import { EMULATOR_PROJECT_ID } from "./emulator";
+
+const useEmulator = process.env.NEXT_PUBLIC_FIREBASE_EMULATOR === "1";
 
 export const firebaseConfig = {
   apiKey: "AIzaSyCrOMNWkTf4zhW4Prmma-UT0ebYGGnrcdM",
   authDomain: "lhr-recruiting-2026.firebaseapp.com",
-  projectId: "lhr-recruiting-2026",
+  // Auth tokens carry the project id and the server verifies it, so the
+  // browser must use the emulator project when the server does.
+  projectId: useEmulator ? EMULATOR_PROJECT_ID : "lhr-recruiting-2026",
   storageBucket: "lhr-recruiting-2026.firebasestorage.app",
   messagingSenderId: "790227400201",
   appId: "1:790227400201:web:0aa808fee357ea6a27ead8",
@@ -24,7 +29,7 @@ export const storage = getStorage(firebaseClientApp);
 // Local emulator suite. Set NEXT_PUBLIC_FIREBASE_EMULATOR=1 in .env alongside
 // the server-side FIRESTORE_EMULATOR_HOST — both halves must point at the
 // emulator or the Google sign-in popup mints a token the server can't verify.
-if (process.env.NEXT_PUBLIC_FIREBASE_EMULATOR === "1") {
+if (useEmulator) {
   connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
   connectStorageEmulator(storage, "127.0.0.1", 9199);

--- a/lib/firebase/emulator.ts
+++ b/lib/firebase/emulator.ts
@@ -1,0 +1,11 @@
+/**
+ * Project id the local Firebase emulators run under.
+ *
+ * `demo-` prefixed ids are reserved by Firebase for emulator use: the CLI
+ * refuses to deploy to them and the SDKs can never reach a real project with
+ * one, so a stray `firebase deploy` from this repo cannot push the deny-all
+ * emulator rules to production. The browser SDK, the Admin SDK, the seed
+ * script and the `emulators` npm script must all agree on this value — Auth
+ * tokens carry the project id and the server verifies it.
+ */
+export const EMULATOR_PROJECT_ID = "demo-lhr-recruiting";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "emulators": "npx -y firebase-tools@15 emulators:start --project lhr-recruiting-2026",
+    "emulators": "npx -y firebase-tools@15 emulators:start --project demo-lhr-recruiting",
     "seed": "node scripts/seed-emulator.mjs"
   },
   "dependencies": {

--- a/scripts/seed-emulator.mjs
+++ b/scripts/seed-emulator.mjs
@@ -19,7 +19,10 @@ if (!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_AUTH_EMULATOR_
   process.exit(1);
 }
 
-admin.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID || "lhr-recruiting-2026" });
+// Must match the id the emulators were started with (package.json) and the
+// one the app uses in emulator mode (lib/firebase/emulator.ts). A demo-
+// prefixed id can never be deployed to or reach a real project.
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
 const db = admin.firestore();
 const auth = admin.auth();
 


### PR DESCRIPTION
The nine P0 items from today's readiness audit, one commit each. P1 items (release-day) follow as separate PRs.

- Applicant-facing create and commit routes now return the sanitized application, never the raw document. Commit route also checks revocation and logs properly. Fixes #42
- Commit/decline is only possible once the decision is visible to the applicant. Fixes #43
- `preferredSystems` must be up to 3 distinct systems from the applicant's team; submitting with none is refused. Fixes #44
- Apply page: shows a real error or "applications are closed" instead of "Application Submitted" when loading fails; drafts after close can't be edited; submitted applications can be edited while open (the Edit button now works). Fixes #45
- Fake-data seeder is admin-only and only before the cycle opens; Settings page redirects non-admins. Fixes #46
- Captains can only manage users on their own team, never themselves, and can't move anyone to another team; team/system values are validated. Fixes #47
- Emulators run under `demo-lhr-recruiting`, which the Firebase CLI refuses to deploy to, so `firebase deploy` can't push the emulator rules to production. Fixes #48
- Applicant application page reads the recruiting step from the existing applications route (the old endpoint didn't exist); the interview signup link hides when the step is unknown. Fixes #49
- Teams tab "save rejection message" works. Fixes #50

Verified: `npm run build` passes; a 40-check regression against the emulators covers every changed route (sanitization, commit gate before/after release, all `preferredSystems` shapes, seeder and Settings gating per role, captain/admin user updates, rejection-message save, sign-in under the demo project).