### PR TITLE
fix: guard user typing after timestamp conversion

### DIFF
--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -26,8 +26,8 @@ export async function requireAdmin() {
       throw new Error("User not found");
     }
 
-    const userData = userDoc.exists ? toUser(userDoc.data()!) : undefined;
-    if (userData?.role !== UserRole.ADMIN) {
+    const userData = toUser(userDoc.data()!);
+    if (userData.role !== UserRole.ADMIN) {
       throw new Error("Forbidden: Admin access required");
     }
 
@@ -66,7 +66,7 @@ export async function requireStaff() {
       throw new Error("User not found");
     }
 
-    const userData = userDoc.exists ? toUser(userDoc.data()!) : undefined;
+    const userData = toUser(userDoc.data()!);
     const allowedRoles = [
       UserRole.ADMIN,
       UserRole.TEAM_CAPTAIN_OB,
@@ -74,7 +74,7 @@ export async function requireStaff() {
       UserRole.REVIEWER
     ];
 
-    if (!allowedRoles.includes(userData?.role)) {
+    if (!allowedRoles.includes(userData.role)) {
       throw new Error("Forbidden: Staff access required");
     }
 


### PR DESCRIPTION
Follow-up to #96, which failed type-check on deploy: `toUser()` made the guard's user strongly typed, so `allowedRoles.includes(userData?.role)` no longer compiled. Both guard sites already check `userDoc.exists`, so the user is non-optional. `npx tsc --noEmit` and `npm run build` verified with exit codes checked.