### PR TITLE
fix: refuse staff actions on unsubmitted applications

### DIFF
--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -976,6 +976,14 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
 
           {/* Only show Advance/Reject buttons for non-reviewers */}
           {currentUser?.role !== UserRole.REVIEWER && (() => {
+            // Drafts get no buttons: every action on them is refused server-side.
+            if (selectedApp.status === ApplicationStatus.IN_PROGRESS) {
+              return (
+                <p className="font-urbanist text-[12px] text-white/40 rounded-lg px-3 py-2 border border-white/10 bg-white/5">
+                  Not submitted yet — review actions unlock once the applicant submits.
+                </p>
+              );
+            }
             const isDecisionMode = recruitingStep === RecruitingStep.RELEASE_TRIAL ||
               recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
               recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
-import { rejectApplicationFromSystems } from "@/lib/firebase/applications";
+import { getApplication, rejectApplicationFromSystems } from "@/lib/firebase/applications";
+import { ApplicationStatus } from "@/lib/models/Application";
+import { DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
 import { requireStaffForApplication } from "@/lib/auth/guard";
 import { UserRole, User } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
@@ -41,6 +43,15 @@ export async function POST(
       return NextResponse.json({
         error: "Reviewers are not authorized to reject applicants"
       }, { status: 403 });
+    }
+
+    // Drafts are not reviewable; see the status route for why this matters.
+    const application = await getApplication(id);
+    if (!application) {
+      return NextResponse.json({ error: "Application not found" }, { status: 404 });
+    }
+    if (application.status === ApplicationStatus.IN_PROGRESS) {
+      return NextResponse.json({ error: DRAFT_ACTION_ERROR }, { status: 400 });
     }
 
     const body = await request.json();

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -8,6 +8,7 @@ import { UserRole, User } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
 import { getRecruitingConfig } from "@/lib/firebase/config";
 import { getStageDecisionForStatus, isAtOrPast } from "@/lib/utils/statusUtils";
+import { DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
 import { sendStatusEmail } from "@/lib/email/send";
 import type { EmailTrigger } from "@/lib/models/EmailTemplate";
 import { appCache } from "@/lib/utils/appCache";
@@ -35,14 +36,18 @@ export async function POST(
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
 
-    // Prevent waitlisting/accepting/rejecting of applications that aren't submitted
-    if (status === ApplicationStatus.WAITLISTED || status === ApplicationStatus.ACCEPTED) {
+    // Nothing can be done with a draft. This used to guard only waitlist and
+    // accept; advancing an unsubmitted application to Interview moved its
+    // status past in_progress, which froze the applicant's own form ("Failed
+    // to save") and put an empty application in the interview queue. Staff
+    // moving a draft to Submitted is the one legitimate transition.
+    if (status !== ApplicationStatus.IN_PROGRESS && status !== ApplicationStatus.SUBMITTED) {
       const application = await getApplication(id);
       if (!application) {
         return NextResponse.json({ error: "Application not found" }, { status: 404 });
       }
       if (application.status === ApplicationStatus.IN_PROGRESS) {
-        return NextResponse.json({ error: "Cannot waitlist or accept an in-progress application" }, { status: 400 });
+        return NextResponse.json({ error: DRAFT_ACTION_ERROR }, { status: 400 });
       }
     }
 

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkTeamAccess } from "@/lib/auth/teamAccess";
+import { checkTeamAccess, DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
 import { Application, InterviewEventStatus } from "@/lib/models/Application";
 import { requireStaff } from "@/lib/auth/guard";
 import { getApplication, updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, rejectApplicationFromSystems } from "@/lib/firebase/applications";
@@ -148,6 +148,11 @@ export async function POST(request: NextRequest) {
           const accessError = checkTeamAccess(currentUser, application);
           if (accessError) {
             return { id: appId, success: false, error: accessError };
+          }
+
+          // Drafts are not reviewable; see the single-application status route.
+          if (application.status === ApplicationStatus.IN_PROGRESS && action !== "submitted") {
+            return { id: appId, success: false, error: DRAFT_ACTION_ERROR };
           }
 
           switch (action) {

--- a/lib/auth/teamAccess.ts
+++ b/lib/auth/teamAccess.ts
@@ -98,3 +98,10 @@ export function resolveScorecardSystem(
     }
     return { system: requested ?? application.preferredSystems?.[0] };
 }
+
+/**
+ * Refusal for any staff action on an unsubmitted application. Advancing a
+ * draft used to be possible and froze the applicant's own form.
+ */
+export const DRAFT_ACTION_ERROR =
+  "This applicant hasn't submitted their application yet. Nothing can be done with it until they do.";

--- a/scripts/qa/drafts-regress.mjs
+++ b/scripts/qa/drafts-regress.mjs
@@ -1,0 +1,97 @@
+// No staff action may touch an unsubmitted (in_progress) application:
+// single-application status route, reject route, and bulk route all refuse,
+// nothing is written, and the applicant's own form keeps working. Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/drafts-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const get = async (id) => (await db.doc(`applications/${id}`).get()).data();
+const untouched = (a) => a.status === "in_progress" && !(a.interviewOffers || []).length && !(a.trialOffers || []).length && !a.reviewDecision && !(a.rejectedBySystems || []).length;
+const S = (a) => `${a.status}/offers=${(a.interviewOffers || []).length}/rd=${a.reviewDecision ?? "-"}/rb=${(a.rejectedBySystems || []).join("+") || "-"}`;
+const isDraftErr = (r) => r.status === 400 && /hasn't submitted/i.test(r.json?.error || "");
+
+await ensureUser({ uid: "u-cap", email: "cap.e@utexas.edu", name: "Electric Captain", role: "team_captain_ob", memberProfile: { team: "Electric", system: "Electronics" } });
+await ensureUser({ uid: "u-body", email: "lead.body@utexas.edu", name: "Body Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+await ensureUser({ uid: "u-draft", email: "draft@utexas.edu", name: "Drafter", role: "applicant" });
+const adminC = await session("admin@utexas.edu"), capC = await session("cap.e@utexas.edu"), bodyC = await session("lead.body@utexas.edu"), appC = await session("draft@utexas.edu");
+const base = (status, extra = {}) => ({ userId: "u-draft", userEmail: "draft@utexas.edu", team: "Electric", preferredSystems: ["Body", "Dynamics"], status, formData: { whyJoin: "hi" }, createdAt: now(), updatedAt: now(), ...(status !== "in_progress" ? { submittedAt: now() } : {}), ...extra });
+await db.doc("applications/dr-1").set(base("in_progress"));
+await db.doc("applications/dr-2").set(base("in_progress"));
+await db.doc("applications/dr-sub").set(base("submitted"));
+await db.doc("applications/dr-sub2").set(base("submitted"));
+await db.doc("users/u-draft").set({ applications: ["dr-1", "dr-2", "dr-sub", "dr-sub2"] }, { merge: true });
+let r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing" }); check("step -> reviewing", r.status === 200);
+
+// ---- single-application status route ----
+for (const [who, c, body] of [["admin", adminC, { status: "interview" }], ["lead", bodyC, { status: "interview", systems: ["Body"] }], ["captain", capC, { status: "interview", systems: ["Body", "Dynamics"] }]]) {
+  r = await api(c, "POST", "/api/admin/applications/dr-1/status", body);
+  check(`${who} advancing a draft to interview -> 400 draft error`, isDraftErr(r), `${r.status} ${r.json?.error}`);
+}
+for (const status of ["trial", "rejected", "waitlisted", "accepted"]) {
+  r = await api(adminC, "POST", "/api/admin/applications/dr-1/status", { status, ...(status === "accepted" ? { offer: { system: "Body", role: "Member" } } : {}) });
+  check(`admin setting draft -> ${status} -> 400 draft error`, isDraftErr(r), `${r.status} ${r.json?.error}`);
+}
+check("draft untouched after all status attempts", untouched(await get("dr-1")), S(await get("dr-1")));
+
+// ---- reject route ----
+r = await api(bodyC, "POST", "/api/admin/applications/dr-1/reject", { systems: ["Body"] });
+check("lead rejecting a draft -> 400 draft error", isDraftErr(r), `${r.status} ${r.json?.error}`);
+r = await api(capC, "POST", "/api/admin/applications/dr-1/reject", { systems: ["Body", "Dynamics"] });
+check("captain rejecting a draft -> 400 draft error", isDraftErr(r), `${r.status} ${r.json?.error}`);
+check("draft untouched after reject attempts", untouched(await get("dr-1")), S(await get("dr-1")));
+
+// ---- bulk route: draft refused per item, submitted sibling still processed ----
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-1", "dr-sub"], action: "interview" });
+const item = (id) => (r.json?.results || []).find((x) => x.id === id);
+check("bulk interview: draft item refused with draft error", r.status === 200 && item("dr-1")?.success === false && /hasn't submitted/i.test(item("dr-1")?.error || ""), JSON.stringify(item("dr-1")));
+check("bulk interview: submitted item still advanced", item("dr-sub")?.success === true && (await get("dr-sub")).status === "interview", JSON.stringify(item("dr-sub")));
+r = await api(bodyC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2"], action: "reject", systems: ["Body"] });
+check("bulk reject by lead: draft refused", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || ""), JSON.stringify(item("dr-2")));
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "interviewing" });
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2"], action: "trial" });
+check("bulk trial: draft refused", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || ""), `${r.status} ${JSON.stringify(item("dr-2") ?? r.json)}`);
+check("drafts untouched after bulk attempts", untouched(await get("dr-1")) && untouched(await get("dr-2")), `${S(await get("dr-1"))} | ${S(await get("dr-2"))}`);
+
+// ---- submitted applications are unaffected ----
+r = await api(bodyC, "POST", "/api/admin/applications/dr-sub2/status", { status: "interview", systems: ["Body"] });
+check("lead advancing a SUBMITTED app still works", r.status === 200 && (await get("dr-sub2")).status === "interview", `${r.status} ${r.json?.error || ""}`);
+r = await api(bodyC, "POST", "/api/admin/applications/dr-sub2/reject", { systems: ["Body"] });
+check("lead rejecting a SUBMITTED app still works", r.status === 200, `${r.status} ${r.json?.error || ""}`);
+
+// ---- the applicant can still edit and submit their draft (applications open) ----
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open" });
+r = await api(appC, "PATCH", "/api/applications/dr-1", { formData: { whyJoin: "still editing" } });
+check("applicant can still save the draft", r.status === 200 && (await get("dr-1")).formData?.whyJoin === "still editing", `${r.status} ${r.json?.error || ""}`);
+
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open" });
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Incident fix. A lead advanced two unsubmitted (in_progress) applications to Interview. The status route only guarded waitlist/accept against drafts, so interview/trial/reject went through: the applications' status moved past in_progress, which froze the applicants' own forms ("Failed to save" — the applicant PATCH only accepts in_progress/submitted) and put empty applications in the interview queue.

**Guard:** every staff action on a draft is now refused with a clear 400 — single-application status route (any status other than in_progress/submitted), reject route, and bulk route (per item, so submitted siblings in the same batch still process; the `submitted` bulk action stays allowed). The detail view shows "Not submitted yet — review actions unlock once the applicant submits" instead of buttons.

**Data:** the two affected applications were reverted to in_progress (offers, review decision cleared) before this PR; both applicants can edit and submit normally. Interview offers need re-extending after they submit.

**Tests:** `scripts/qa/drafts-regress.mjs` (committed) — admin/lead/captain advance, every status transition, reject route, bulk interview/reject/trial: all refused, drafts byte-for-byte untouched, submitted applications unaffected, applicant can still save — 20/20. Rejection harness 27/27 and bulk harness 12/12 still pass. `npm run build` clean.