### PR TITLE
fix: convert user timestamps before client serialization

### DIFF
--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -4,6 +4,7 @@ import { UserRole } from "@/lib/models/User";
 import { getApplication } from "@/lib/firebase/applications";
 import { Application } from "@/lib/models/Application";
 import { redirect } from "next/navigation";
+import { toUser } from "@/lib/firebase/users";
 
 // Error message that indicates the Firebase user record was deleted
 const USER_NOT_FOUND_ERROR = "no user record";
@@ -25,7 +26,7 @@ export async function requireAdmin() {
       throw new Error("User not found");
     }
 
-    const userData = userDoc.data();
+    const userData = userDoc.exists ? toUser(userDoc.data()!) : undefined;
     if (userData?.role !== UserRole.ADMIN) {
       throw new Error("Forbidden: Admin access required");
     }
@@ -65,7 +66,7 @@ export async function requireStaff() {
       throw new Error("User not found");
     }
 
-    const userData = userDoc.data();
+    const userData = userDoc.exists ? toUser(userDoc.data()!) : undefined;
     const allowedRoles = [
       UserRole.ADMIN,
       UserRole.TEAM_CAPTAIN_OB,

--- a/lib/firebase/users.ts
+++ b/lib/firebase/users.ts
@@ -4,6 +4,21 @@ import { User } from "@/lib/models/User";
 const USERS_COLLECTION = "users";
 
 /**
+ * Firestore doc -> User. Converts Timestamp fields to Dates: server components
+ * hand User objects straight to client components, and React can serialize a
+ * Date across that boundary but not a Firestore Timestamp (class instance).
+ * Adding `createdAt` to user docs without this took down every page that
+ * passed the user through.
+ */
+export function toUser(data: FirebaseFirestore.DocumentData): User {
+  const { createdAt, ...rest } = data;
+  const user = rest as User;
+  if (createdAt && typeof createdAt.toDate === "function") user.createdAt = createdAt.toDate();
+  else if (createdAt instanceof Date) user.createdAt = createdAt;
+  return user;
+}
+
+/**
  * Get a user by their UID
  */
 export async function getUser(uid: string): Promise<User | null> {
@@ -13,11 +28,7 @@ export async function getUser(uid: string): Promise<User | null> {
     return null;
   }
 
-  // Cast existing data to User interface
-  // Note: Firestore timestamps might need conversion if User has Date fields
-  // Currently User model mostly has strings/enums, so raw matching should work
-  // or we can add safety checks if needed.
-  return doc.data() as User;
+  return toUser(doc.data()!);
 }
 
 /**
@@ -32,7 +43,7 @@ export async function updateUser(uid: string, data: Partial<User>): Promise<void
  */
 export async function getAllUsers(): Promise<User[]> {
   const snapshot = await adminDb.collection(USERS_COLLECTION).get();
-  return snapshot.docs.map((doc) => doc.data() as User);
+  return snapshot.docs.map((doc) => toUser(doc.data()));
 }
 
 /**
@@ -45,6 +56,6 @@ export async function getSystemLeads(team: string, system: string): Promise<User
     .where("memberProfile.system", "==", system)
     .get();
 
-  return snapshot.docs.map((doc) => doc.data() as User);
+  return snapshot.docs.map((doc) => toUser(doc.data()));
 }
 


### PR DESCRIPTION
Hotfix. #93 added `createdAt` to user docs (and backfilled it). `requireStaff`/`getUser` returned the raw Firestore doc, so that field arrived as a `Timestamp` class instance, which React cannot serialize into a client component — `/admin/configuration` passes the user into `ConfigurationTabs` and started 500ing. `toUser()` now converts Timestamps to Dates at every user-doc read (guard + users.ts).