### PR TITLE
Fix the interview-close and decision-day sweeps

### DIFF
--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
     if (step === RecruitingStep.CLOSE_INTERVIEWS) {
       try {
         const rejectedIds = await autoRejectUnscheduledInterviewApplicants();
-        logger.info({ rejectedCount: rejectedIds.length }, "Swept unscheduled interview applicants");
+        logger.info({ rejectedCount: rejectedIds.length, rejectedIds }, "Swept unscheduled interview applicants");
       } catch (err) {
         logger.error({ err }, "Failed to sweep unscheduled interview applicants");
         sweepError = "The step was saved, but the unscheduled-interview sweep did not finish. Save this same step again to re-run it.";

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -5,7 +5,8 @@ import { getRecruitingConfig } from "@/lib/firebase/config";
 import { ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
 import { Team } from "@/lib/models/User";
 import { InterviewSlotConfig } from "@/lib/models/Interview";
-import { getUserVisibleStatus, sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
+import { getUserVisibleStatus, sanitizeApplicationForApplicant, isAtOrPast } from "@/lib/utils/statusUtils";
+import { RecruitingStep } from "@/lib/models/Config";
 import { slugifySystem } from "@/lib/firebase/utils";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
@@ -136,12 +137,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         }
 
         try {
-          const config = await getInterviewConfig(application.team, offer.system);
-          if (!config || !config.signupLink) {
+          const interviewConfig = await getInterviewConfig(application.team, offer.system);
+          if (!interviewConfig || !interviewConfig.signupLink) {
             return { ...offer, configMissing: true };
           }
 
-          return { ...offer, signupLink: config.signupLink };
+          // The booking window closes at close_interviews; a pending offer past
+          // that point is a status display, not an invitation to book.
+          if (isAtOrPast(config.currentStep, RecruitingStep.CLOSE_INTERVIEWS)) {
+            return { ...offer };
+          }
+
+          return { ...offer, signupLink: interviewConfig.signupLink };
         } catch (error) {
           logger.error({ err: error, system: offer.system }, "Failed to load interview config");
           return { ...offer, error: "Failed to load signup link" };

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -936,10 +936,27 @@ export async function autoRejectUnscheduledInterviewApplicants(): Promise<string
   for (const doc of snapshot.docs) {
     const data = doc.data();
     const offers = normalizeInterviewOffers(data.interviewOffers) || [];
+    if (offers.length === 0) continue;
 
-    if (data.team === Team.SOLAR) continue;
-    if (offers.length <= 1) continue;
-    if (data.selectedInterviewSystem) continue;
+    // Booking happens on an external link, so offer status is the only record
+    // of what happened. In order:
+    //  1. An interview that took place is never swept, whatever else is on
+    //     the record — a second offer added afterwards used to get the
+    //     applicant rejected because they never used the picker.
+    //  2. Offers that all ended explicitly (no-show, cancelled) are closed out
+    //     for every team; those applicants otherwise sit at "Interview" with a
+    //     live signup link through decision day 3.
+    //  3. Non-Solar applicants holding several offers who never picked one
+    //     never booked anything.
+    // A lone PENDING offer is ambiguous (never booked, or interviewed and not
+    // yet marked) and is left alone rather than rejected on a guess.
+    const statuses = offers.map((o) => o.status);
+    if (statuses.includes(InterviewEventStatus.COMPLETED)) continue;
+    const allEnded = statuses.every(
+      (s) => s === InterviewEventStatus.NO_SHOW || s === InterviewEventStatus.CANCELLED
+    );
+    const neverPicked = data.team !== Team.SOLAR && offers.length > 1 && !data.selectedInterviewSystem;
+    if (!allEnded && !neverPicked) continue;
 
     await rejectApplicationFromSystems(doc.id, offers.map((o) => o.system));
     rejectedIds.push(doc.id);

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -1074,7 +1074,13 @@ export async function sweepOnDecisionAdvance(
     // committed to, and the stale snapshot would reject it.
     const isCrossTeamRejectable = (d: FirebaseFirestore.DocumentData): boolean =>
       !TERMINAL.includes(d.status) &&
-      d.status !== ApplicationStatus.WAITLISTED; // reneg pathway stays alive
+      d.status !== ApplicationStatus.WAITLISTED && // reneg pathway stays alive
+      // ...and so does its second half: an acceptance stamped for the day being
+      // entered (or later) is a promotion off the waitlist that this very
+      // advance is about to reveal. Rejecting it here destroyed it before the
+      // applicant ever saw it. If they leave it unanswered it expires on the
+      // next advance through pass 1 like any other offer.
+      !(d.status === ApplicationStatus.ACCEPTED && (d.trialDecisionDay || 1) >= dayEntered);
 
     for (const other of others.docs) {
       if (other.id === doc.id) continue;


### PR DESCRIPTION
Two sweep bugs; one commit each.

- **#57** The `close_interviews` sweep now reads offer status, not just count. An applicant whose interview was marked completed is never auto-rejected (a second offer added afterward used to reject them); an applicant whose offers all ended (no-show / cancelled) is closed out for every team, including single-offer cases that previously sat at "Interview" with a live signup link through decision day 3. A lone still-pending offer is left alone as before. The interview signup link is also withheld once the step is past `close_interviews`, and the swept ids are now logged.
- **#56** The Day 2/3 sweep no longer rejects a waitlist promotion at the moment it should become visible: an acceptance stamped for the day being entered (or later) is exempt from the cross-team rejection pass. If the promoted applicant never answers, it still expires on the next advance like any other offer.

Verified on the emulators (20 checks) across `interviewing → close_interviews → day1 → day2 → day3`: completed-interview spared, multi-offer-never-picked rejected, single-pending spared, no-show/cancelled rejected, Solar handled, rejection masked until `release_trial`, signup link withheld after close, sweep idempotent; and the promotion survives day 2, other live applications still cross-team rejected, an unanswered promotion expires on day 3.

Fixes #56, fixes #57