### PR TITLE
Waitlisting an applicant always reaches them

### DIFF
--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, getApplication } from "@/lib/firebase/applications";
 import { requireStaffForApplication } from "@/lib/auth/guard";
@@ -260,6 +261,13 @@ export async function POST(
           ...offer,
           issuedAt: new Date()
         };
+      }
+
+      // Leaving ACCEPTED (rescinded to the waitlist, or rejected) withdraws the
+      // offer: the sanitizer would otherwise keep shipping it to the applicant
+      // and the dashboard would keep rendering the acceptance card.
+      if (status !== ApplicationStatus.ACCEPTED && application.status === ApplicationStatus.ACCEPTED && application.offer) {
+        updateData.offer = FieldValue.delete();
       }
 
       // If rejecting, clean up accidental or unreleased offers depending on current recruiting step

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -91,20 +91,20 @@ export function getStageDecisionForStatus(
     }
   }
 
+  // A waitlist is always a final-stage decision, whatever the applicant's
+  // current status: rescinding an acceptance to the waitlist, or waitlisting a
+  // straggler still at SUBMITTED, must overwrite trialDecision, or the
+  // applicant keeps seeing the previous outcome (an ACCEPTED applicant kept
+  // their Accept button, and it 500'd). Visibility is still gated by the
+  // decision day the caller stamps alongside this.
+  if (newStatus === ApplicationStatus.WAITLISTED) {
+    return { field: 'trialDecision', decision: 'waitlisted' };
+  }
+
   // Moving from interview to trial
   if (currentStatus === ApplicationStatus.INTERVIEW) {
     if (newStatus === ApplicationStatus.TRIAL) {
       return { field: 'interviewDecision', decision: 'advanced' };
-    }
-    if (newStatus === ApplicationStatus.WAITLISTED) {
-      return { field: 'trialDecision', decision: 'waitlisted' };
-    }
-  }
-
-  // Moving from trial to waitlisted
-  if (currentStatus === ApplicationStatus.TRIAL) {
-    if (newStatus === ApplicationStatus.WAITLISTED) {
-      return { field: 'trialDecision', decision: 'waitlisted' };
     }
   }
 


### PR DESCRIPTION
- Moving any application to Waitlisted now writes `trialDecision: waitlisted` (with the usual decision-day stamp) regardless of the applicant's current status. Previously this only happened from Interview or Trial, so rescinding an acceptance to the waitlist left the applicant seeing "Accepted" with an Accept button that failed, and waitlisting someone still at Submitted showed them "Submitted" forever.
- Leaving Accepted (to waitlist or reject) removes the stored offer so it stops being sent to the applicant.

Verified on the emulators: accepted → waitlisted during Day 1 is masked on Day 1 and shows "Waitlisted" on Day 2 with the offer gone; submitted → waitlisted during Day 2 shows on Day 3; the existing interview → waitlisted path is unchanged. Fixes #53