### PR TITLE
fix: serve hero video from wix cdn

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -41,6 +41,9 @@ export default function Hero() {
                     playsInline
                     className="w-full h-full object-cover"
                 >
+                    {/* Wix-hosted first so hero traffic doesn't count against
+                        Vercel fast data transfer; local copy is the fallback. */}
+                    <source src="https://video.wixstatic.com/video/649d3f_3f5feefdc5e546919b75b93cff8ec35c/1080p/mp4/file.mp4" type="video/mp4" />
                     <source src="/background.mp4" type="video/mp4" />
                 </video>
                 {/* Ocean Blue duotone wash (brand: photos on blue), then a


### PR DESCRIPTION
The 25MB `public/background.mp4` hero video was the dominant fast-data-transfer cost (~96% of static payload, downloaded by every homepage visitor). Point the hero at the Wix-hosted copy (CloudFront, immutable cache, range support) so egress lands on Wix instead of Vercel. Local file stays as a fallback `<source>` — zero transfer while the Wix link works, silent recovery if it ever dies.