### PR TITLE
Record release emails as sent only when they were actually sent

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -138,6 +138,7 @@ export default function AdminSettingsPage() {
       let totalSent = 0;
       let totalFailed = 0;
       let totalSkipped = 0;
+      const skipReasons: Record<string, number> = {};
       
       toast.loading(`Processing ${chunks.length} batches...`, { id: toastId });
       
@@ -165,12 +166,23 @@ export default function AdminSettingsPage() {
         totalSent += data.sentCount || 0;
         totalSkipped += data.skippedCount || 0;
         totalFailed += data.failedCount || 0;
+        for (const [reason, n] of Object.entries(data.skipReasons || {})) {
+          skipReasons[reason] = (skipReasons[reason] || 0) + (n as number);
+        }
       }
-      
-      toast.success(`Completed! Sent: ${totalSent}, Skipped: ${totalSkipped}, Failed: ${totalFailed}`, { 
-        id: toastId,
-        duration: 5000 
-      });
+
+      const summary = `Sent: ${totalSent}, Skipped: ${totalSkipped}, Failed: ${totalFailed}`;
+      const problems: string[] = [];
+      if (skipReasons.globally_disabled) problems.push(`${skipReasons.globally_disabled} not sent because emails are globally disabled`);
+      if (skipReasons.no_template) problems.push(`${skipReasons.no_template} not sent because their team has no template for this step`);
+      if (skipReasons.template_disabled) problems.push(`${skipReasons.template_disabled} not sent because the template is disabled`);
+      if (totalFailed > 0) problems.push(`${totalFailed} failed to send and will be retried on the next run`);
+
+      if (problems.length > 0) {
+        toast.error(`${summary}. ${problems.join("; ")}.`, { id: toastId, duration: 15000 });
+      } else {
+        toast.success(`Completed! ${summary}`, { id: toastId, duration: 5000 });
+      }
     } catch (error: any) {
       console.error(error);
       toast.error(error.message || "Error triggering emails", { id: toastId });

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -83,6 +83,9 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
   let sentCount = 0;
   let skippedCount = 0;
   let failedCount = 0;
+  // Skips that are worth showing the admin: a missing template or a kill
+  // switch means a whole cohort silently got nothing.
+  const skipReasons: Record<string, number> = {};
 
   for (const app of applications) {
     try {
@@ -129,7 +132,7 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
 
           logger.info({ appId: app.id, trigger: expectedTrigger }, "Sending email");
           
-          await sendStatusEmail({
+          const result = await sendStatusEmail({
             trigger: expectedTrigger,
             applicantName: app.userName || "Applicant",
             applicantEmail: app.userEmail || "",
@@ -138,18 +141,25 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
             isFakeData: app.isFakeData,
             config: emailConfig,
           });
-          
-          if (!app.isFakeData && app.userEmail && !app.userEmail.includes(".fake")) {
-              const newEmailsSent = force 
-                ? Array.from(new Set([...(app.emailsSent || []), expectedTrigger]))
-                : [...(app.emailsSent || []), expectedTrigger];
-              await updateApplication(app.id, { emailsSent: newEmailsSent });
-              sentCount++;
-              
-              // Safe rate (10/sec)
-              await sleep(100);
+
+          if (result.sent) {
+            // Only a real send is recorded. A skipped or failed send must stay
+            // eligible for the next run — the non-force path skips anyone
+            // already in emailsSent, so a false "sent" can never be retried
+            // without force-sending to everyone who did get the email.
+            const newEmailsSent = force
+              ? Array.from(new Set([...(app.emailsSent || []), expectedTrigger]))
+              : [...(app.emailsSent || []), expectedTrigger];
+            await updateApplication(app.id, { emailsSent: newEmailsSent });
+            sentCount++;
+
+            // Safe rate (10/sec)
+            await sleep(100);
+          } else if (result.reason === "send_failed") {
+            failedCount++;
           } else {
-              skippedCount++;
+            skippedCount++;
+            skipReasons[result.reason] = (skipReasons[result.reason] || 0) + 1;
           }
         } else {
           skippedCount++;
@@ -163,5 +173,5 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
     }
   }
   
-  return { sentCount, skippedCount, failedCount };
+  return { sentCount, skippedCount, failedCount, skipReasons };
 }

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -20,13 +20,28 @@ interface SendStatusEmailParams {
   config?: EmailTemplatesConfig; // Optional pre-loaded config
 }
 
+/** Why an email did not go out. Callers decide what to record based on this. */
+export type EmailSkipReason =
+  | "fake_account"
+  | "globally_disabled"
+  | "no_template"
+  | "template_disabled"
+  | "send_failed";
+
+export type SendStatusEmailResult =
+  | { sent: true }
+  | { sent: false; reason: EmailSkipReason };
+
 /**
  * Send a status-change email using the configured template.
  * This is the main entry point for all automated recruiting emails.
  *
- * Designed to be fire-and-forget: catches all errors internally.
+ * Never throws. The result says whether an email actually left: a skip (kill
+ * switch, missing or disabled template) and a failed SES send both come back
+ * as `sent: false`, and callers must not record those as delivered — the
+ * batch trigger skips anyone already marked, so a false "sent" is permanent.
  */
-export async function sendStatusEmail(params: SendStatusEmailParams): Promise<void> {
+export async function sendStatusEmail(params: SendStatusEmailParams): Promise<SendStatusEmailResult> {
   try {
     // SECURITY: Never send emails to fake accounts
     if (params.isFakeData || params.applicantEmail.includes(".fake")) {
@@ -34,7 +49,7 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<vo
         { trigger: params.trigger, to: params.applicantEmail },
         "Skipping email to fake account"
       );
-      return;
+      return { sent: false, reason: "fake_account" };
     }
 
     // Load email config from Firestore if not provided
@@ -43,7 +58,7 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<vo
     // Check global kill switch
     if (!config.globalEnabled) {
       logger.info({ trigger: params.trigger }, "Email sending globally disabled, skipping");
-      return;
+      return { sent: false, reason: "globally_disabled" };
     }
 
     // Find this team's template for the trigger. Deliberately no cross-team
@@ -56,13 +71,13 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<vo
         { trigger: params.trigger, team: params.teamName },
         "No email template for this team/trigger — skipping send"
       );
-      return;
+      return { sent: false, reason: "no_template" };
     }
 
     // Check per-template enabled flag
     if (!template.enabled) {
       logger.info({ trigger: params.trigger }, "Email template disabled, skipping");
-      return;
+      return { sent: false, reason: "template_disabled" };
     }
 
     // Build variables and render
@@ -85,12 +100,15 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<vo
       { trigger: params.trigger, to: params.applicantEmail, team: params.teamName },
       "Status email sent successfully"
     );
+    return { sent: true };
   } catch (error) {
-    // Fire-and-forget: log errors but never throw
+    // Never throw; the caller reads the result. `err` is the key pino
+    // serializes, so the stack actually reaches the log.
     logger.error(
-      { trigger: params.trigger, to: params.applicantEmail, error },
+      { trigger: params.trigger, to: params.applicantEmail, err: error },
       "Failed to send status email (non-blocking)"
     );
+    return { sent: false, reason: "send_failed" };
   }
 }
 


### PR DESCRIPTION
- `sendStatusEmail` now reports whether an email actually left (or why not: kill switch off, no template for the team, template disabled, SES failure) instead of returning nothing.
- The batch trigger only marks an applicant as emailed on a real send. Failed sends count as failed and are retried on the next run; skips are counted with their reason. Previously every applicant was marked as sent regardless, so a failed release could only be recovered by force-sending to everyone.
- The Settings page completion toast now calls out the problems: how many weren't sent because emails are globally disabled, because a team has no template, or because sends failed.

Verified on the emulators with SES credentials invalid: 3 applicants → `failedCount: 3`, nothing recorded, second run retries all 3; kill switch → `skipReasons.globally_disabled: 3`; missing team templates → `skipReasons.no_template: 3`; nothing recorded in either case. `tsc` clean.

Fixes #51