### PR TITLE
fix: QA audit quick wins (#63, #67, #68, #76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,9 +158,10 @@ admin UI, or by a one-off script against Firestore. Several live docs already di
 their code defaults.
 
 Everything config-driven is cached, and the TTLs differ: questions 2h server-side plus 30 min
-in the applicant's browser (`localStorage`), About and FAQ 15 min, interviews 10 min,
-scorecards 5 min. Each admin tab states its own delay — keep that notice accurate when adding
-a new one.
+in the applicant's browser (`localStorage`), About, teams and FAQ 15 min. Interview and
+scorecard configs are **not** cached — those routes read Firestore per request, so an admin
+edit is live immediately. If you add a cache, say so in the tab's UI; don't state a delay
+that no cache actually enforces.
 
 ## Styling
 

--- a/app/admin/configuration/InterviewsTab.tsx
+++ b/app/admin/configuration/InterviewsTab.tsx
@@ -5,7 +5,7 @@ import { User, UserRole } from "@/lib/models/User";
 import { InterviewConfigForm } from "./InterviewConfigForm";
 import { CreateConfigModal } from "./CreateConfigModal";
 import { InitializeSystemButton } from "./InitializeSystemButton";
-import { AlertTriangle, Clock } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
 interface InterviewsTabProps {
   configs: InterviewSlotConfig[];
@@ -30,17 +30,6 @@ export function InterviewsTab({
           <p className="font-urbanist text-[14px] text-white/35">
             Manage interview settings, interviewers, and availability.
           </p>
-          <div
-            className="inline-flex items-center gap-1.5 mt-2.5 px-2.5 py-1 rounded-md text-[11px] font-medium"
-            style={{
-              backgroundColor: "rgba(255,181,38,0.06)",
-              border: "1px solid rgba(255,181,38,0.12)",
-              color: "rgba(255,181,38,0.6)",
-            }}
-          >
-            <Clock className="h-3 w-3" />
-            Changes may take up to 10 minutes to appear due to caching.
-          </div>
         </div>
 
         {showCreateButton && (

--- a/app/admin/configuration/ScorecardsTab.tsx
+++ b/app/admin/configuration/ScorecardsTab.tsx
@@ -274,12 +274,6 @@ export function ScorecardsTab() {
               ? "Define evaluation criteria for interviews."
               : "Define evaluation criteria for application reviews."}
           </p>
-          <div
-            className="inline-flex items-center gap-1.5 mt-2.5 px-2.5 py-1 rounded-md text-[11px] font-medium"
-            style={{ backgroundColor: "rgba(255,181,38,0.06)", border: "1px solid rgba(255,181,38,0.12)", color: "rgba(255,181,38,0.6)" }}
-          >
-            Changes may take up to 5 minutes to appear for reviewers due to caching.
-          </div>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -209,6 +209,15 @@ export async function POST(
         }
       }
 
+      // addMultipleTrialOffers enforces one trial invite per application and
+      // throws otherwise, which the catch below would render as a bare 500.
+      // Say so here instead, while the caller can still act on it.
+      if (systemsToOffer.length > 1) {
+        return NextResponse.json({
+          error: "Only one trial workday invite can be extended per application. Select a single system."
+        }, { status: 400 });
+      }
+
       // Atomically create trial offers and un-reject systems in a single transaction
       // Also set interviewDecision since we're advancing from interview to trial
       updatedApp = await addMultipleTrialOffers(id, systemsToOffer, 'advanced');

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -41,9 +41,16 @@ function resolveBulkSystems(
   const ranked: string[] = application.preferredSystems || [];
   if (requested.length > 0) {
     const systems = requested.filter((s) => ranked.includes(s));
-    return systems.length > 0
-      ? { systems }
-      : { systems: [], error: `Applicant did not rank ${requested.join(", ")}` };
+    if (systems.length === 0) {
+      return { systems: [], error: `Applicant did not rank ${requested.join(", ")}` };
+    }
+    // Same one-invite-per-application rule addMultipleTrialOffers enforces.
+    // Reported here so a two-system bulk run comes back as a per-applicant
+    // error rather than a thrown exception logged as an incident.
+    if (action === "trial" && systems.length > 1) {
+      return { systems: [], error: "Select a single system for the trial offer" };
+    }
+    return { systems };
   }
   if (action === "interview") {
     return ranked.length > 0 ? { systems: ranked } : { systems: [], error: "Applicant has no ranked systems" };

--- a/app/api/admin/config/email/route.ts
+++ b/app/api/admin/config/email/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   } catch (error: any) {
     console.error("Failed to fetch email templates config:", error);
     if (error.message === "Unauthorized") return new NextResponse("Unauthorized", { status: 401 });
-    if (error.message === "Forbidden") return new NextResponse("Forbidden", { status: 403 });
+    if (error.message.includes("Forbidden")) return new NextResponse("Forbidden", { status: 403 });
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }
@@ -24,7 +24,7 @@ export async function PUT(request: Request) {
   } catch (error: any) {
     console.error("Failed to update email templates config:", error);
     if (error.message === "Unauthorized") return new NextResponse("Unauthorized", { status: 401 });
-    if (error.message === "Forbidden") return new NextResponse("Forbidden", { status: 403 });
+    if (error.message.includes("Forbidden")) return new NextResponse("Forbidden", { status: 403 });
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -134,6 +134,7 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
           
           const result = await sendStatusEmail({
             trigger: expectedTrigger,
+            applicationId: app.id,
             applicantName: app.userName || "Applicant",
             applicantEmail: app.userEmail || "",
             teamName,

--- a/app/api/admin/scorecards/[id]/route.ts
+++ b/app/api/admin/scorecards/[id]/route.ts
@@ -128,7 +128,10 @@ export async function DELETE(
         .where("team", "==", team)
         .get();
       
-      const batch = adminDb.batch();
+      // Reassigned after every commit: a WriteBatch cannot be reused once
+      // committed, so the 501st update would throw with the config already
+      // deleted, leaving orphaned aggregate ratings behind.
+      let batch = adminDb.batch();
       let batchCount = 0;
 
       for (const doc of applicationsSnapshot.docs) {
@@ -156,6 +159,7 @@ export async function DELETE(
           // Firestore batches are limited to 500 operations
           if (batchCount >= 500) {
             await batch.commit();
+            batch = adminDb.batch();
             batchCount = 0;
           }
         }

--- a/app/api/admin/scorecards/route.ts
+++ b/app/api/admin/scorecards/route.ts
@@ -10,10 +10,6 @@ import { ScorecardType } from "@/lib/models/Scorecard";
 import { logger } from "@/lib/logger";
 
 
-// Cache scorecard configs for 5 minutes
-const CACHE_MAX_AGE = 300;
-const STALE_WHILE_REVALIDATE = 60;
-
 /**
  * GET /api/admin/scorecards
  * List all scorecard configs the user is authorized to see.
@@ -34,7 +30,10 @@ export async function GET(request: NextRequest) {
       { 
         status: 200,
         headers: {
-          'Cache-Control': `private, s-maxage=${CACHE_MAX_AGE}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}`,
+          // `private` forbids shared caches from storing this, and `s-maxage`
+          // is only read by shared caches — the old header combined the two and
+          // so cached nothing anywhere. Stated plainly rather than half-meant.
+          'Cache-Control': 'private, no-store',
         },
       }
     );

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -23,11 +23,12 @@ function isIgnoredException(properties: Record<string, unknown> | undefined): bo
 }
 
 if (!token || !host) {
+  // Warn, never throw: analytics is optional locally, and .env.example ships
+  // these blank, so a throw here greeted every fresh checkout with a crash on
+  // first page load. Production stays silent — the vars are set there.
   if (process.env.NODE_ENV !== "production") {
-    throw new Error(
-      !token
-        ? "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is configured"
-        : "NEXT_PUBLIC_POSTHOG_HOST variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once NEXT_PUBLIC_POSTHOG_HOST is configured",
+    console.warn(
+      `PostHog disabled: ${!token ? "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN" : "NEXT_PUBLIC_POSTHOG_HOST"} is not set. Analytics and client error monitoring are off for this session.`
     );
   }
 } else {

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -12,6 +12,8 @@ import type { EmailTrigger, EmailTemplatesConfig } from "@/lib/models/EmailTempl
 
 interface SendStatusEmailParams {
   trigger: EmailTrigger;
+  /** Logged instead of the applicant's address — see emailDomain() in ses.ts. */
+  applicationId?: string;
   applicantName: string;
   applicantEmail: string;
   teamName: string;
@@ -46,7 +48,7 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<Se
     // SECURITY: Never send emails to fake accounts
     if (params.isFakeData || params.applicantEmail.includes(".fake")) {
       logger.info(
-        { trigger: params.trigger, to: params.applicantEmail },
+        { trigger: params.trigger, applicationId: params.applicationId },
         "Skipping email to fake account"
       );
       return { sent: false, reason: "fake_account" };
@@ -97,7 +99,7 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<Se
     // Send via SES - Use Team Name as the sender display name
     await sendEmail(params.applicantEmail, renderedSubject, htmlBody, `${params.teamName} Team`);
     logger.info(
-      { trigger: params.trigger, to: params.applicantEmail, team: params.teamName },
+      { trigger: params.trigger, applicationId: params.applicationId, team: params.teamName },
       "Status email sent successfully"
     );
     return { sent: true };
@@ -105,7 +107,7 @@ export async function sendStatusEmail(params: SendStatusEmailParams): Promise<Se
     // Never throw; the caller reads the result. `err` is the key pino
     // serializes, so the stack actually reaches the log.
     logger.error(
-      { trigger: params.trigger, to: params.applicantEmail, err: error },
+      { trigger: params.trigger, applicationId: params.applicationId, err: error },
       "Failed to send status email (non-blocking)"
     );
     return { sent: false, reason: "send_failed" };

--- a/lib/email/ses.ts
+++ b/lib/email/ses.ts
@@ -8,6 +8,20 @@ import { logger } from "@/lib/logger";
  */
 let _sesClient: SESClient | null = null;
 
+/**
+ * Domain half of an address, for logging.
+ *
+ * Recipient addresses must never reach the logs: `logger.error` tees its
+ * context fields to PostHog error monitoring, which files a GitHub issue per
+ * exception, so one throttled release batch would publish every applicant's
+ * address. The domain is what is actually diagnostic here (SES suppression
+ * lists and MX failures are domain-wide) and identifies nobody.
+ */
+function emailDomain(address: string): string {
+  const at = address.lastIndexOf("@");
+  return at === -1 ? "unknown" : address.slice(at + 1);
+}
+
 function getSesClient(): SESClient {
   if (!_sesClient) {
     const region = process.env.AWS_SES_REGION;
@@ -79,10 +93,16 @@ export async function sendEmail(
   try {
     const client = getSesClient();
     const result = await client.send(command);
-    logger.info({ to, subject, messageId: result.MessageId }, "Email sent successfully");
+    logger.info(
+      { recipientDomain: emailDomain(to), messageId: result.MessageId },
+      "Email sent successfully"
+    );
     return result.MessageId;
   } catch (error) {
-    logger.error({ to, subject, error }, "Failed to send email via SES");
+    logger.error(
+      { recipientDomain: emailDomain(to), error },
+      "Failed to send email via SES"
+    );
     throw error;
   }
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -38,7 +38,6 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  console.log("Middleware pass:", request.nextUrl.pathname, "Session:", !!sessionCookie);
   return NextResponse.next();
 }
 


### PR DESCRIPTION
Four low-risk fixes from the Aug 2026 readiness audit. `npm run build` passes.

### #63 — applicant addresses in error monitoring
`logger.error` tees its context fields to PostHog, which files a GitHub issue per exception, so a throttled release batch would have published every recipient's address.

- `ses.ts` logs `recipientDomain` (the domain half only) instead of the address. The domain is what is diagnostic — SES suppression and MX failures are domain-wide.
- `send.ts` had the same leak on the same failure via its own catch; it now logs `applicationId`, passed down from the trigger route.
- `subject` dropped from both SES log lines: status subjects render `{{applicantName}}`, and lead notifications build `ACCEPTED: Team Invite for <name>`, so the subject leaked names alongside the addresses.

### #67 — scorecard DELETE reused a committed WriteBatch
`let batch`, reassigned after each `commit()`. A team with 500+ rated applications no longer throws on the 501st write with the config already deleted.

### #68 — errors surfacing as bare 500s
- `config/email/route.ts` matched `error.message === "Forbidden"`, but `requireAdmin` throws `"Forbidden: Admin access required"`, so non-admin staff got a 500 logged as a real error. Now `.includes()`.
- The single-system trial rule is checked in the status route and returns 400 with the reason, ahead of the throw in `addMultipleTrialOffers`.
- Bulk hits the same throw by a different path — `resolveBulkSystems` capped candidates at one only when systems were inferred, not when staff selected them explicitly. Two selected systems reached the throw, and the per-item catch calls `logger.error`, so a 50-applicant run would have filed 50 PostHog exceptions. Now a per-applicant error string.

### #76 — misleading notices and dev noise
- Both cache notices deleted. The Interviews tab takes its configs as props from a server component, so nothing cached anything; the scorecards route combined `private` (shared caches must not store) with `s-maxage` (read only by shared caches), which cached nothing anywhere. Header is now an honest `private, no-store` — no behavior change.
- Removed the per-request `console.log` in `proxy.ts`.
- The blank-PostHog-token dev throw is a `console.warn`, so a fresh checkout no longer crashes on first page load.
- CLAUDE.md's TTL table corrected: interview and scorecard configs are not cached.

**Not fixed:** `.env.example` still ships an empty `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`. Now cosmetic rather than fatal, since the throw it triggered is gone. See #76.