### PR TITLE
feat: admin stats page and read-only stats api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,8 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 # FIREBASE_STORAGE_EMULATOR_HOST=127.0.0.1:9199
 # NEXT_PUBLIC_FIREBASE_EMULATOR=1
+
+# Read-only stats feed for the recruiting bot: GET /api/stats with
+# Authorization: Bearer <token>. Aggregate counts only, never PII, never a user
+# session. Rotate to cut the bot off.
+STATS_API_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,14 @@ proxy.ts                               route-level redirect middleware
 ```
 
 `app/admin/` holds `dashboard`, `applications` (the big one — sidebar + detail + scorecards +
-CSV export + bulk actions), `users`, `teams`, `configuration` (the CMS), and `settings`.
+CSV export + bulk actions), `stats` (aggregate numbers + trends, all staff), `users`, `teams`,
+`configuration` (the CMS), and `settings`.
+
+Stats are computed in `lib/firebase/stats.ts` from timestamps already on the data (no stored
+snapshots, no cron) and cached 5 min. Everything in that payload is a count — never add a
+field that identifies an applicant. `GET /api/stats` serves a reduced copy to the recruiting
+bot, gated by `STATS_API_TOKEN` (a bearer token, not a user session) so the bot never holds a
+staff login.
 
 ## Domain model
 

--- a/app/admin/stats/StatsView.tsx
+++ b/app/admin/stats/StatsView.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import { Download, Loader2, RefreshCw } from "lucide-react";
+import { useStats } from "@/hooks/useStats";
+import { Team } from "@/lib/models/User";
+import { ApplicationStatus } from "@/lib/models/Application";
+import { getTeamColor } from "@/lib/teamColors";
+import type { RecruitingStats, SystemDemand } from "@/lib/firebase/stats";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
+
+const STATUS_ORDER: ApplicationStatus[] = [
+  ApplicationStatus.IN_PROGRESS,
+  ApplicationStatus.SUBMITTED,
+  ApplicationStatus.INTERVIEW,
+  ApplicationStatus.TRIAL,
+  ApplicationStatus.ACCEPTED,
+  ApplicationStatus.WAITLISTED,
+  ApplicationStatus.COMMITTED,
+  ApplicationStatus.DECLINED,
+  ApplicationStatus.REJECTED,
+];
+
+const STATUS_LABELS: Record<ApplicationStatus, string> = {
+  [ApplicationStatus.IN_PROGRESS]: "In progress",
+  [ApplicationStatus.SUBMITTED]: "Submitted",
+  [ApplicationStatus.INTERVIEW]: "Interview",
+  [ApplicationStatus.TRIAL]: "Trial",
+  [ApplicationStatus.ACCEPTED]: "Accepted",
+  [ApplicationStatus.WAITLISTED]: "Waitlisted",
+  [ApplicationStatus.COMMITTED]: "Committed",
+  [ApplicationStatus.DECLINED]: "Declined",
+  [ApplicationStatus.REJECTED]: "Rejected",
+};
+
+const GOLD = "var(--lhr-gold)";
+
+type Metric = "submitted" | "created" | "accounts";
+type Mode = "cumulative" | "per-bucket";
+type Range = "24h" | "7d" | "all";
+type BucketMinutes = 15 | 60 | 1440;
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+const fmtInt = (n: number) => n.toLocaleString("en-US");
+const pct = (n: number, d: number) => (d > 0 ? `${Math.round((100 * n) / d)}%` : "—");
+
+function startOfLocalDay(ms: number): number {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function fmtTick(ms: number, bucket: BucketMinutes): string {
+  const d = new Date(ms);
+  if (bucket === 1440) return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return d.toLocaleString("en-US", { weekday: "short", hour: "numeric" });
+}
+
+function fmtWhen(ms: number, bucket: BucketMinutes): string {
+  const d = new Date(ms);
+  if (bucket === 1440) return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  return d.toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+function downloadCsv(filename: string, rows: (string | number)[][]) {
+  const esc = (v: string | number) => {
+    const s = String(v);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const blob = new Blob([rows.map((r) => r.map(esc).join(",")).join("\n")], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ---------------------------------------------------------------------------
+// Series building (client-side re-bucketing of the sparse 15-minute points)
+// ---------------------------------------------------------------------------
+
+interface Row { t: number; total: number; byTeam: Record<Team, number> }
+
+function buildRows(stats: RecruitingStats, metric: Metric, mode: Mode, bucket: BucketMinutes, range: Range): Row[] {
+  const from = new Date(stats.series.from).getTime();
+  const to = new Date(stats.series.to).getTime();
+  const bucketMs = bucket * 60e3;
+  const key = (ms: number) => (bucket === 1440 ? startOfLocalDay(ms) : Math.floor(ms / bucketMs) * bucketMs);
+  const next = (k: number) => (bucket === 1440 ? startOfLocalDay(k + 36 * 3600e3) : k + bucketMs);
+
+  const grid = new Map<number, Row>();
+  for (let k = key(from); k <= key(to); k = next(k)) {
+    grid.set(k, { t: k, total: 0, byTeam: { [Team.ELECTRIC]: 0, [Team.SOLAR]: 0, [Team.COMBUSTION]: 0 } });
+  }
+  for (const p of stats.series.points) {
+    const row = grid.get(key(new Date(p.t).getTime()));
+    if (!row) continue;
+    if (metric === "accounts") { row.total += p.accounts; continue; }
+    for (const team of TEAMS) { const v = p[metric][team] || 0; row.byTeam[team] += v; row.total += v; }
+  }
+  let rows = [...grid.values()];
+  if (mode === "cumulative") {
+    let total = 0; const acc: Record<Team, number> = { [Team.ELECTRIC]: 0, [Team.SOLAR]: 0, [Team.COMBUSTION]: 0 };
+    rows = rows.map((r) => {
+      total += r.total;
+      for (const team of TEAMS) acc[team] += r.byTeam[team];
+      return { t: r.t, total, byTeam: { ...acc } };
+    });
+  }
+  const now = to;
+  const start = range === "24h" ? now - 24 * 3600e3 : range === "7d" ? now - 7 * 24 * 3600e3 : -Infinity;
+  return rows.filter((r) => r.t >= key(Math.max(start, from)));
+}
+
+// ---------------------------------------------------------------------------
+// Chart
+// ---------------------------------------------------------------------------
+
+interface Series { key: string; label: string; color: string; dash?: string; value: (r: Row) => number }
+
+function TimeChart({ rows, series, kind, bucket }: { rows: Row[]; series: Series[]; kind: "line" | "bar"; bucket: BucketMinutes }) {
+  const W = 960, H = 300, ML = 44, MR = 70, MT = 16, MB = 34;
+  const IW = W - ML - MR, IH = H - MT - MB;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<{ i: number; x: number; y: number } | null>(null);
+
+  const n = rows.length;
+  const maxRaw = Math.max(1, ...rows.map((r) => (kind === "bar" ? series.reduce((a, s) => a + s.value(r), 0) : Math.max(...series.map((s) => s.value(r))))));
+  const step = niceStep(maxRaw);
+  const ymax = Math.ceil(maxRaw / step) * step;
+  const X = (i: number) => ML + (n <= 1 ? IW / 2 : (i * IW) / (n - 1));
+  const XB = (i: number) => ML + ((i + 0.5) * IW) / Math.max(1, n);
+  const Y = (v: number) => MT + IH - (v / ymax) * IH;
+  const tickEvery = Math.max(1, Math.ceil(n / 8));
+
+  const onMove = (e: React.MouseEvent<SVGRectElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const frac = (e.clientX - rect.left) / rect.width;
+    const i = Math.max(0, Math.min(n - 1, kind === "bar" ? Math.floor(frac * n) : Math.round(frac * (n - 1))));
+    const wrap = wrapRef.current?.getBoundingClientRect();
+    setHover({ i, x: e.clientX - (wrap?.left ?? 0), y: e.clientY - (wrap?.top ?? 0) });
+  };
+
+  if (n === 0) return <div className="h-40 flex items-center justify-center text-[13px] text-white/30">No data in this range.</div>;
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto block select-none">
+        {/* grid + y labels */}
+        {Array.from({ length: Math.round(ymax / step) + 1 }, (_, k) => k * step).map((v) => (
+          <g key={v}>
+            <line x1={ML} x2={W - MR} y1={Y(v)} y2={Y(v)} stroke="currentColor" className="text-white/10" strokeWidth={1} />
+            <text x={ML - 8} y={Y(v) + 4} textAnchor="end" fill="currentColor" className="text-white/35" fontSize={11}>{fmtInt(v)}</text>
+          </g>
+        ))}
+        {/* x labels */}
+        {rows.map((r, i) => (i % tickEvery === 0 || i === n - 1) && (i === n - 1 ? (n - 1) % tickEvery > tickEvery / 2 || n - 1 === 0 : true) ? (
+          <text key={r.t} x={kind === "bar" ? XB(i) : X(i)} y={H - 10} textAnchor="middle" fill="currentColor" className="text-white/35" fontSize={11}>{fmtTick(r.t, bucket)}</text>
+        ) : null)}
+
+        {kind === "bar" ? (
+          rows.map((r, i) => {
+            const bw = Math.max(2, IW / n - 2);
+            let acc = 0; const total = series.reduce((a, s) => a + s.value(r), 0);
+            return (
+              <g key={r.t}>
+                {series.map((s) => {
+                  const v = s.value(r); if (!v) return null;
+                  const y0 = Y(acc), y1 = Y(acc + v); acc += v;
+                  const isTop = acc === total; const h = Math.max(1, y0 - y1 - (acc - v > 0 ? 1 : 0));
+                  const x = XB(i) - bw / 2; const rr = isTop ? Math.min(3, bw / 2, h) : 0;
+                  return <path key={s.key} d={`M${x},${y0} V${y1 + rr} Q${x},${y1} ${x + rr},${y1} H${x + bw - rr} Q${x + bw},${y1} ${x + bw},${y1 + rr} V${y0} Z`} fill={s.color} />;
+                })}
+              </g>
+            );
+          })
+        ) : (
+          series.map((s) => (
+            <g key={s.key}>
+              <path d={rows.map((r, i) => `${i ? "L" : "M"}${X(i).toFixed(1)},${Y(s.value(r)).toFixed(1)}`).join(" ")} fill="none" stroke={s.color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" strokeDasharray={s.dash} />
+              <circle cx={W - MR + 6} cy={Y(s.value(rows[n - 1]))} r={3.5} fill={s.color} />
+              <text x={W - MR + 14} y={Y(s.value(rows[n - 1])) + 4} fill="currentColor" className="text-white/80" fontSize={11} fontWeight={600}>{fmtInt(s.value(rows[n - 1]))}</text>
+            </g>
+          ))
+        )}
+
+        {hover && kind === "line" && <line x1={X(hover.i)} x2={X(hover.i)} y1={MT} y2={MT + IH} stroke="currentColor" className="text-white/30" strokeDasharray="2 3" />}
+        <rect x={ML} y={MT} width={IW} height={IH} fill="transparent" onMouseMove={onMove} onMouseLeave={() => setHover(null)} />
+      </svg>
+      {hover && (
+        <div className="absolute pointer-events-none z-10 rounded-lg border border-white/10 bg-[#0c1218] px-3 py-2 text-[12px] shadow-xl min-w-[170px]"
+          style={{ left: Math.min(hover.x + 14, (wrapRef.current?.clientWidth ?? 400) - 190), top: hover.y + 14 }}>
+          <div className="font-semibold text-white mb-1">{fmtWhen(rows[hover.i].t, bucket)}</div>
+          {series.map((s) => (
+            <div key={s.key} className="flex items-center justify-between gap-4 text-white/70">
+              <span className="flex items-center gap-1.5"><i className="inline-block w-2 h-2 rounded-sm" style={{ background: s.color }} />{s.label}</span>
+              <b className="text-white tabular-nums">{fmtInt(s.value(rows[hover.i]))}</b>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function niceStep(max: number): number {
+  const raw = max / 4;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const norm = raw / mag;
+  const nice = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 2.5 ? 2.5 : norm <= 5 ? 5 : 10;
+  return Math.max(1, nice * mag); // counts: never a fractional gridline
+}
+
+// ---------------------------------------------------------------------------
+// UI atoms
+// ---------------------------------------------------------------------------
+
+function Segmented<T extends string | number>({ value, options, onChange }: { value: T; options: { value: T; label: string; disabled?: boolean }[]; onChange: (v: T) => void }) {
+  return (
+    <div className="inline-flex rounded-lg border border-white/10 bg-white/[0.04] p-0.5">
+      {options.map((o) => (
+        <button key={String(o.value)} disabled={o.disabled} onClick={() => onChange(o.value)}
+          className={clsx("px-2.5 h-7 rounded-md text-[12px] font-semibold transition-colors",
+            o.value === value ? "bg-white/10 text-white" : "text-white/50 hover:text-white/80",
+            o.disabled && "opacity-30 cursor-not-allowed")}>
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Card({ title, right, children, className }: { title?: string; right?: React.ReactNode; children: React.ReactNode; className?: string }) {
+  return (
+    <section className={clsx("rounded-xl border border-white/10 bg-white/[0.04] p-5", className)}>
+      {(title || right) && (
+        <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+          {title && <h2 className="text-[14px] font-semibold text-white">{title}</h2>}
+          {right}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+function Tile({ value, label, sub }: { value: string; label: string; sub?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3.5">
+      <div className="text-[26px] font-bold text-white tracking-tight tabular-nums leading-none">{value}</div>
+      <div className="text-[12px] text-white/60 mt-1.5">{label}</div>
+      {sub && <div className="text-[11px] text-white/35 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+function ExportButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button onClick={onClick} className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md border border-white/10 text-[12px] font-semibold text-white/50 hover:text-white hover:bg-white/5">
+      <Download className="h-3 w-3" /> CSV
+    </button>
+  );
+}
+
+function Bar({ value, max, color }: { value: number; max: number; color: string }) {
+  return (
+    <div className="h-1.5 rounded-full bg-white/5 w-full overflow-hidden">
+      <div className="h-full rounded-full" style={{ width: `${max > 0 ? (100 * value) / max : 0}%`, background: color }} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function StatsView() {
+  const { stats, error, isLoading, refreshing, refresh } = useStats();
+
+  const [metric, setMetric] = useState<Metric>("submitted");
+  const [mode, setMode] = useState<Mode>("cumulative");
+  const [bucket, setBucket] = useState<BucketMinutes>(60);
+  const [range, setRange] = useState<Range>("all");
+  const [split, setSplit] = useState(true);
+
+  const [sysTeam, setSysTeam] = useState<Team>(Team.ELECTRIC);
+  const [sysSort, setSysSort] = useState<{ key: keyof SystemDemand; dir: "asc" | "desc" }>({ key: "any", dir: "desc" });
+
+  const rows = useMemo(() => (stats ? buildRows(stats, metric, mode, bucket, range) : []), [stats, metric, mode, bucket, range]);
+
+  const series: Series[] = useMemo(() => {
+    if (metric === "accounts") return [{ key: "accounts", label: "Applicant accounts", color: GOLD, value: (r) => r.total }];
+    if (split) return TEAMS.map((t) => ({ key: t, label: t, color: getTeamColor(t), value: (r) => r.byTeam[t] }));
+    return [{ key: "total", label: metric === "submitted" ? "Submitted" : "Started", color: GOLD, value: (r) => r.total }];
+  }, [metric, split]);
+
+  const systemRows = useMemo(() => {
+    if (!stats) return [];
+    const list = [...stats.systems[sysTeam]];
+    const { key, dir } = sysSort;
+    list.sort((a, b) => {
+      const av = a[key], bv = b[key];
+      const c = typeof av === "number" && typeof bv === "number" ? av - bv : String(av).localeCompare(String(bv));
+      return dir === "asc" ? c : -c;
+    });
+    return list;
+  }, [stats, sysTeam, sysSort]);
+
+  const activeStatuses = useMemo(() => {
+    if (!stats) return [] as ApplicationStatus[];
+    return STATUS_ORDER.filter((s) => s === ApplicationStatus.IN_PROGRESS || s === ApplicationStatus.SUBMITTED || stats.applications.byStatus[s] > 0);
+  }, [stats]);
+
+  const toggleSort = (key: keyof SystemDemand) =>
+    setSysSort((s) => (s.key === key ? { key, dir: s.dir === "desc" ? "asc" : "desc" } : { key, dir: key === "system" ? "asc" : "desc" }));
+
+  return (
+    <div className="min-h-screen pt-24 pb-20 relative">
+      <div className="fixed inset-0 -z-10" style={{ background: "radial-gradient(ellipse at 20% 0%, rgba(4,95,133,0.07) 0%, transparent 50%), #030608" }} />
+      <div className="container mx-auto px-6 md:px-10 max-w-6xl">
+        {/* Header */}
+        <div className="mb-8 flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold tracking-[0.3em] uppercase mb-3" style={{ color: "var(--lhr-gray-blue)" }}>Admin</p>
+            <h1 className="text-3xl md:text-4xl font-bold text-white tracking-tight">Stats</h1>
+            {stats && (
+              <p className="text-[12px] text-white/35 mt-2">
+                Step <span className="text-white/60 font-semibold">{stats.step}</span> · computed {new Date(stats.generatedAt).toLocaleString("en-US", { hour: "numeric", minute: "2-digit", month: "short", day: "numeric" })} · cached 5 min · aggregate only, no applicant is identifiable here
+              </p>
+            )}
+          </div>
+          <button onClick={() => refresh().catch(() => undefined)} disabled={refreshing}
+            className={clsx("inline-flex items-center gap-2 px-4 h-10 rounded-lg text-[13px] font-semibold transition-all duration-200",
+              refreshing ? "bg-white/5 border border-white/5 text-white/20 cursor-not-allowed" : "bg-white/5 border border-white/10 text-white/60 hover:bg-white/10 hover:text-white active:scale-95")}>
+            {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5 opacity-60" />}
+            Recompute
+          </button>
+        </div>
+
+        {error && <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-300">Couldn&apos;t load stats: {String(error.message || error)}</div>}
+        {isLoading && !stats && <div className="flex items-center gap-2 text-white/40 text-[13px]"><Loader2 className="h-4 w-4 animate-spin" /> Computing…</div>}
+
+        {stats && (
+          <div className="space-y-6">
+            {/* Tiles */}
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+              <Tile value={fmtInt(stats.accounts.applicants)} label="Applicant accounts" sub={`+${stats.velocity.accountsLastHour} last hour · +${stats.velocity.accountsLast24h} last 24h`} />
+              <Tile value={fmtInt(stats.applications.total)} label="Applications started" sub={`+${stats.velocity.createdLastHour} last hour · +${stats.velocity.createdLast24h} last 24h`} />
+              <Tile value={fmtInt(stats.applications.submitted)} label="Submitted" sub={`+${stats.velocity.submittedLastHour} last hour · +${stats.velocity.submittedLast24h} last 24h`} />
+              <Tile value={pct(stats.applications.submitted, stats.applications.total)} label="Submit rate" sub={`${fmtInt(stats.applications.byStatus[ApplicationStatus.IN_PROGRESS])} still in progress`} />
+              <Tile value={fmtInt(stats.crossTeam.applicants)} label="Distinct applicants" sub={`${fmtInt(stats.crossTeam.byTeamCount[2] + stats.crossTeam.byTeamCount[3])} applied to 2+ teams`} />
+            </div>
+
+            {/* Time series */}
+            <Card title="Over time" right={
+              <div className="flex items-center gap-2 flex-wrap">
+                <Segmented value={metric} onChange={setMetric} options={[{ value: "submitted", label: "Submitted" }, { value: "created", label: "Started" }, { value: "accounts", label: "Accounts" }]} />
+                <Segmented value={mode} onChange={setMode} options={[{ value: "cumulative", label: "Cumulative" }, { value: "per-bucket", label: "Per bucket" }]} />
+                <Segmented value={bucket} onChange={setBucket} options={[{ value: 15, label: "15m" }, { value: 60, label: "1h" }, { value: 1440, label: "Day" }]} />
+                <Segmented value={range} onChange={setRange} options={[{ value: "24h", label: "24h" }, { value: "7d", label: "7d" }, { value: "all", label: "All" }]} />
+                <Segmented value={split ? "team" : "total"} onChange={(v) => setSplit(v === "team")} options={[{ value: "total", label: "Total" }, { value: "team", label: "By team", disabled: metric === "accounts" }]} />
+                <ExportButton onClick={() => downloadCsv(`${metric}-${mode}-${bucket}m.csv`, [["time", ...series.map((s) => s.label)], ...rows.map((r) => [new Date(r.t).toISOString(), ...series.map((s) => s.value(r))])])} />
+              </div>
+            }>
+              <div className="flex items-center gap-4 mb-2 text-[12px] text-white/50">
+                {series.map((s) => <span key={s.key} className="inline-flex items-center gap-1.5"><i className="inline-block w-3 h-[3px] rounded-full" style={{ background: s.color }} />{s.label}</span>)}
+              </div>
+              <TimeChart rows={rows} series={series} kind={mode === "cumulative" ? "line" : "bar"} bucket={bucket} />
+              {metric === "accounts" && stats.accounts.applicantsWithCreatedAt < stats.accounts.applicants && (
+                <p className="text-[11px] text-white/30 mt-2">Accounts line covers {fmtInt(stats.accounts.applicantsWithCreatedAt)} of {fmtInt(stats.accounts.applicants)} applicant accounts — the rest predate creation-time tracking.</p>
+              )}
+            </Card>
+
+            {/* Team × status */}
+            <Card title="Pipeline by team" right={<ExportButton onClick={() => downloadCsv("pipeline-by-team.csv", [["team", "started", "submitted", ...activeStatuses.map((s) => STATUS_LABELS[s])], ...TEAMS.map((t) => [t, stats.applications.byTeam[t].total, stats.applications.byTeam[t].submitted, ...activeStatuses.map((s) => stats.applications.byTeam[t].byStatus[s])]), ["All", stats.applications.total, stats.applications.submitted, ...activeStatuses.map((s) => stats.applications.byStatus[s])]])} />}>
+              <div className="overflow-x-auto">
+                <table className="w-full text-[13px] tabular-nums">
+                  <thead>
+                    <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                      <th className="text-left font-semibold py-2 pr-4">Team</th>
+                      <th className="text-right font-semibold py-2 px-3">Started</th>
+                      <th className="text-right font-semibold py-2 px-3">Submitted</th>
+                      {activeStatuses.map((s) => <th key={s} className="text-right font-semibold py-2 px-3">{s === ApplicationStatus.SUBMITTED ? "Awaiting review" : STATUS_LABELS[s]}</th>)}
+                      <th className="text-left font-semibold py-2 pl-4 w-40">Submitted share</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {TEAMS.map((t) => {
+                      const row = stats.applications.byTeam[t];
+                      return (
+                        <tr key={t} className="border-t border-white/5">
+                          <td className="py-2.5 pr-4 font-semibold text-white flex items-center gap-2"><i className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: getTeamColor(t) }} />{t}</td>
+                          <td className="text-right px-3 text-white/80">{fmtInt(row.total)}</td>
+                          <td className="text-right px-3 text-white font-semibold">{fmtInt(row.submitted)}</td>
+                          {activeStatuses.map((s) => <td key={s} className={clsx("text-right px-3", row.byStatus[s] ? "text-white/80" : "text-white/20")}>{fmtInt(row.byStatus[s])}</td>)}
+                          <td className="pl-4"><div className="flex items-center gap-2"><Bar value={row.submitted} max={row.total} color={getTeamColor(t)} /><span className="text-white/50 text-[11px] w-9 text-right">{pct(row.submitted, row.total)}</span></div></td>
+                        </tr>
+                      );
+                    })}
+                    <tr className="border-t border-white/10 text-white">
+                      <td className="py-2.5 pr-4 font-semibold">All teams</td>
+                      <td className="text-right px-3 font-semibold">{fmtInt(stats.applications.total)}</td>
+                      <td className="text-right px-3 font-semibold">{fmtInt(stats.applications.submitted)}</td>
+                      {activeStatuses.map((s) => <td key={s} className="text-right px-3 font-semibold">{fmtInt(stats.applications.byStatus[s])}</td>)}
+                      <td className="pl-4"><div className="flex items-center gap-2"><Bar value={stats.applications.submitted} max={stats.applications.total} color={GOLD} /><span className="text-white/50 text-[11px] w-9 text-right">{pct(stats.applications.submitted, stats.applications.total)}</span></div></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+
+            {/* System demand */}
+            <Card title="System demand" right={
+              <div className="flex items-center gap-2 flex-wrap">
+                <Segmented value={sysTeam} onChange={setSysTeam} options={TEAMS.map((t) => ({ value: t, label: t }))} />
+                <ExportButton onClick={() => downloadCsv(`system-demand-${sysTeam.toLowerCase()}.csv`, [["system", "1st", "2nd", "3rd", "any", "submitted", "rejectedBy", "interviewOffers", "trialOffers"], ...systemRows.map((r) => [r.system, r.rank1, r.rank2, r.rank3, r.any, r.submitted, r.rejectedBy, r.interviewOffers, r.trialOffers])])} />
+              </div>
+            }>
+              <div className="overflow-x-auto">
+                <table className="w-full text-[13px] tabular-nums">
+                  <thead>
+                    <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                      {([["system", "System"], ["rank1", "1st"], ["rank2", "2nd"], ["rank3", "3rd"], ["any", "Any rank"], ["submitted", "Submitted"], ["rejectedBy", "Rejected by"], ["interviewOffers", "Interviews"], ["trialOffers", "Trials"]] as [keyof SystemDemand, string][]).map(([k, label]) => (
+                        <th key={k} onClick={() => toggleSort(k)} className={clsx("font-semibold py-2 px-3 cursor-pointer select-none whitespace-nowrap hover:text-white/70", k === "system" ? "text-left pl-0" : "text-right", sysSort.key === k && "text-white/80")}>
+                          {label}{sysSort.key === k ? (sysSort.dir === "desc" ? " ↓" : " ↑") : ""}
+                        </th>
+                      ))}
+                      <th className="text-left font-semibold py-2 pl-4 w-40">Share of team</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {systemRows.map((r) => {
+                      const max = Math.max(1, ...stats.systems[sysTeam].map((x) => x.any));
+                      return (
+                        <tr key={r.system} className="border-t border-white/5">
+                          <td className="py-2.5 pr-3 font-semibold text-white whitespace-nowrap">{r.system}</td>
+                          {(["rank1", "rank2", "rank3", "any", "submitted", "rejectedBy", "interviewOffers", "trialOffers"] as (keyof SystemDemand)[]).map((k) => (
+                            <td key={k} className={clsx("text-right px-3", r[k] ? (k === "any" ? "text-white font-semibold" : "text-white/80") : "text-white/20")}>{fmtInt(r[k] as number)}</td>
+                          ))}
+                          <td className="pl-4"><Bar value={r.any} max={max} color={getTeamColor(sysTeam)} /></td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-[11px] text-white/30 mt-3">Counts of applications ranking each system in that position. &ldquo;Any rank&rdquo; is what a system lead sees in their queue; &ldquo;Rejected by&rdquo;, &ldquo;Interviews&rdquo; and &ldquo;Trials&rdquo; fill in as review progresses.</p>
+            </Card>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              {/* Cross-team */}
+              <Card title="Cross-team applicants">
+                <div className="grid grid-cols-3 gap-3 mb-4">
+                  {([1, 2, 3] as const).map((n) => (
+                    <div key={n} className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5">
+                      <div className="text-[22px] font-bold text-white tabular-nums leading-none">{fmtInt(stats.crossTeam.byTeamCount[n])}</div>
+                      <div className="text-[11px] text-white/50 mt-1">{n === 1 ? "one team" : `${n} teams`}</div>
+                    </div>
+                  ))}
+                </div>
+                {stats.crossTeam.combos.length > 0 ? (
+                  <div className="space-y-2">
+                    {stats.crossTeam.combos.map((c) => (
+                      <div key={c.teams.join("+")} className="flex items-center gap-3 text-[13px]">
+                        <span className="flex items-center gap-1.5 w-48 text-white/80">{c.teams.map((t) => <i key={t} className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: getTeamColor(t) }} />)}<span className="ml-1">{c.teams.join(" + ")}</span></span>
+                        <Bar value={c.count} max={stats.crossTeam.combos[0].count} color={GOLD} />
+                        <span className="w-10 text-right text-white tabular-nums font-semibold">{fmtInt(c.count)}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : <p className="text-[12px] text-white/30">No one has applied to more than one team yet.</p>}
+              </Card>
+
+              {/* Uploads */}
+              <Card title="Uploads (submitted applications)">
+                <div className="space-y-4">
+                  {([["Resume attached", stats.uploads.resume], ["Portfolio attached", stats.uploads.portfolio]] as [string, number][]).map(([label, v]) => (
+                    <div key={label}>
+                      <div className="flex items-center justify-between text-[13px] mb-1.5"><span className="text-white/70">{label}</span><span className="text-white font-semibold tabular-nums">{fmtInt(v)} <span className="text-white/40 font-normal">/ {fmtInt(stats.uploads.submitted)} · {pct(v, stats.uploads.submitted)}</span></span></div>
+                      <Bar value={v} max={stats.uploads.submitted} color={GOLD} />
+                    </div>
+                  ))}
+                  <p className="text-[11px] text-white/30">Resumes are required on the form; portfolios are optional. A low resume number here means uploads are failing, not that people skipped it.</p>
+                </div>
+              </Card>
+
+              {/* Demographics */}
+              {([["Major", stats.demographics.major, "majors.csv"], ["Graduation year", stats.demographics.graduationYear, "graduation-years.csv"]] as [string, { value: string; count: number }[], string][]).map(([title, list, file]) => (
+                <Card key={title} title={`${title} (submitted)`} right={<ExportButton onClick={() => downloadCsv(file, [[title.toLowerCase(), "count"], ...list.map((x) => [x.value, x.count])])} />}>
+                  {list.length === 0 ? <p className="text-[12px] text-white/30">Nothing submitted yet.</p> : (
+                    <div className="space-y-2">
+                      {list.map((x) => (
+                        <div key={x.value} className="flex items-center gap-3 text-[13px]">
+                          <span className="w-44 truncate text-white/80" title={x.value}>{x.value}</span>
+                          <Bar value={x.count} max={list[0].count} color={x.value === "Other" ? "rgba(255,255,255,0.2)" : GOLD} />
+                          <span className="w-10 text-right text-white tabular-nums font-semibold">{fmtInt(x.count)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              ))}
+            </div>
+
+            <p className="text-[11px] text-white/25 leading-relaxed">
+              History is reconstructed from creation and submission timestamps rather than stored snapshots, so an application that is submitted and later reopened drops out of the submitted history. Seeded fake applications are excluded. The recruiting bot reads a reduced copy of these numbers from <code className="text-white/40">/api/stats</code>.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/stats/page.tsx
+++ b/app/admin/stats/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { requireStaff } from "@/lib/auth/guard";
+import { StatsView } from "./StatsView";
+
+export const metadata: Metadata = { title: "Stats" };
+
+// The admin layout already gates on staff; the explicit call here is the
+// house rule (every admin page guards itself) and keeps the page safe if the
+// layout ever changes.
+export default async function AdminStatsPage() {
+  try {
+    await requireStaff();
+  } catch {
+    redirect("/admin/dashboard");
+  }
+  return <StatsView />;
+}

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { requireStaff } from "@/lib/auth/guard";
+import { getRecruitingStats, invalidateRecruitingStats } from "@/lib/firebase/stats";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET  /api/admin/stats — full aggregate stats for /admin/stats (staff only).
+ * POST /api/admin/stats — drop the 5-minute cache and recompute.
+ *
+ * Aggregate only: nothing in the payload identifies an applicant.
+ */
+export async function GET() {
+  try {
+    await requireStaff();
+    const stats = await getRecruitingStats();
+    return NextResponse.json(stats, { headers: { "Cache-Control": "private, no-store" } });
+  } catch (error) {
+    return handleError(error, "Failed to load admin stats");
+  }
+}
+
+export async function POST() {
+  try {
+    await requireStaff();
+    invalidateRecruitingStats();
+    const stats = await getRecruitingStats({ fresh: true });
+    return NextResponse.json(stats, { headers: { "Cache-Control": "private, no-store" } });
+  } catch (error) {
+    return handleError(error, "Failed to refresh admin stats");
+  }
+}
+
+function handleError(error: unknown, message: string) {
+  if (error instanceof Error && error.message === "Unauthorized") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (error instanceof Error && error.message.includes("Forbidden")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  logger.error({ err: error }, message);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -106,6 +106,7 @@ export async function POST(request: Request) {
           phoneNumber: null,
           email: user.email || "NA",
           isMember: false,
+          createdAt: new Date(),
         };
 
         // write the new user to firestore

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { checkStatsToken } from "@/lib/auth/statsToken";
+import { getRecruitingStats, toPublicStats } from "@/lib/firebase/stats";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/stats
+ *
+ * Read-only aggregate recruiting numbers for the recruiting bot. Token-gated
+ * (Authorization: Bearer STATS_API_TOKEN), never a user session, and the
+ * response shape contains only counts — see toPublicStats().
+ */
+export async function GET(request: Request) {
+  const auth = checkStatsToken(request);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  try {
+    const stats = await getRecruitingStats();
+    return NextResponse.json(toPublicStats(stats), {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    logger.error({ err: error }, "Failed to compute public stats");
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,6 +24,7 @@ type AdminNavItem = { href: string; label: string; restrictTo?: UserRole[] };
 const ADMIN_NAV: AdminNavItem[] = [
   { href: '/admin/dashboard', label: 'Admin' },
   { href: '/admin/applications', label: 'Applicants' },
+  { href: '/admin/stats', label: 'Stats' },
   { href: '/admin/users', label: 'Users', restrictTo: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB] },
   { href: '/admin/configuration', label: 'Configuration' },
   { href: '/admin/settings', label: 'Settings', restrictTo: [UserRole.ADMIN] },

--- a/hooks/useStats.ts
+++ b/hooks/useStats.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import { authFetcher } from "@/lib/auth/fetcher";
+import type { RecruitingStats } from "@/lib/firebase/stats";
+
+/**
+ * Aggregate recruiting stats for /admin/stats. Server-cached for 5 minutes;
+ * refresh() forces a recompute.
+ */
+export function useStats() {
+  const { data, error, isLoading, mutate } = useSWR<RecruitingStats>("/api/admin/stats", authFetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+  });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const res = await fetch("/api/admin/stats", { method: "POST" });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || "Refresh failed");
+      const fresh = (await res.json()) as RecruitingStats;
+      await mutate(fresh, { revalidate: false });
+    } finally {
+      setRefreshing(false);
+    }
+  }, [mutate]);
+
+  return { stats: data ?? null, error, isLoading, refreshing, refresh };
+}

--- a/lib/auth/statsToken.ts
+++ b/lib/auth/statsToken.ts
@@ -1,0 +1,23 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * Bearer-token check for the read-only stats endpoints.
+ *
+ * This is deliberately not a user session: the recruiting bot holds this
+ * token and nothing else, so the most it can ever do is read aggregate
+ * numbers. Rotate STATS_API_TOKEN in Vercel to cut it off.
+ */
+export function checkStatsToken(request: Request): { ok: true } | { ok: false; status: number; error: string } {
+  const expected = process.env.STATS_API_TOKEN;
+  if (!expected) return { ok: false, status: 503, error: "STATS_API_TOKEN is not configured" };
+
+  const header = request.headers.get("authorization") || "";
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) return { ok: false, status: 401, error: "Unauthorized" };
+
+  // Hash both sides so the comparison is constant-time regardless of length.
+  const a = createHash("sha256").update(match[1]).digest();
+  const b = createHash("sha256").update(expected).digest();
+  if (!timingSafeEqual(a, b)) return { ok: false, status: 401, error: "Unauthorized" };
+  return { ok: true };
+}

--- a/lib/firebase/stats.ts
+++ b/lib/firebase/stats.ts
@@ -1,0 +1,373 @@
+import { adminDb } from "./admin";
+import { getRecruitingConfig } from "./config";
+import { Team, UserRole } from "@/lib/models/User";
+import { ApplicationStatus } from "@/lib/models/Application";
+import { RecruitingStep } from "@/lib/models/Config";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
+
+/**
+ * Aggregate recruiting statistics.
+ *
+ * Everything here is a count. No document in the response carries a name, an
+ * email, a uid, or free text — the stats page is meant to be safe to
+ * screenshot into Slack, and /api/stats hands a further-reduced subset to the
+ * recruiting bot. Keep it that way: add numbers, never records.
+ *
+ * History is derived from timestamps already on the data (createdAt,
+ * submittedAt, user createdAt) rather than stored snapshots, so there is no
+ * cron to keep alive. One consequence: an application that is submitted and
+ * later reopened drops out of the "submitted" history entirely.
+ */
+
+export const STATS_BUCKET_MINUTES = 15;
+const STATS_TTL_MS = 5 * 60 * 1000;
+const SERIES_MAX_DAYS = 90;
+const DEMOGRAPHIC_TOP_N = 15;
+
+export const STATS_TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
+const STATUSES = Object.values(ApplicationStatus) as ApplicationStatus[];
+
+export type TeamCounts = Record<Team, number>;
+export type StatusCounts = Record<ApplicationStatus, number>;
+
+const zeroTeams = (): TeamCounts => ({ [Team.ELECTRIC]: 0, [Team.SOLAR]: 0, [Team.COMBUSTION]: 0 });
+const zeroStatuses = (): StatusCounts =>
+  Object.fromEntries(STATUSES.map((s) => [s, 0])) as StatusCounts;
+
+export interface StatsSeriesPoint {
+  /** Bucket start, ISO. Buckets with nothing in them are omitted. */
+  t: string;
+  created: TeamCounts;
+  submitted: TeamCounts;
+  accounts: number;
+}
+
+export interface SystemDemand {
+  system: string;
+  /** Applications ranking this system anywhere. */
+  any: number;
+  rank1: number;
+  rank2: number;
+  rank3: number;
+  /** Submitted applications ranking it anywhere. */
+  submitted: number;
+  rejectedBy: number;
+  interviewOffers: number;
+  trialOffers: number;
+}
+
+export interface RecruitingStats {
+  generatedAt: string;
+  step: RecruitingStep;
+  accounts: { applicants: number; staff: number; applicantsWithCreatedAt: number };
+  applications: {
+    total: number;
+    /** Ever submitted (anything past in_progress) — does not shrink as applicants advance. */
+    submitted: number;
+    byStatus: StatusCounts;
+    byTeam: Record<Team, { total: number; submitted: number; byStatus: StatusCounts }>;
+  };
+  velocity: {
+    createdLastHour: number;
+    createdLast24h: number;
+    submittedLastHour: number;
+    submittedLast24h: number;
+    accountsLastHour: number;
+    accountsLast24h: number;
+  };
+  systems: Record<Team, SystemDemand[]>;
+  crossTeam: {
+    /** Distinct applicants with at least one application. */
+    applicants: number;
+    byTeamCount: { 1: number; 2: number; 3: number };
+    combos: { teams: Team[]; count: number }[];
+  };
+  uploads: { submitted: number; resume: number; portfolio: number };
+  demographics: {
+    major: { value: string; count: number }[];
+    graduationYear: { value: string; count: number }[];
+  };
+  series: { bucketMinutes: number; from: string; to: string; points: StatsSeriesPoint[] };
+}
+
+/** The subset handed to the recruiting bot. Numbers only, no free text. */
+export interface PublicRecruitingStats {
+  generatedAt: string;
+  step: RecruitingStep;
+  applicantAccounts: number;
+  applications: {
+    total: number;
+    /** Ever submitted — the "how many applications have been submitted" number. */
+    submitted: number;
+    byStatus: StatusCounts;
+    byTeam: Record<Team, { total: number; submitted: number; inProgress: number }>;
+  };
+  velocity: RecruitingStats["velocity"];
+  systems: Record<Team, { system: string; any: number; rank1: number; submitted: number }[]>;
+  crossTeam: RecruitingStats["crossTeam"]["byTeamCount"];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toMs = (t: any): number | null => {
+  if (!t) return null;
+  if (typeof t.toMillis === "function") return t.toMillis();
+  if (t instanceof Date) return t.getTime();
+  if (typeof t._seconds === "number") return t._seconds * 1000;
+  return null;
+};
+
+const isTeam = (t: unknown): t is Team => STATS_TEAMS.includes(t as Team);
+
+const normalizeText = (v: unknown): string | null => {
+  if (typeof v !== "string") return null;
+  const s = v.replace(/\s+/g, " ").trim();
+  return s.length ? s : null;
+};
+
+/**
+ * Free-text tally that folds case ("ECE" / "ece" / "Ece" are one row) and
+ * displays whichever spelling was used most.
+ */
+class TextTally {
+  private buckets = new Map<string, { count: number; spellings: Map<string, number> }>();
+  add(raw: unknown) {
+    const s = normalizeText(raw);
+    if (!s) return;
+    const key = s.toLowerCase();
+    let b = this.buckets.get(key);
+    if (!b) { b = { count: 0, spellings: new Map() }; this.buckets.set(key, b); }
+    b.count++;
+    b.spellings.set(s, (b.spellings.get(s) || 0) + 1);
+  }
+  top(n: number): { value: string; count: number }[] {
+    const rows = [...this.buckets.values()].map((b) => ({
+      value: [...b.spellings.entries()].sort((a, c) => c[1] - a[1])[0][0],
+      count: b.count,
+    }));
+    rows.sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+    const head = rows.slice(0, n);
+    const rest = rows.slice(n).reduce((acc, r) => acc + r.count, 0);
+    if (rest > 0) head.push({ value: "Other", count: rest });
+    return head;
+  }
+}
+
+export async function computeRecruitingStats(): Promise<RecruitingStats> {
+  const now = Date.now();
+  const [config, appsSnap, usersSnap] = await Promise.all([
+    getRecruitingConfig(),
+    adminDb
+      .collection("applications")
+      .select(
+        "team", "status", "preferredSystems", "createdAt", "submittedAt", "isFakeData", "userId",
+        "rejectedBySystems", "interviewOffers", "trialOffers",
+        "formData.major", "formData.graduationYear", "formData.resumeUrl", "formData.portfolioUrl"
+      )
+      .get(),
+    adminDb.collection("users").select("role", "createdAt").get(),
+  ]);
+
+  // ---- accounts ----
+  let applicants = 0, staff = 0, applicantsWithCreatedAt = 0;
+  const accountTimes: number[] = [];
+  for (const d of usersSnap.docs) {
+    const u = d.data();
+    if (u.role === UserRole.APPLICANT) {
+      applicants++;
+      const ms = toMs(u.createdAt);
+      if (ms !== null) { applicantsWithCreatedAt++; accountTimes.push(ms); }
+    } else {
+      staff++;
+    }
+  }
+
+  // ---- applications ----
+  const byStatus = zeroStatuses();
+  const byTeam = Object.fromEntries(
+    STATS_TEAMS.map((t) => [t, { total: 0, submitted: 0, byStatus: zeroStatuses() }])
+  ) as RecruitingStats["applications"]["byTeam"];
+  let submittedEver = 0;
+  const systems = Object.fromEntries(
+    STATS_TEAMS.map((t) => [t, new Map<string, SystemDemand>()])
+  ) as Record<Team, Map<string, SystemDemand>>;
+  for (const t of STATS_TEAMS) {
+    for (const s of TEAM_SYSTEMS[t]) {
+      systems[t].set(s.value, { system: s.value, any: 0, rank1: 0, rank2: 0, rank3: 0, submitted: 0, rejectedBy: 0, interviewOffers: 0, trialOffers: 0 });
+    }
+  }
+  const demand = (team: Team, system: string): SystemDemand => {
+    let d = systems[team].get(system);
+    if (!d) { d = { system, any: 0, rank1: 0, rank2: 0, rank3: 0, submitted: 0, rejectedBy: 0, interviewOffers: 0, trialOffers: 0 }; systems[team].set(system, d); }
+    return d;
+  };
+
+  const teamsByUser = new Map<string, Set<Team>>();
+  const majors = new TextTally();
+  const gradYears = new TextTally();
+  const uploads = { submitted: 0, resume: 0, portfolio: 0 };
+  const velocity = { createdLastHour: 0, createdLast24h: 0, submittedLastHour: 0, submittedLast24h: 0, accountsLastHour: 0, accountsLast24h: 0 };
+  const createdEvents: { ms: number; team: Team }[] = [];
+  const submittedEvents: { ms: number; team: Team }[] = [];
+  let total = 0;
+
+  const HOUR = 3600e3, DAY = 24 * HOUR;
+
+  for (const d of appsSnap.docs) {
+    const a = d.data();
+    if (a.isFakeData) continue;
+    if (!isTeam(a.team)) continue;
+    const team = a.team;
+    const status = (STATUSES.includes(a.status) ? a.status : ApplicationStatus.IN_PROGRESS) as ApplicationStatus;
+    const submitted = status !== ApplicationStatus.IN_PROGRESS; // anything past in_progress was submitted at some point
+
+    total++;
+    byStatus[status]++;
+    byTeam[team].total++;
+    byTeam[team].byStatus[status]++;
+    if (submitted) { submittedEver++; byTeam[team].submitted++; }
+
+    const createdMs = toMs(a.createdAt);
+    if (createdMs !== null) {
+      createdEvents.push({ ms: createdMs, team });
+      if (now - createdMs < HOUR) velocity.createdLastHour++;
+      if (now - createdMs < DAY) velocity.createdLast24h++;
+    }
+    const submittedMs = submitted ? toMs(a.submittedAt) : null;
+    if (submittedMs !== null) {
+      submittedEvents.push({ ms: submittedMs, team });
+      if (now - submittedMs < HOUR) velocity.submittedLastHour++;
+      if (now - submittedMs < DAY) velocity.submittedLast24h++;
+    }
+
+    const ranked: string[] = Array.isArray(a.preferredSystems) ? a.preferredSystems.filter((s: unknown) => typeof s === "string") : [];
+    ranked.forEach((sys, i) => {
+      const dm = demand(team, sys);
+      dm.any++;
+      if (i === 0) dm.rank1++; else if (i === 1) dm.rank2++; else if (i === 2) dm.rank3++;
+      if (submitted) dm.submitted++;
+    });
+    for (const sys of (Array.isArray(a.rejectedBySystems) ? a.rejectedBySystems : [])) {
+      if (typeof sys === "string") demand(team, sys).rejectedBy++;
+    }
+    for (const o of (Array.isArray(a.interviewOffers) ? a.interviewOffers : [])) {
+      if (o && typeof o.system === "string") demand(team, o.system).interviewOffers++;
+    }
+    for (const o of (Array.isArray(a.trialOffers) ? a.trialOffers : [])) {
+      if (o && typeof o.system === "string") demand(team, o.system).trialOffers++;
+    }
+
+    if (typeof a.userId === "string") {
+      if (!teamsByUser.has(a.userId)) teamsByUser.set(a.userId, new Set());
+      teamsByUser.get(a.userId)!.add(team);
+    }
+
+    if (submitted) {
+      uploads.submitted++;
+      const fd = a.formData || {};
+      if (normalizeText(fd.resumeUrl)) uploads.resume++;
+      if (normalizeText(fd.portfolioUrl)) uploads.portfolio++;
+      majors.add(fd.major);
+      gradYears.add(fd.graduationYear);
+    }
+  }
+
+  for (const ms of accountTimes) {
+    if (now - ms < HOUR) velocity.accountsLastHour++;
+    if (now - ms < DAY) velocity.accountsLast24h++;
+  }
+
+  // ---- cross-team ----
+  const byTeamCount = { 1: 0, 2: 0, 3: 0 };
+  const combos = new Map<string, number>();
+  for (const teams of teamsByUser.values()) {
+    const n = Math.min(3, teams.size) as 1 | 2 | 3;
+    byTeamCount[n]++;
+    if (teams.size > 1) {
+      const key = STATS_TEAMS.filter((t) => teams.has(t)).join("+");
+      combos.set(key, (combos.get(key) || 0) + 1);
+    }
+  }
+
+  // ---- time series (sparse 15-minute buckets) ----
+  const allTimes = [...createdEvents.map((e) => e.ms), ...submittedEvents.map((e) => e.ms), ...accountTimes];
+  const bucketMs = STATS_BUCKET_MINUTES * 60e3;
+  const earliest = allTimes.length ? Math.min(...allTimes) : now;
+  const from = Math.max(earliest, now - SERIES_MAX_DAYS * DAY);
+  const fromBucket = Math.floor(from / bucketMs) * bucketMs;
+  const buckets = new Map<number, StatsSeriesPoint>();
+  const bucketFor = (ms: number): StatsSeriesPoint => {
+    const start = Math.max(fromBucket, Math.floor(ms / bucketMs) * bucketMs); // anything older folds into the first bucket
+    let p = buckets.get(start);
+    if (!p) { p = { t: new Date(start).toISOString(), created: zeroTeams(), submitted: zeroTeams(), accounts: 0 }; buckets.set(start, p); }
+    return p;
+  };
+  for (const e of createdEvents) bucketFor(e.ms).created[e.team]++;
+  for (const e of submittedEvents) bucketFor(e.ms).submitted[e.team]++;
+  for (const ms of accountTimes) bucketFor(ms).accounts++;
+  const points = [...buckets.entries()].sort((a, b) => a[0] - b[0]).map(([, p]) => p);
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    step: config.currentStep,
+    accounts: { applicants, staff, applicantsWithCreatedAt },
+    applications: { total, submitted: submittedEver, byStatus, byTeam },
+    velocity,
+    systems: Object.fromEntries(
+      STATS_TEAMS.map((t) => [t, [...systems[t].values()].sort((a, b) => b.any - a.any || a.system.localeCompare(b.system))])
+    ) as Record<Team, SystemDemand[]>,
+    crossTeam: {
+      applicants: teamsByUser.size,
+      byTeamCount,
+      combos: [...combos.entries()]
+        .map(([key, count]) => ({ teams: key.split("+") as Team[], count }))
+        .sort((a, b) => b.count - a.count),
+    },
+    uploads,
+    demographics: { major: majors.top(DEMOGRAPHIC_TOP_N), graduationYear: gradYears.top(DEMOGRAPHIC_TOP_N) },
+    series: { bucketMinutes: STATS_BUCKET_MINUTES, from: new Date(fromBucket).toISOString(), to: new Date(now).toISOString(), points },
+  };
+}
+
+// Module-level cache: the computation reads every application once, which is
+// cheap but not free. Five minutes matches how often anyone needs these numbers.
+let cached: { stats: RecruitingStats; at: number } | null = null;
+let inflight: Promise<RecruitingStats> | null = null;
+
+export async function getRecruitingStats(opts: { fresh?: boolean } = {}): Promise<RecruitingStats> {
+  if (!opts.fresh && cached && Date.now() - cached.at < STATS_TTL_MS) return cached.stats;
+  if (!inflight) {
+    inflight = computeRecruitingStats()
+      .then((stats) => { cached = { stats, at: Date.now() }; return stats; })
+      .finally(() => { inflight = null; });
+  }
+  return inflight;
+}
+
+export function invalidateRecruitingStats(): void {
+  cached = null;
+}
+
+export function toPublicStats(s: RecruitingStats): PublicRecruitingStats {
+  return {
+    generatedAt: s.generatedAt,
+    step: s.step,
+    applicantAccounts: s.accounts.applicants,
+    applications: {
+      total: s.applications.total,
+      submitted: s.applications.submitted,
+      byStatus: s.applications.byStatus,
+      byTeam: Object.fromEntries(
+        STATS_TEAMS.map((t) => [t, {
+          total: s.applications.byTeam[t].total,
+          submitted: s.applications.byTeam[t].submitted,
+          inProgress: s.applications.byTeam[t].byStatus[ApplicationStatus.IN_PROGRESS],
+        }])
+      ) as PublicRecruitingStats["applications"]["byTeam"],
+    },
+    velocity: s.velocity,
+    systems: Object.fromEntries(
+      STATS_TEAMS.map((t) => [t, s.systems[t].map((d) => ({ system: d.system, any: d.any, rank1: d.rank1, submitted: d.submitted }))])
+    ) as PublicRecruitingStats["systems"],
+    crossTeam: s.crossTeam.byTeamCount,
+  };
+}

--- a/lib/models/User.ts
+++ b/lib/models/User.ts
@@ -62,5 +62,7 @@ export interface User {
   phoneNumber: string | null;
   isMember: boolean;
   memberProfile?: Member;
+  /** Set on first sign-in. Older accounts were backfilled from Firebase Auth creation time. */
+  createdAt?: Date;
 }
 

--- a/scripts/qa/stats-regress.mjs
+++ b/scripts/qa/stats-regress.mjs
@@ -1,0 +1,107 @@
+// Stats feature checks against the emulators: token gate, PII-free shape,
+// staff gate, numbers match seeded data.
+//
+// Run against the emulator suite with the dev server started with
+// STATS_API_TOKEN=test-stats-token (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/stats-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile, createdAt }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}), ...(createdAt ? { createdAt } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(method, path, { cookie, token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (cookie) headers.cookie = cookie; if (token) headers.authorization = `Bearer ${token}`;
+  const r = await fetch(BASE + path, { method, headers, body: body ? JSON.stringify(body) : undefined });
+  const text = await r.text(); let json = null; try { json = JSON.parse(text); } catch {}
+  return { status: r.status, json, text };
+}
+const ago = (h) => new Date(Date.now() - h * 3600e3);
+
+// ---- seed a known dataset ----
+await db.doc("applications/st-7").delete(); // left over from a previous run
+await ensureUser({ uid: "s-lead", email: "lead.stats@utexas.edu", name: "Stats Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+for (let i = 0; i < 6; i++) await ensureUser({ uid: `s-app-${i}`, email: `stats${i}@utexas.edu`, name: `Person ${i} Secretname`, role: "applicant", createdAt: ago(30 - i * 5) });
+await ensureUser({ uid: "s-app-old", email: "old@utexas.edu", name: "No CreatedAt", role: "applicant" }); // no createdAt
+const A = (id, team, userId, status, ranked, createdH, submittedH, { formData = {}, ...extra } = {}) =>
+  db.doc(`applications/${id}`).set({ team, userId, userEmail: `${userId}@utexas.edu`, userName: "Hidden Applicant", status, preferredSystems: ranked, createdAt: ago(createdH), ...(submittedH !== null ? { submittedAt: ago(submittedH) } : {}), formData: { major: "  Mechanical   Engineering ", graduationYear: "2028", resumeUrl: "https://x/r.pdf", ...formData }, ...extra });
+await A("st-1", "Electric", "s-app-0", "submitted", ["Body", "Dynamics"], 30, 28);
+await A("st-2", "Electric", "s-app-1", "submitted", ["Dynamics", "Body", "Powertrain"], 26, 20, { formData: { portfolioUrl: "https://x/p.pdf", major: "mechanical engineering" } });
+await A("st-3", "Electric", "s-app-2", "in_progress", ["Body"], 10, null);
+await A("st-4", "Solar", "s-app-0", "submitted", ["Powertrain"], 25, 0.5, { formData: { major: "ECE", graduationYear: "2027" } }); // s-app-0 applied to 2 teams; submitted in last hour
+await A("st-5", "Combustion", "s-app-3", "in_progress", ["Aerodynamics", "Body"], 0.5, null);
+await A("st-6", "Combustion", "s-app-4", "rejected", ["Aerodynamics"], 40, 39, { rejectedBySystems: ["Aerodynamics"], reviewDecision: "rejected" });
+await A("st-fake", "Electric", "s-app-5", "submitted", ["Body"], 5, 4, { isFakeData: true }); // must be excluded
+
+const adminC = await session("admin@utexas.edu"), leadC = await session("lead.stats@utexas.edu"), appC = await session("stats0@utexas.edu");
+await api("POST", "/api/admin/stats", { cookie: adminC }); // drop any cache from a previous run
+
+// ---- /api/stats token gate ----
+let r = await api("GET", "/api/stats");
+check("bot API without token -> 401", r.status === 401, `${r.status}`);
+r = await api("GET", "/api/stats", { token: "wrong" });
+check("bot API with wrong token -> 401", r.status === 401, `${r.status}`);
+r = await api("GET", "/api/stats", { cookie: adminC });
+check("bot API with a staff session but no token -> 401 (sessions don't count)", r.status === 401, `${r.status}`);
+r = await api("GET", "/api/stats", { token: "test-stats-token" });
+check("bot API with token -> 200", r.status === 200, `${r.status}`);
+const pub = r.json;
+check("bot API: no PII anywhere in the payload", !/utexas|Secretname|Hidden|s-app-|@/.test(r.text) && !/email|name|userId|uid/i.test(Object.keys(JSON.stringify(pub)).join("")), r.text.slice(0, 120));
+check("bot API: counts exclude fake data", pub?.applications?.total === 6 && pub.applications.byStatus.submitted === 3, JSON.stringify(pub?.applications?.byStatus));
+check("bot API: per-team submitted is ever-submitted (rejected Combustion app counts)", pub?.applications?.byTeam?.Electric?.submitted === 2 && pub.applications.byTeam.Solar.submitted === 1 && pub.applications.byTeam.Combustion.submitted === 1 && pub.applications.submitted === 4, JSON.stringify(pub?.applications?.byTeam));
+check("bot API: applicant accounts counted, staff not", pub?.applicantAccounts === 8, `${pub?.applicantAccounts}`); // seed applicant + 6 + old
+check("bot API: velocity last hour (1 created, 1 submitted)", pub?.velocity?.createdLastHour === 1 && pub.velocity.submittedLastHour === 1, JSON.stringify(pub?.velocity));
+check("bot API: system demand rank1 (Electric Body = 2, Dynamics = 1, Body any = 3)", pub?.systems?.Electric?.find((s) => s.system === "Body")?.rank1 === 2 && pub.systems.Electric.find((s) => s.system === "Dynamics")?.rank1 === 1 && pub.systems.Electric.find((s) => s.system === "Body")?.any === 3, JSON.stringify(pub?.systems?.Electric?.slice(0, 3)));
+check("bot API: cross-team counts (1 applicant on 2 teams)", pub?.crossTeam?.[2] === 1 && pub.crossTeam[1] === 4, JSON.stringify(pub?.crossTeam));
+check("bot API: no demographics or series in the reduced copy", pub && !("demographics" in pub) && !("series" in pub));
+
+// ---- /api/admin/stats gate + full payload ----
+r = await api("GET", "/api/admin/stats", { cookie: appC });
+check("admin stats as applicant -> 403", r.status === 403, `${r.status}`);
+r = await api("GET", "/api/admin/stats");
+check("admin stats unauthenticated -> 401", r.status === 401, `${r.status}`);
+r = await api("GET", "/api/admin/stats", { cookie: leadC });
+check("admin stats as system lead -> 200 (all staff)", r.status === 200, `${r.status}`);
+const full = r.json;
+check("full stats: no PII either", !/utexas|Secretname|Hidden|s-app-|@/.test(r.text));
+check("full stats: majors whitespace-normalised and case-folded (3 spellings -> one row, most common spelling shown)", full?.demographics?.major?.length === 2 && full.demographics.major[0].value === "Mechanical Engineering" && full.demographics.major[0].count === 3 && full.demographics.major[1].value === "ECE", JSON.stringify(full?.demographics?.major));
+check("full stats: graduation years", full?.demographics?.graduationYear?.find((g) => g.value === "2028")?.count === 3 && full.demographics.graduationYear.find((g) => g.value === "2027")?.count === 1, JSON.stringify(full?.demographics?.graduationYear));
+check("full stats: uploads among ever-submitted (4 resumes, 1 portfolio of 4)", full?.uploads?.submitted === 4 && full.uploads.resume === 4 && full.uploads.portfolio === 1, JSON.stringify(full?.uploads));
+check("full stats: rejectedBy surfaces in system demand", full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")?.rejectedBy === 1, JSON.stringify(full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")));
+check("full stats: cross-team combo Electric+Solar = 1", full?.crossTeam?.combos?.[0]?.teams?.join("+") === "Electric+Solar" && full.crossTeam.combos[0].count === 1, JSON.stringify(full?.crossTeam?.combos));
+const pts = full?.series?.points || [];
+const sum = (k, team) => pts.reduce((a, p) => a + (team ? p[k][team] : Object.values(p[k]).reduce((x, y) => x + y, 0)), 0);
+check("full stats: series totals reconcile (created 6, submitted 3+1 rejected-was-submitted, accounts 6 w/ createdAt)", sum("created") === 6 && sum("submitted") === 4 && pts.reduce((a, p) => a + p.accounts, 0) === 6, `created=${sum("created")} submitted=${sum("submitted")} accounts=${pts.reduce((a, p) => a + p.accounts, 0)}`);
+check("full stats: series is sparse (fewer points than 15-min buckets over 40h)", pts.length > 0 && pts.length < 40 * 4, `${pts.length} points`);
+check("full stats: accounts createdAt coverage reported (6 of 8)", full?.accounts?.applicantsWithCreatedAt === 6 && full.accounts.applicants === 8, JSON.stringify(full?.accounts));
+
+// ---- cache + refresh ----
+await A("st-7", "Solar", "s-app-5", "submitted", ["TrackSim"], 1, 0.2);
+r = await api("GET", "/api/admin/stats", { cookie: adminC });
+check("cached: new app not visible yet on GET", r.json?.applications?.total === 6, `${r.json?.applications?.total}`);
+r = await api("POST", "/api/admin/stats", { cookie: adminC });
+check("POST recompute -> 200 and sees the new app", r.status === 200 && r.json?.applications?.total === 7, `${r.status} ${r.json?.applications?.total}`);
+r = await api("POST", "/api/admin/stats", { cookie: appC });
+check("POST recompute as applicant -> 403", r.status === 403, `${r.status}`);
+
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Replaces the "have a bot log into the admin console every hour" workflow with two things:

**`/admin/stats` (all staff).** Aggregate numbers and trends: applicant accounts, applications started / submitted / submit rate, velocity (last hour / 24h), an over-time chart (submitted · started · accounts × cumulative / per-bucket × 15m / 1h / day × 24h / 7d / all × total / by team), pipeline by team and status, system demand by rank position (1st/2nd/3rd/any, plus rejected-by / interview / trial counts as review progresses), cross-team applicants and combos, upload rates, and major / graduation-year distributions. Every table exports CSV. Nothing on the page identifies an applicant — it is safe to screenshot into Slack. Works in both themes.

**`GET /api/stats` (the bot).** A reduced copy of the same numbers, gated by `Authorization: Bearer STATS_API_TOKEN` — a dedicated secret, never a user session, so the bot holds no staff login and can only ever read counts. The response is a fixed allowlist of numbers; there is no code path that returns a name, email or uid.

**How it's computed.** `lib/firebase/stats.ts` does one projected read of `applications` and `users` and derives history from the timestamps already on the data (`createdAt`, `submittedAt`, user `createdAt`) — no stored snapshots, no cron. Cached 5 minutes; the page has a Recompute button. "Submitted" means ever-submitted everywhere (tiles, chart, API), so it does not shrink as applicants advance; the pipeline table shows the current status breakdown.

**User `createdAt`.** New user docs now record it; existing ones were backfilled from Firebase Auth creation time (913 users) so the accounts trend line has history.

**Tests.** `scripts/qa/stats-regress.mjs` (committed): token gate (no token / wrong token / staff session without token all 401), PII-free payload, staff-only admin route, fake-data exclusion, per-team and per-rank counts, velocity, cross-team, demographics case-folding, uploads, series reconciliation, cache + recompute — 27 checks. `npm run build` clean; page verified in Chrome in dark and light mode.

**Setup after merge.** Add `STATS_API_TOKEN` to Vercel env (value handed over separately) and give the same value to computa with the instruction to call `GET https://lhrrecruiting.org/api/stats` instead of browsing the site.