### PR TITLE
Bulk actions: per-application systems and per-record scoping

### DIFF
--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -168,7 +168,14 @@ export default function FullScreenListView(props: Props) {
     setBulkResult(null);
     setConfirmAction(null);
     try {
-      const systems = currentUser?.memberProfile?.system ? [currentUser.memberProfile.system] : undefined;
+      // Only a lead's system should scope a bulk action. Admins and captains
+      // leave it to the server, which picks per application from what the
+      // applicant ranked — passing a captain's own system here stamped it onto
+      // every selected applicant.
+      const systems =
+        currentUser?.role === UserRole.SYSTEM_LEAD && currentUser.memberProfile?.system
+          ? [currentUser.memberProfile.system]
+          : undefined;
       const res = await bulkUpdateStatus(Array.from(selectedIds), action, systems);
       setBulkResult(res.summary);
       setSelectedIds(new Set());

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Application, InterviewEventStatus } from "@/lib/models/Application";
 import { requireStaff } from "@/lib/auth/guard";
 import { getApplication, updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, rejectApplicationFromSystems } from "@/lib/firebase/applications";
 import { ApplicationStatus } from "@/lib/models/Application";
@@ -21,6 +22,43 @@ interface BulkStatusRequest {
 /**
  * POST /api/admin/applications/bulk-status
  */
+/**
+ * Systems a bulk interview/trial offer targets for one application.
+ *
+ * Explicit systems are intersected with what the applicant ranked: an offer
+ * for a system they never listed is invisible to that system's lead (scoping
+ * is a preferredSystems array-contains), and it used to be exactly what a
+ * captain's own system got stamped onto every selected applicant. With no
+ * systems given (admins and captains), an interview offer goes to every ranked
+ * system and a trial offer to the one system they interviewed for.
+ */
+function resolveBulkSystems(
+  application: Application,
+  requested: string[],
+  action: "interview" | "trial"
+): { systems: string[]; error?: string } {
+  const ranked: string[] = application.preferredSystems || [];
+  if (requested.length > 0) {
+    const systems = requested.filter((s) => ranked.includes(s));
+    return systems.length > 0
+      ? { systems }
+      : { systems: [], error: `Applicant did not rank ${requested.join(", ")}` };
+  }
+  if (action === "interview") {
+    return ranked.length > 0 ? { systems: ranked } : { systems: [], error: "Applicant has no ranked systems" };
+  }
+  const completed = (application.interviewOffers || [])
+    .filter((o) => o.status === InterviewEventStatus.COMPLETED)
+    .map((o) => o.system);
+  const candidates =
+    completed.length > 0 ? completed : application.selectedInterviewSystem ? [application.selectedInterviewSystem] : ranked;
+  if (candidates.length === 1) return { systems: candidates };
+  return {
+    systems: [],
+    error: candidates.length === 0 ? "Applicant has no system to offer a trial for" : "Select which system the trial offer is for",
+  };
+}
+
 export async function POST(request: NextRequest) {
   try {
     const { user: currentUser } = await requireStaff();
@@ -55,13 +93,13 @@ export async function POST(request: NextRequest) {
     // System leads can only act on their own system
     const isHigherAuthority = currentUser.role === UserRole.ADMIN || currentUser.role === UserRole.TEAM_CAPTAIN_OB;
 
-    // For interview/trial, systems are ALWAYS required. 
-    // For reject, it's required for system leads, but optional for higher authorities (will reject all preferred).
-    if (["interview", "trial"].includes(action) && (!systems || systems.length === 0)) {
-      return NextResponse.json({ error: "Systems array is required for this action" }, { status: 400 });
-    }
-    
-    if (action === "reject" && !isHigherAuthority && (!systems || systems.length === 0)) {
+    // Interview, trial and reject need a system per application. Leads must
+    // name theirs. Admins and captains may omit it: the toolbar has no system
+    // picker for them, and each application supplies its own default below
+    // (ranked systems for interview and reject, the interviewed system for
+    // trial). Requiring it here made bulk Interview/Trial fail for exactly the
+    // roles that run the cycle.
+    if (["interview", "trial", "reject"].includes(action) && !isHigherAuthority && (!systems || systems.length === 0)) {
       return NextResponse.json({ error: "Systems array is required for this action" }, { status: 400 });
     }
 
@@ -111,12 +149,16 @@ export async function POST(request: NextRequest) {
 
           switch (action) {
             case "interview": {
-              await addMultipleInterviewOffers(appId, effectiveSystems, 'advanced');
+              const target = resolveBulkSystems(application, effectiveSystems, "interview");
+              if (target.error) return { id: appId, success: false, error: target.error };
+              await addMultipleInterviewOffers(appId, target.systems, 'advanced');
               return { id: appId, success: true };
             }
 
             case "trial": {
-              await addMultipleTrialOffers(appId, effectiveSystems, 'advanced');
+              const target = resolveBulkSystems(application, effectiveSystems, "trial");
+              if (target.error) return { id: appId, success: false, error: target.error };
+              await addMultipleTrialOffers(appId, target.systems, 'advanced');
               return { id: appId, success: true };
             }
 

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { checkTeamAccess } from "@/lib/auth/teamAccess";
 import { Application, InterviewEventStatus } from "@/lib/models/Application";
 import { requireStaff } from "@/lib/auth/guard";
 import { getApplication, updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, rejectApplicationFromSystems } from "@/lib/firebase/applications";
@@ -139,12 +140,14 @@ export async function POST(request: NextRequest) {
             return { id: appId, success: false, error: "Application not found" };
           }
 
-          // Team-based authorization check for non-admins
-          if (!isHigherAuthority && currentUser.role !== UserRole.ADMIN) {
-            const userTeam = currentUser.memberProfile?.team;
-            if (!userTeam || userTeam !== application.team) {
-              return { id: appId, success: false, error: "No access to this application" };
-            }
+          // Same per-record scoping as every single-application route: captains
+          // are limited to their team, leads to their team and to applications
+          // that ranked their system. The old inline check exempted captains
+          // entirely (isHigherAuthority already included them) and never
+          // looked at preferredSystems for leads.
+          const accessError = checkTeamAccess(currentUser, application);
+          if (accessError) {
+            return { id: appId, success: false, error: accessError };
           }
 
           switch (action) {


### PR DESCRIPTION
Two issues in one PR because both change the same block of `bulk-status`; one commit each.

- **#54** Bulk Interview and Trial no longer require a `systems` array from admins and captains (the toolbar has no system picker for them, so these actions always failed with 400). Each application now gets its own default: interview offers for every system the applicant ranked, a trial offer for the system they interviewed for. Systems that are passed explicitly are intersected with the applicant's ranking, so a captain's own system is no longer stamped onto every selected applicant. The toolbar only sends a system for system leads.
- **#55** Each application in a bulk request is scoped with the same `checkTeamAccess` the single-record routes use: captains limited to their team, leads to their team and to applicants who ranked their system. Previously captains skipped the team check entirely and leads were checked on team only.

Verified on the emulators (12 checks): admin bulk interview → offers match each applicant's ranking; captain passing an unranked system is refused per application with nothing stamped; captain without systems → ranked systems; bulk trial → the completed-interview system; Electric captain bulk-rejecting a Solar application refused; Body lead refused on an application that ranked only Powertrain, allowed on one that ranked Body; leads still must name a system.

Fixes #54, fixes #55