### PR TITLE
feat: single-team split on stats page

### DIFF
--- a/app/admin/stats/StatsView.tsx
+++ b/app/admin/stats/StatsView.tsx
@@ -463,6 +463,16 @@ export function StatsView() {
                     <div key={n} className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5">
                       <div className="text-[22px] font-bold text-white tabular-nums leading-none">{fmtInt(stats.crossTeam.byTeamCount[n])}</div>
                       <div className="text-[11px] text-white/50 mt-1">{n === 1 ? "one team" : `${n} teams`}</div>
+                      {n === 1 && (
+                        <div className="flex items-center gap-2.5 mt-2 text-[11px] text-white/60 tabular-nums">
+                          {TEAMS.map((t) => (
+                            <span key={t} className="inline-flex items-center gap-1" title={`Applied only to ${t}`}>
+                              <i className="inline-block w-2 h-2 rounded-sm" style={{ background: getTeamColor(t) }} />
+                              {fmtInt(stats.crossTeam.singleTeam[t])}
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/lib/firebase/stats.ts
+++ b/lib/firebase/stats.ts
@@ -80,6 +80,8 @@ export interface RecruitingStats {
     /** Distinct applicants with at least one application. */
     applicants: number;
     byTeamCount: { 1: number; 2: number; 3: number };
+    /** Of the single-team applicants, which team they picked. */
+    singleTeam: TeamCounts;
     combos: { teams: Team[]; count: number }[];
   };
   uploads: { submitted: number; resume: number; portfolio: number };
@@ -278,10 +280,12 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
 
   // ---- cross-team ----
   const byTeamCount = { 1: 0, 2: 0, 3: 0 };
+  const singleTeam = zeroTeams();
   const combos = new Map<string, number>();
   for (const teams of teamsByUser.values()) {
     const n = Math.min(3, teams.size) as 1 | 2 | 3;
     byTeamCount[n]++;
+    if (teams.size === 1) singleTeam[[...teams][0]]++;
     if (teams.size > 1) {
       const key = STATS_TEAMS.filter((t) => teams.has(t)).join("+");
       combos.set(key, (combos.get(key) || 0) + 1);
@@ -318,6 +322,7 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
     crossTeam: {
       applicants: teamsByUser.size,
       byTeamCount,
+      singleTeam,
       combos: [...combos.entries()]
         .map(([key, count]) => ({ teams: key.split("+") as Team[], count }))
         .sort((a, b) => b.count - a.count),

--- a/scripts/qa/stats-regress.mjs
+++ b/scripts/qa/stats-regress.mjs
@@ -86,6 +86,7 @@ check("full stats: majors whitespace-normalised and case-folded (3 spellings -> 
 check("full stats: graduation years", full?.demographics?.graduationYear?.find((g) => g.value === "2028")?.count === 3 && full.demographics.graduationYear.find((g) => g.value === "2027")?.count === 1, JSON.stringify(full?.demographics?.graduationYear));
 check("full stats: uploads among ever-submitted (4 resumes, 1 portfolio of 4)", full?.uploads?.submitted === 4 && full.uploads.resume === 4 && full.uploads.portfolio === 1, JSON.stringify(full?.uploads));
 check("full stats: rejectedBy surfaces in system demand", full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")?.rejectedBy === 1, JSON.stringify(full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")));
+check("full stats: single-team split (Electric 2, Solar 0, Combustion 2)", full?.crossTeam?.singleTeam?.Electric === 2 && full.crossTeam.singleTeam.Solar === 0 && full.crossTeam.singleTeam.Combustion === 2, JSON.stringify(full?.crossTeam?.singleTeam));
 check("full stats: cross-team combo Electric+Solar = 1", full?.crossTeam?.combos?.[0]?.teams?.join("+") === "Electric+Solar" && full.crossTeam.combos[0].count === 1, JSON.stringify(full?.crossTeam?.combos));
 const pts = full?.series?.points || [];
 const sum = (k, team) => pts.reduce((a, p) => a + (team ? p[k][team] : Object.values(p[k]).reduce((x, y) => x + y, 0)), 0);


### PR DESCRIPTION
Cross-team tile now shows, under the one-team count, how many applicants applied only to Electric / Solar / Combustion (exclusive split — the pipeline table's per-team totals include multi-team applicants). `crossTeam.singleTeam` added to the full stats payload; harness +1 check (28/28).