### PR TITLE
fix: add email to sign-in allowlist

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -16,7 +16,8 @@ const allowed_emails_extras = [
   "lhroutreach@gmail.com",
   "longhornracingrecruitment@gmail.com",
   "matthew.king2023@gmail.com",
-  "ella.reinhart13@gmail.com"
+  "ella.reinhart13@gmail.com",
+  "britneyhoang954@gmail.com"
 ]
 
 


### PR DESCRIPTION
Adds britneyhoang954@gmail.com to allowed_emails_extras so they can sign in without a utexas.edu address.