### PR TITLE
fix: status filter uses per-lead display status

### DIFF
--- a/app/admin/applications/_components/ApplicationsSidebar.tsx
+++ b/app/admin/applications/_components/ApplicationsSidebar.tsx
@@ -301,7 +301,10 @@ export default function ApplicationsSidebar() {
 
   const filteredApplications = applications.filter(app => {
     // Note: name/email search is now handled server-side
-    const matchesStatus = statusFilters.length === 0 || statusFilters.includes(app.status);
+    // Filter on the status the lead actually sees (their own system's
+    // rejection shows as Rejected even while the application is alive for
+    // other systems), otherwise the Rejected chip never matches those rows.
+    const matchesStatus = statusFilters.length === 0 || statusFilters.includes(getDisplayStatusForUser(app, currentUser));
     const appSystems = app.preferredSystems || [];
     const matchesSystem = systemFilters.length === 0 || appSystems.some(s => systemFilters.includes(s));
     const matchesTeam = teamFilters.length === 0 || teamFilters.includes(app.team);


### PR DESCRIPTION
The applicant list filtered on raw `app.status` while the badge showed `getDisplayStatusForUser` — for a system lead, an application their system rejected wears a Rejected badge (status is still `submitted` for the other ranked systems, per #92) but the Rejected chip never matched it and deselecting Rejected never hid it. Filter now uses the same display status as the badge.