### PR TITLE
fix: staff transition guard (landmine audit tier 1)

### DIFF
--- a/app/admin/applications/_components/ApplicationsContext.tsx
+++ b/app/admin/applications/_components/ApplicationsContext.tsx
@@ -15,7 +15,7 @@ interface ApplicationWithUser extends Application {
 type SortBy = "date" | "name" | "rating" | "interviewRating";
 type SortDirection = "asc" | "desc";
 
-type BulkAction = "accept" | "reject" | "waitlist" | "interview" | "trial" | "submitted";
+type BulkAction = "reject" | "waitlist" | "interview" | "trial" | "submitted";
 
 interface BulkActionResult {
   id: string;

--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -104,9 +104,10 @@ export default function FullScreenListView(props: Props) {
   // Determine which actions are allowed based on the recruiting step
   const canInterview = true; // Always allowed
   const canTrial = isAtOrPast(recruitingStep, RecruitingStep.INTERVIEWING);
-  const canAcceptWaitlist = isAtOrPast(recruitingStep, RecruitingStep.TRIAL_WORKDAY);
+  const canWaitlist = isAtOrPast(recruitingStep, RecruitingStep.RELEASE_TRIAL);
   const canReject = true; // Always allowed
-  const canRevert = true; // Always allowed
+  // Wipes every system's offers and decisions on the application — captains and admins only.
+  const canRevert = currentUser?.role === UserRole.ADMIN || currentUser?.role === UserRole.TEAM_CAPTAIN_OB;
 
   const groupedApplications = useMemo(() => {
     if (!groupByUser) return [];
@@ -535,10 +536,10 @@ export default function FullScreenListView(props: Props) {
           ) : (
             <div className="flex items-center gap-2">
               <button disabled={!canReject} title={!canReject ? "Not allowed in current recruiting step" : ""} onClick={() => setConfirmAction('reject')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canReject && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#ef4444', !canReject)}>Reject</button>
-              <button disabled={!canAcceptWaitlist} title={!canAcceptWaitlist ? "Waitlisting requires Trial phase" : ""} onClick={() => setConfirmAction('waitlist')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canAcceptWaitlist && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#ff9404', !canAcceptWaitlist)}>Waitlist</button>
+              <button disabled={!canWaitlist} title={!canWaitlist ? "Waitlisting opens once trial offers are released" : ""} onClick={() => setConfirmAction('waitlist')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canWaitlist && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#ff9404', !canWaitlist)}>Waitlist</button>
               <button disabled={!canInterview} title={!canInterview ? "Not allowed in current recruiting step" : ""} onClick={() => setConfirmAction('interview')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canInterview && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#06b6d4', !canInterview)}>Interview</button>
               <button disabled={!canTrial} title={!canTrial ? "Trial phase hasn't started" : ""} onClick={() => setConfirmAction('trial')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canTrial && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#a855f7', !canTrial)}>Trial</button>
-              <button disabled={!canRevert} title={!canRevert ? "Not allowed in current recruiting step" : ""} onClick={() => setConfirmAction('submitted')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canRevert && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('rgba(255,255,255,0.7)', !canRevert)}>Revert to Submitted</button>
+              <button disabled={!canRevert} title={!canRevert ? "Admins and team captains only" : ""} onClick={() => setConfirmAction('submitted')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canRevert && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('rgba(255,255,255,0.7)', !canRevert)}>Revert to Submitted</button>
             </div>
           )}
         </div>

--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -60,7 +60,7 @@ function getDisplayStatusForUser(app: any, user: any): ApplicationStatus {
   return app.status;
 }
 
-type BulkAction = "accept" | "reject" | "waitlist" | "interview" | "trial" | "submitted";
+type BulkAction = "reject" | "waitlist" | "interview" | "trial" | "submitted";
 
 interface Props {
   applications: any[];
@@ -538,7 +538,6 @@ export default function FullScreenListView(props: Props) {
               <button disabled={!canAcceptWaitlist} title={!canAcceptWaitlist ? "Waitlisting requires Trial phase" : ""} onClick={() => setConfirmAction('waitlist')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canAcceptWaitlist && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#ff9404', !canAcceptWaitlist)}>Waitlist</button>
               <button disabled={!canInterview} title={!canInterview ? "Not allowed in current recruiting step" : ""} onClick={() => setConfirmAction('interview')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canInterview && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#06b6d4', !canInterview)}>Interview</button>
               <button disabled={!canTrial} title={!canTrial ? "Trial phase hasn't started" : ""} onClick={() => setConfirmAction('trial')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canTrial && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#a855f7', !canTrial)}>Trial</button>
-              <button disabled={!canAcceptWaitlist} title={!canAcceptWaitlist ? "Accepting requires Trial phase" : ""} onClick={() => setConfirmAction('accept')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canAcceptWaitlist && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('#22c55e', !canAcceptWaitlist)}>Accept</button>
               <button disabled={!canRevert} title={!canRevert ? "Not allowed in current recruiting step" : ""} onClick={() => setConfirmAction('submitted')} className={clsx("px-3 py-1.5 text-[11px] font-semibold rounded-md font-urbanist", !canRevert && "opacity-50 cursor-not-allowed")} style={actionBtnStyle('rgba(255,255,255,0.7)', !canRevert)}>Revert to Submitted</button>
             </div>
           )}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { RecruitingConfig, RecruitingStep, Announcement } from "@/lib/models/Config";
+import { STEP_ORDER } from "@/lib/utils/statusUtils";
 import { format } from "date-fns";
 import clsx from "clsx";
 
@@ -90,7 +91,26 @@ export default function AdminSettingsPage() {
     // sweep (the route fires on the step value, not on change), so it is
     // allowed — but never silently.
     const isCurrent = selectedStep === config?.currentStep;
+    const fromIdx = config ? STEP_ORDER.indexOf(config.currentStep) : -1;
+    const toIdx = STEP_ORDER.indexOf(selectedStep);
+    const isNext = toIdx === fromIdx + 1;
     const consequence = SWEEP_CONSEQUENCES[selectedStep];
+    // Out-of-order moves (skipping ahead, going back) need the step name typed
+    // back, and the server insists on it (#116). Sweep steps already do.
+    let confirmation: string | undefined;
+    if (!isCurrent && !isNext && !consequence) {
+      const direction = toIdx < fromIdx ? "back" : "ahead, skipping steps";
+      const typed = prompt(
+        `You are moving ${direction}: "${config?.currentStep}" to "${selectedStep}". Skipped steps' automatic actions will not run, and going back can re-hide decisions applicants have already seen.\n\nType ${selectedStep} to continue.`
+      );
+      if (typed !== selectedStep) {
+        if (typed !== null) toast.error("Step name did not match. Nothing was changed.");
+        return;
+      }
+      confirmation = typed;
+    } else if (consequence) {
+      confirmation = selectedStep;
+    }
     if (consequence) {
       const typed = prompt(
         `${isCurrent ? "Re-running" : "Entering"} "${selectedStep}" ${consequence}. This cannot be undone.\n\nType ${selectedStep} to continue.`
@@ -103,13 +123,15 @@ export default function AdminSettingsPage() {
       if (!confirm(`Re-run the actions for "${selectedStep}"? Sweeps for this step are safe to repeat, and you will be prompted to send its emails again (already-sent applicants are skipped).`)) return;
     } else if (RELEASE_STEPS.includes(selectedStep)) {
       if (!confirm(`Move to "${selectedStep}"? You will be prompted to send this step's emails right after.`)) return;
+    } else if (isNext) {
+      if (!confirm(`Move to "${selectedStep}"?`)) return;
     }
 
     setSaving(true);
     try {
       const res = await fetch("/api/admin/config/recruiting", {
         method: "POST",
-        body: JSON.stringify({ step: selectedStep }),
+        body: JSON.stringify({ step: selectedStep, confirm: confirmation }),
       });
       if (res.ok) {
         setConfig((prev) => prev ? { ...prev, currentStep: selectedStep, updatedAt: new Date() } : null);

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -98,10 +98,12 @@ export default function AdminSettingsPage() {
     // Out-of-order moves (skipping ahead, going back) need the step name typed
     // back, and the server insists on it (#116). Sweep steps already do.
     let confirmation: string | undefined;
-    if (!isCurrent && !isNext && !consequence) {
+    if (!isCurrent && !isNext) {
+      // Out of order always gets the skipped-steps warning, and a sweep step
+      // reached out of order gets both warnings in one prompt.
       const direction = toIdx < fromIdx ? "back" : "ahead, skipping steps";
       const typed = prompt(
-        `You are moving ${direction}: "${config?.currentStep}" to "${selectedStep}". Skipped steps' automatic actions will not run, and going back can re-hide decisions applicants have already seen.\n\nType ${selectedStep} to continue.`
+        `You are moving ${direction}: "${config?.currentStep}" to "${selectedStep}". Skipped steps' automatic actions will not run, and going back can re-hide decisions applicants have already seen.${consequence ? ` Entering "${selectedStep}" also ${consequence}. This cannot be undone.` : ""}\n\nType ${selectedStep} to continue.`
       );
       if (typed !== selectedStep) {
         if (typed !== null) toast.error("Step name did not match. Nothing was changed.");
@@ -110,8 +112,6 @@ export default function AdminSettingsPage() {
       confirmation = typed;
     } else if (consequence) {
       confirmation = selectedStep;
-    }
-    if (consequence) {
       const typed = prompt(
         `${isCurrent ? "Re-running" : "Entering"} "${selectedStep}" ${consequence}. This cannot be undone.\n\nType ${selectedStep} to continue.`
       );

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -121,7 +121,7 @@ export default function AdminSettingsPage() {
       }
     } else if (isCurrent) {
       if (!confirm(`Re-run the actions for "${selectedStep}"? Sweeps for this step are safe to repeat, and you will be prompted to send its emails again (already-sent applicants are skipped).`)) return;
-    } else if (RELEASE_STEPS.includes(selectedStep)) {
+    } else if (RELEASE_STEPS.includes(selectedStep) && !confirmation) {
       if (!confirm(`Move to "${selectedStep}"? You will be prompted to send this step's emails right after.`)) return;
     } else if (isNext) {
       if (!confirm(`Move to "${selectedStep}"?`)) return;

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -8,6 +8,7 @@ import { getRecruitingConfig } from "@/lib/firebase/config";
 import { requireStaffForApplication } from "@/lib/auth/guard";
 import { UserRole, User } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
+import { appCache } from "@/lib/utils/appCache";
 
 
 /**
@@ -97,6 +98,8 @@ export async function POST(
     if (!updatedApp) {
       return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
+
+    appCache.invalidateApplications();
 
     return NextResponse.json({
       application: updatedApp,

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -3,6 +3,8 @@ import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { getApplication, rejectApplicationFromSystems } from "@/lib/firebase/applications";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
+import { validateStaffTransition } from "@/lib/utils/transitions";
+import { getRecruitingConfig } from "@/lib/firebase/config";
 import { requireStaffForApplication } from "@/lib/auth/guard";
 import { UserRole, User } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
@@ -52,6 +54,11 @@ export async function POST(
     }
     if (application.status === ApplicationStatus.IN_PROGRESS) {
       return NextResponse.json({ error: DRAFT_ACTION_ERROR }, { status: 400 });
+    }
+    const { currentStep } = await getRecruitingConfig();
+    const refusal = validateStaffTransition({ from: application.status, to: ApplicationStatus.REJECTED, role: currentUser.role, step: currentStep, perSystemReject: true });
+    if (refusal) {
+      return NextResponse.json({ error: refusal.error }, { status: refusal.status });
     }
 
     const body = await request.json();

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
-import { updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, getApplication } from "@/lib/firebase/applications";
+import { updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, getApplication, revertToSubmitted } from "@/lib/firebase/applications";
 import { requireStaffForApplication } from "@/lib/auth/guard";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { UserRole, User } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
 import { getRecruitingConfig } from "@/lib/firebase/config";
 import { getStageDecisionForStatus, isAtOrPast } from "@/lib/utils/statusUtils";
-import { DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
+import { validateStaffTransition } from "@/lib/utils/transitions";
 import { sendStatusEmail } from "@/lib/email/send";
 import type { EmailTrigger } from "@/lib/models/EmailTemplate";
 import { appCache } from "@/lib/utils/appCache";
@@ -36,26 +36,18 @@ export async function POST(
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
 
-    // Nothing can be done with a draft. This used to guard only waitlist and
-    // accept; advancing an unsubmitted application to Interview moved its
-    // status past in_progress, which froze the applicant's own form ("Failed
-    // to save") and put an empty application in the interview queue. Staff
-    // moving a draft to Submitted is the one legitimate transition.
-    if (status !== ApplicationStatus.IN_PROGRESS && status !== ApplicationStatus.SUBMITTED) {
-      const application = await getApplication(id);
-      if (!application) {
-        return NextResponse.json({ error: "Application not found" }, { status: 404 });
-      }
-      if (application.status === ApplicationStatus.IN_PROGRESS) {
-        return NextResponse.json({ error: DRAFT_ACTION_ERROR }, { status: 400 });
-      }
+    // Every staff status change goes through the transition table: which
+    // statuses it may come from, the earliest step it is allowed at, which
+    // roles may make it, and the statuses staff may never set. See
+    // lib/utils/transitions.ts for the history behind each rule.
+    const current = await getApplication(id);
+    if (!current) {
+      return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
-
-    // Reviewers cannot advance or reject applicants - they can only submit scorecards and notes
-    if (currentUser.role === UserRole.REVIEWER) {
-      return NextResponse.json({
-        error: "Reviewers are not authorized to advance or reject applicants"
-      }, { status: 403 });
+    const { currentStep: stepNow } = await getRecruitingConfig();
+    const refusal = validateStaffTransition({ from: current.status, to: status, role: currentUser.role, step: stepNow });
+    if (refusal) {
+      return NextResponse.json({ error: refusal.error }, { status: refusal.status });
     }
 
     // A system lead may only extend interview offers for their own system.
@@ -217,6 +209,10 @@ export async function POST(
       // Atomically create trial offers and un-reject systems in a single transaction
       // Also set interviewDecision since we're advancing from interview to trial
       updatedApp = await addMultipleTrialOffers(id, systemsToOffer, 'advanced');
+    } else if (status === ApplicationStatus.SUBMITTED) {
+      // Revert to a fresh review (or force-submit a draft). Full reset, and
+      // the original submission time is kept.
+      updatedApp = await revertToSubmitted(id);
     } else {
       // For other status changes (reject, accept), update status and stage decision
       const application = await getApplication(id);
@@ -225,6 +221,9 @@ export async function POST(
       }
 
       logger.info({
+        applicationId: id,
+        actorUid: currentUser.uid,
+        actorRole: currentUser.role,
         currentStatus: application.status,
         newStatus: status,
         action: 'status_change'
@@ -258,6 +257,16 @@ export async function POST(
 
         updateData.trialDecisionDay = decisionDay;
         logger.info({ decisionDay, currentStep }, "Set trial decision day");
+      }
+
+      // The waitlist modal picks a system too; it used to be dropped on the floor.
+      if (status === ApplicationStatus.WAITLISTED && typeof offer?.system === "string") {
+        updateData.waitlistSystem = offer.system;
+      }
+
+      // The waitlist modal picks a system too; it used to be dropped on the floor.
+      if (status === ApplicationStatus.WAITLISTED && typeof offer?.system === "string") {
+        updateData.waitlistSystem = offer.system;
       }
 
       // If accepting, save offer details if provided

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -269,8 +269,21 @@ export async function POST(
       }
 
       // The waitlist modal picks a system too; it used to be dropped on the floor.
+      // Staff-facing only (the sanitizer strips it) and cleared on the way out
+      // so a stale system never outlives the waitlist.
       if (status === ApplicationStatus.WAITLISTED && typeof offer?.system === "string") {
         updateData.waitlistSystem = offer.system;
+      } else if (application.status === ApplicationStatus.WAITLISTED && status !== ApplicationStatus.WAITLISTED) {
+        updateData.waitlistSystem = FieldValue.delete();
+      }
+
+      // Un-rejecting: an acceptance or waitlist decision means the earlier
+      // stages were passed, so stale stage rejections must not keep the
+      // applicant's dashboard on "Rejected" (getUserVisibleStatus checks
+      // reviewDecision first). Trial offers do the same in addMultipleTrialOffers.
+      if (status === ApplicationStatus.ACCEPTED || status === ApplicationStatus.WAITLISTED) {
+        if (application.reviewDecision === "rejected") updateData.reviewDecision = "advanced";
+        if (application.interviewDecision === "rejected") updateData.interviewDecision = "advanced";
       }
 
       // If accepting, save offer details if provided

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -264,11 +264,6 @@ export async function POST(
         updateData.waitlistSystem = offer.system;
       }
 
-      // The waitlist modal picks a system too; it used to be dropped on the floor.
-      if (status === ApplicationStatus.WAITLISTED && typeof offer?.system === "string") {
-        updateData.waitlistSystem = offer.system;
-      }
-
       // If accepting, save offer details if provided
       if (status === ApplicationStatus.ACCEPTED && offer) {
         updateData.offer = {

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -220,6 +220,9 @@ export async function POST(request: NextRequest) {
               if (wField) {
                 updateData[wField] = wDecision;
               }
+              // Un-rejecting (see the single-application route).
+              if (application.reviewDecision === "rejected") updateData.reviewDecision = "advanced";
+              if (application.interviewDecision === "rejected") updateData.interviewDecision = "advanced";
               if (wField === 'trialDecision') {
                 // Decisions made during TRIAL_WORKDAY are visible on DAY 1.
                 // Decisions made during RELEASE_DECISIONS_DAY1 are visible on DAY 2.

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -51,6 +51,10 @@ function resolveBulkSystems(
 ): { systems: string[]; error?: string } {
   const ranked: string[] = application.preferredSystems || [];
   if (requested.length > 0) {
+    // Deliberately stricter than the single-application route, which lets a
+    // captain pull one applicant into a system they didn't rank (#104):
+    // stamping an unranked system across a whole selection is the accident
+    // case this intersection exists to stop (#54).
     const systems = requested.filter((s) => ranked.includes(s));
     return systems.length > 0
       ? { systems }
@@ -138,8 +142,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Trial offers cannot be extended at the current recruiting step" }, { status: 400 });
     }
 
-    if (action === "waitlist" && !isAtOrPast(currentStep, RecruitingStep.TRIAL_WORKDAY)) {
-      return NextResponse.json({ error: "Waitlist decisions cannot be made at the current recruiting step" }, { status: 400 });
+    if (action === "waitlist" && !isAtOrPast(currentStep, RecruitingStep.RELEASE_TRIAL)) {
+      return NextResponse.json({ error: "Waitlist decisions can't be made until trial offers are released" }, { status: 400 });
     }
 
     // Process each application

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { checkTeamAccess, DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
 import { Application, InterviewEventStatus } from "@/lib/models/Application";
 import { requireStaff } from "@/lib/auth/guard";
-import { getApplication, updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, rejectApplicationFromSystems } from "@/lib/firebase/applications";
+import { getApplication, updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, rejectApplicationFromSystems, revertToSubmitted } from "@/lib/firebase/applications";
+import { validateStaffTransition } from "@/lib/utils/transitions";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { UserRole } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
@@ -12,7 +13,17 @@ import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
 
 
-type BulkAction = "accept" | "reject" | "waitlist" | "interview" | "trial" | "submitted";
+// No bulk accept: an acceptance carries a per-applicant offer (system, role)
+// that someone has to choose, and bulk had been writing none (#110).
+type BulkAction = "reject" | "waitlist" | "interview" | "trial" | "submitted";
+
+const TARGET_STATUS: Record<BulkAction, ApplicationStatus> = {
+  reject: ApplicationStatus.REJECTED,
+  waitlist: ApplicationStatus.WAITLISTED,
+  interview: ApplicationStatus.INTERVIEW,
+  trial: ApplicationStatus.TRIAL,
+  submitted: ApplicationStatus.SUBMITTED,
+};
 
 interface BulkStatusRequest {
   applicationIds: string[];
@@ -82,7 +93,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "applicationIds array is required" }, { status: 400 });
     }
 
-    if (!action || !["accept", "reject", "waitlist", "interview", "trial", "submitted"].includes(action)) {
+    if (!action || !["reject", "waitlist", "interview", "trial", "submitted"].includes(action)) {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });
     }
 
@@ -127,8 +138,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Trial offers cannot be extended at the current recruiting step" }, { status: 400 });
     }
 
-    if (["accept", "waitlist"].includes(action) && !isAtOrPast(currentStep, RecruitingStep.TRIAL_WORKDAY)) {
-      return NextResponse.json({ error: "Accept/Waitlist decisions cannot be made at the current recruiting step" }, { status: 400 });
+    if (action === "waitlist" && !isAtOrPast(currentStep, RecruitingStep.TRIAL_WORKDAY)) {
+      return NextResponse.json({ error: "Waitlist decisions cannot be made at the current recruiting step" }, { status: 400 });
     }
 
     // Process each application
@@ -153,6 +164,18 @@ export async function POST(request: NextRequest) {
           // Drafts are not reviewable; see the single-application status route.
           if (application.status === ApplicationStatus.IN_PROGRESS && action !== "submitted") {
             return { id: appId, success: false, error: DRAFT_ACTION_ERROR };
+          }
+
+          // Same transition table as the single-application route, per item.
+          const refusal = validateStaffTransition({
+            from: application.status,
+            to: TARGET_STATUS[action as BulkAction],
+            role: currentUser.role,
+            step: currentStep,
+            perSystemReject: true, // bulk reject is already scoped to the lead's own system
+          });
+          if (refusal) {
+            return { id: appId, success: false, error: refusal.error };
           }
 
           switch (action) {
@@ -180,28 +203,6 @@ export async function POST(request: NextRequest) {
               return { id: appId, success: true };
             }
 
-            case "accept": {
-              const { field, decision } = getStageDecisionForStatus(application.status, ApplicationStatus.ACCEPTED);
-              const updateData: Record<string, unknown> = { status: ApplicationStatus.ACCEPTED };
-              if (field) {
-                updateData[field] = decision;
-              }
-              if (field === 'trialDecision') {
-                // Decisions made during TRIAL_WORKDAY are visible on DAY 1.
-                // Decisions made during RELEASE_DECISIONS_DAY1 are visible on DAY 2.
-                // Decisions made during RELEASE_DECISIONS_DAY2 are visible on DAY 3.
-                let decisionDay: 1 | 2 | 3 = 1;
-                if (currentStep === RecruitingStep.RELEASE_DECISIONS_DAY1) {
-                  decisionDay = 2;
-                } else if (currentStep === RecruitingStep.RELEASE_DECISIONS_DAY2 || currentStep === RecruitingStep.RELEASE_DECISIONS_DAY3) {
-                  decisionDay = 3;
-                }
-                updateData.trialDecisionDay = decisionDay;
-              }
-              await updateApplication(appId, updateData as any);
-              return { id: appId, success: true };
-            }
-
             case "waitlist": {
               const { field: wField, decision: wDecision } = getStageDecisionForStatus(application.status, ApplicationStatus.WAITLISTED);
               const updateData: Record<string, unknown> = { status: ApplicationStatus.WAITLISTED };
@@ -225,13 +226,9 @@ export async function POST(request: NextRequest) {
             }
 
             case "submitted": {
-              const updateData: Record<string, unknown> = { 
-                status: ApplicationStatus.SUBMITTED,
-                reviewDecision: 'pending',
-                interviewDecision: 'pending',
-                trialDecision: 'pending',
-              };
-              await updateApplication(appId, updateData as any);
+              // Full reset (offers, decisions, commitment, decision day),
+              // keeping the original submission time (#108).
+              await revertToSubmitted(appId);
               return { id: appId, success: true };
             }
 

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -5,6 +5,7 @@ import { RecruitingStep } from "@/lib/models/Config";
 import { autoRejectUnscheduledInterviewApplicants, sweepOnDecisionAdvance } from "@/lib/firebase/applications";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
+import { STEP_ORDER } from "@/lib/utils/statusUtils";
 
 
 export async function GET(request: NextRequest) {
@@ -34,7 +35,7 @@ export async function POST(request: NextRequest) {
     const { uid } = await requireAdmin();
     
     const body = await request.json();
-    const { step, renegEnabled } = body;
+    const { step, renegEnabled, confirm } = body;
 
     // Reneg toggle can be flipped on its own, without a step change.
     if (step === undefined && typeof renegEnabled === "boolean") {
@@ -44,6 +45,24 @@ export async function POST(request: NextRequest) {
 
     if (!Object.values(RecruitingStep).includes(step)) {
         return NextResponse.json({ error: "Invalid step" }, { status: 400 });
+    }
+
+    // Steps move forward one at a time. Re-saving the current step is the
+    // documented sweep recovery. Skipping ahead silently misses one-shot
+    // sweeps (close_interviews, day 2/3) and going back un-reveals decisions
+    // applicants have already seen, so both need the step name typed back.
+    // The UI collects it; this insists on it (#116).
+    const { currentStep: before } = await getRecruitingConfig();
+    const fromIdx = STEP_ORDER.indexOf(before);
+    const toIdx = STEP_ORDER.indexOf(step);
+    const isCurrent = toIdx === fromIdx;
+    const isNext = toIdx === fromIdx + 1;
+    if (!isCurrent && !isNext && confirm !== step) {
+      const direction = toIdx < fromIdx ? "back" : "ahead";
+      return NextResponse.json({
+        error: `Moving ${direction} from ${before} to ${step} skips the normal order. Type the step name to confirm.`,
+        requiresConfirmation: true,
+      }, { status: 400 });
     }
 
     await updateRecruitingStep(step, uid);

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -282,7 +282,7 @@ export async function getUserApplicationForTeam(
  */
 export async function updateApplication(
   applicationId: string,
-  updates: Partial<Pick<Application, "formData" | "preferredSystems" | "originalPreferredSystems" | "status" | "interviewOffers" | "selectedInterviewSystem" | "rejectedBySystems" | "trialOffers" | "reviewDecision" | "interviewDecision" | "trialDecision" | "emailsSent">>
+  updates: Partial<Pick<Application, "formData" | "preferredSystems" | "originalPreferredSystems" | "status" | "interviewOffers" | "selectedInterviewSystem" | "rejectedBySystems" | "trialOffers" | "reviewDecision" | "interviewDecision" | "trialDecision" | "trialDecisionDay" | "offer" | "waitlistSystem" | "emailsSent">>
 ): Promise<Application | null> {
   const applicationRef = adminDb
     .collection(APPLICATIONS_COLLECTION)
@@ -304,8 +304,10 @@ export async function updateApplication(
     updateData.interviewOffers = updates.interviewOffers.map(prepareOfferForFirestore);
   }
 
-  // If submitting, set submittedAt
-  if (updates.status === ApplicationStatus.SUBMITTED) {
+  // The first submission stamps submittedAt; a later move back to Submitted
+  // keeps the original (#108 — the stats timeline and "who submitted when"
+  // depend on it).
+  if (updates.status === ApplicationStatus.SUBMITTED && !doc.data()?.submittedAt) {
     updateData.submittedAt = FieldValue.serverTimestamp();
   }
 
@@ -450,6 +452,13 @@ export async function addMultipleInterviewOffers(
       updatedAt: FieldValue.serverTimestamp(),
     };
 
+    // Offers for systems the applicant didn't rank are allowed (staff may pull
+    // someone into a better-fit system), but everything that scopes who can
+    // see an application keys off preferredSystems — so the offered system
+    // joins the ranking, with the applicant's own order kept in
+    // originalPreferredSystems (#104).
+    Object.assign(updateData, joinRanking(data, systems));
+
     // Update status to INTERVIEW if not already
     if (data.status !== ApplicationStatus.INTERVIEW) {
       updateData.status = ApplicationStatus.INTERVIEW;
@@ -472,6 +481,7 @@ export async function addMultipleInterviewOffers(
       id: doc.id,
       interviewOffers: updatedOffers,
       rejectedBySystems: updatedRejections,
+      preferredSystems: (updateData.preferredSystems as Application["preferredSystems"]) ?? data.preferredSystems,
       status: updateData.status || data.status,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: new Date(),
@@ -539,7 +549,12 @@ export async function addMultipleTrialOffers(
       })),
       rejectedBySystems: updatedRejections,
       updatedAt: FieldValue.serverTimestamp(),
+      // A fresh trial offer supersedes any earlier final decision, the way an
+      // interview offer clears interviewDecision (#109).
+      trialDecision: FieldValue.delete(),
+      trialDecisionDay: FieldValue.delete(),
     };
+    Object.assign(updateData, joinRanking(data, systems)); // see addMultipleInterviewOffers (#104)
 
     // Update status to TRIAL if not already
     if (data.status !== ApplicationStatus.TRIAL) {
@@ -559,6 +574,7 @@ export async function addMultipleTrialOffers(
       id: doc.id,
       trialOffers: updatedOffers,
       rejectedBySystems: updatedRejections,
+      preferredSystems: (updateData.preferredSystems as Application["preferredSystems"]) ?? data.preferredSystems,
       status: updateData.status || data.status,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: new Date(),
@@ -1429,4 +1445,54 @@ export async function getSystemApplicationsPaginated(
     nextCursor,
     hasMore,
   };
+}
+
+/**
+ * Update fragment that adds any of `systems` missing from the application's
+ * ranking, preserving the applicant's own order in originalPreferredSystems.
+ * Empty when every system was already ranked.
+ */
+function joinRanking(data: FirebaseFirestore.DocumentData, systems: string[]): Record<string, unknown> {
+  const ranked = (Array.isArray(data.preferredSystems) ? data.preferredSystems : []) as string[];
+  const unranked = systems.filter((s) => !ranked.includes(s));
+  if (unranked.length === 0) return {};
+  const fragment: Record<string, unknown> = { preferredSystems: [...ranked, ...unranked] };
+  if (!Array.isArray(data.originalPreferredSystems)) fragment.originalPreferredSystems = ranked;
+  return fragment;
+}
+
+/**
+ * Revert an application to a fresh Submitted state, or force-submit a draft.
+ * Clears every offer and decision so the applicant sees a clean "Submitted"
+ * and staff review from scratch. Keeps the original submittedAt (stamped only
+ * if this is the first submission) and restores the applicant's own system
+ * ranking if an interview selection or an unranked offer had changed it (#108).
+ */
+export async function revertToSubmitted(applicationId: string): Promise<Application | null> {
+  const ref = adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId);
+  const doc = await ref.get();
+  if (!doc.exists) return null;
+  const data = doc.data()!;
+  const updateData: Record<string, unknown> = {
+    status: ApplicationStatus.SUBMITTED,
+    reviewDecision: "pending",
+    interviewDecision: "pending",
+    trialDecision: "pending",
+    trialDecisionDay: FieldValue.delete(),
+    interviewOffers: [],
+    trialOffers: [],
+    selectedInterviewSystem: null,
+    rejectedBySystems: [],
+    offer: FieldValue.delete(),
+    commitment: FieldValue.delete(),
+    waitlistSystem: FieldValue.delete(),
+    autoRejected: FieldValue.delete(),
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+  if (Array.isArray(data.originalPreferredSystems) && data.originalPreferredSystems.length > 0) {
+    updateData.preferredSystems = data.originalPreferredSystems;
+  }
+  if (!data.submittedAt) updateData.submittedAt = FieldValue.serverTimestamp();
+  await ref.update(updateData);
+  return getApplication(applicationId);
 }

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -304,10 +304,11 @@ export async function updateApplication(
     updateData.interviewOffers = updates.interviewOffers.map(prepareOfferForFirestore);
   }
 
-  // The first submission stamps submittedAt; a later move back to Submitted
-  // keeps the original (#108 — the stats timeline and "who submitted when"
-  // depend on it).
-  if (updates.status === ApplicationStatus.SUBMITTED && !doc.data()?.submittedAt) {
+  // Setting SUBMITTED stamps submittedAt — on first submission and on every
+  // applicant edit afterwards, so staff see the date of the version in front
+  // of them (the applicant route relies on this). Staff reverts go through
+  // revertToSubmitted, which keeps the original date (#108).
+  if (updates.status === ApplicationStatus.SUBMITTED) {
     updateData.submittedAt = FieldValue.serverTimestamp();
   }
 
@@ -1487,6 +1488,10 @@ export async function revertToSubmitted(applicationId: string): Promise<Applicat
     commitment: FieldValue.delete(),
     waitlistSystem: FieldValue.delete(),
     autoRejected: FieldValue.delete(),
+    // A re-advanced applicant must get the stage emails again; trigger-emails
+    // skips anyone whose trigger is already recorded.
+    emailsSent: FieldValue.delete(),
+    renegedFrom: FieldValue.delete(),
     updatedAt: FieldValue.serverTimestamp(),
   };
   if (Array.isArray(data.originalPreferredSystems) && data.originalPreferredSystems.length > 0) {

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -484,6 +484,8 @@ export async function addMultipleInterviewOffers(
       rejectedBySystems: updatedRejections,
       preferredSystems: (updateData.preferredSystems as Application["preferredSystems"]) ?? data.preferredSystems,
       status: updateData.status || data.status,
+      reviewDecision: (updateData.reviewDecision as Application["reviewDecision"]) ?? data.reviewDecision,
+      interviewDecision: null as unknown as Application["interviewDecision"],
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: new Date(),
       submittedAt: data.submittedAt?.toDate(),
@@ -555,6 +557,9 @@ export async function addMultipleTrialOffers(
       trialDecision: FieldValue.delete(),
       trialDecisionDay: FieldValue.delete(),
     };
+    // Re-advancing a rejected applicant: the review stage was passed too, or
+    // getUserVisibleStatus keeps their dashboard on "Rejected" and hides the offer.
+    if (data.reviewDecision === "rejected") updateData.reviewDecision = "advanced";
     Object.assign(updateData, joinRanking(data, systems)); // see addMultipleInterviewOffers (#104)
 
     // Update status to TRIAL if not already
@@ -577,6 +582,10 @@ export async function addMultipleTrialOffers(
       rejectedBySystems: updatedRejections,
       preferredSystems: (updateData.preferredSystems as Application["preferredSystems"]) ?? data.preferredSystems,
       status: updateData.status || data.status,
+      reviewDecision: (updateData.reviewDecision as Application["reviewDecision"]) ?? data.reviewDecision,
+      interviewDecision: (updateData.interviewDecision as Application["interviewDecision"]) ?? data.interviewDecision,
+      trialDecision: undefined,
+      trialDecisionDay: undefined,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: new Date(),
       submittedAt: data.submittedAt?.toDate(),
@@ -1471,10 +1480,13 @@ function joinRanking(data: FirebaseFirestore.DocumentData, systems: string[]): R
  */
 export async function revertToSubmitted(applicationId: string): Promise<Application | null> {
   const ref = adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId);
-  const doc = await ref.get();
-  if (!doc.exists) return null;
-  const data = doc.data()!;
-  const updateData: Record<string, unknown> = {
+  // Transactional like every other multi-field writer here: a concurrent
+  // offer landing between the read and the write must not be clobbered.
+  const found = await adminDb.runTransaction(async (transaction) => {
+    const doc = await transaction.get(ref);
+    if (!doc.exists) return false;
+    const data = doc.data()!;
+    const updateData: Record<string, unknown> = {
     status: ApplicationStatus.SUBMITTED,
     reviewDecision: "pending",
     interviewDecision: "pending",
@@ -1494,10 +1506,13 @@ export async function revertToSubmitted(applicationId: string): Promise<Applicat
     renegedFrom: FieldValue.delete(),
     updatedAt: FieldValue.serverTimestamp(),
   };
-  if (Array.isArray(data.originalPreferredSystems) && data.originalPreferredSystems.length > 0) {
-    updateData.preferredSystems = data.originalPreferredSystems;
-  }
-  if (!data.submittedAt) updateData.submittedAt = FieldValue.serverTimestamp();
-  await ref.update(updateData);
+    if (Array.isArray(data.originalPreferredSystems) && data.originalPreferredSystems.length > 0) {
+      updateData.preferredSystems = data.originalPreferredSystems;
+    }
+    if (!data.submittedAt) updateData.submittedAt = FieldValue.serverTimestamp();
+    transaction.update(ref, updateData);
+    return true;
+  });
+  if (!found) return null;
   return getApplication(applicationId);
 }

--- a/lib/models/Application.ts
+++ b/lib/models/Application.ts
@@ -94,6 +94,9 @@ export interface Application {
   // Decision is only visible to applicant on or after this day
   trialDecisionDay?: 1 | 2 | 3;
 
+  /** System the waitlist decision was made for (the modal's pick). Staff-facing only. */
+  waitlistSystem?: string;
+
   // Offer Details
   offer?: {
     system: string;

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -245,6 +245,7 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     rejectedBySystems,
     autoRejected,
     renegedFrom,
+    waitlistSystem,
     status: rawStatus,
     ...safeData
   } = app;

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -2,7 +2,7 @@ import { Application, ApplicationStatus, StageDecision } from "@/lib/models/Appl
 import { RecruitingStep } from "@/lib/models/Config";
 
 // Order of recruiting steps for comparison
-const STEP_ORDER: RecruitingStep[] = [
+export const STEP_ORDER: RecruitingStep[] = [
   RecruitingStep.PRE_OPEN,
   RecruitingStep.OPEN,
   RecruitingStep.REVIEWING,

--- a/lib/utils/transitions.ts
+++ b/lib/utils/transitions.ts
@@ -1,0 +1,147 @@
+import { ApplicationStatus } from "@/lib/models/Application";
+import { RecruitingStep } from "@/lib/models/Config";
+import { UserRole } from "@/lib/models/User";
+import { isAtOrPast } from "@/lib/utils/statusUtils";
+import { DRAFT_ACTION_ERROR } from "@/lib/auth/teamAccess";
+
+/**
+ * The one place that says which status changes staff may make.
+ *
+ * Before this table the single-application status route validated only that
+ * the target was *a* status: a draft could be advanced (froze the applicant's
+ * form), a committed applicant could be rejected (saw Rejected while still
+ * committed), `committed` could be set by hand (triggered the decision-day
+ * sweep), and a system lead could reject team-wide through a door the
+ * per-system rule never saw. Bulk had step floors; the single route had none.
+ * Both routes and the reject route now consult this.
+ *
+ * Deliberate policy (2026-08-28): advancing to Interview is allowed from the
+ * `open` step — leads review while applications are still open. The applicant's
+ * form goes read-only at that point (#111).
+ */
+
+const S = ApplicationStatus;
+
+export const STATUS_LABELS: Record<ApplicationStatus, string> = {
+  [S.IN_PROGRESS]: "In Progress",
+  [S.SUBMITTED]: "Submitted",
+  [S.INTERVIEW]: "Interview",
+  [S.TRIAL]: "Trial",
+  [S.ACCEPTED]: "Accepted",
+  [S.REJECTED]: "Rejected",
+  [S.WAITLISTED]: "Waitlisted",
+  [S.COMMITTED]: "Committed",
+  [S.DECLINED]: "Declined",
+};
+
+interface TransitionRule {
+  /** Statuses an application may be in for staff to move it to the target. */
+  from: ApplicationStatus[];
+  /** Earliest recruiting step at which the move is allowed. */
+  minStep: RecruitingStep;
+  stepError: string;
+  /** If set, only these roles may make the move (default: any non-reviewer staff). */
+  roles?: UserRole[];
+}
+
+export const STAFF_TRANSITIONS: Partial<Record<ApplicationStatus, TransitionRule>> = {
+  // "Revert to Submitted" — a fresh review. Also force-submits a draft.
+  [S.SUBMITTED]: {
+    from: [S.IN_PROGRESS, S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED, S.ACCEPTED],
+    minStep: RecruitingStep.OPEN,
+    stepError: "Applications can't be changed before the cycle opens.",
+    roles: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB],
+  },
+  [S.INTERVIEW]: {
+    from: [S.SUBMITTED, S.INTERVIEW, S.REJECTED],
+    minStep: RecruitingStep.OPEN,
+    stepError: "Interview offers can't be extended before the cycle opens.",
+  },
+  [S.TRIAL]: {
+    from: [S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED],
+    minStep: RecruitingStep.INTERVIEWING,
+    stepError: "Trial offers can't be extended until the Interviewing step.",
+  },
+  [S.ACCEPTED]: {
+    from: [S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
+    minStep: RecruitingStep.TRIAL_WORKDAY,
+    stepError: "Acceptances can't be issued until the Trial Workday step.",
+  },
+  [S.WAITLISTED]: {
+    from: [S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
+    minStep: RecruitingStep.TRIAL_WORKDAY,
+    stepError: "Waitlist decisions can't be made until the Trial Workday step.",
+  },
+  [S.REJECTED]: {
+    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED],
+    minStep: RecruitingStep.OPEN,
+    stepError: "Applications can't be rejected before the cycle opens.",
+  },
+  // in_progress, committed and declined are never staff-settable: the first
+  // is the applicant's draft, the last two are the applicant's own decision.
+};
+
+export interface TransitionInput {
+  from: ApplicationStatus;
+  to: ApplicationStatus;
+  role: UserRole;
+  step: RecruitingStep;
+  /**
+   * True when a lead's rejection is going through the per-system path
+   * (`/reject`, or bulk reject scoped to their system). A lead may not reject
+   * through the plain status route, which would reject for every system.
+   */
+  perSystemReject?: boolean;
+}
+
+export interface TransitionRefusal {
+  status: 400 | 403;
+  error: string;
+}
+
+export function validateStaffTransition(input: TransitionInput): TransitionRefusal | null {
+  const { from, to, role, step, perSystemReject } = input;
+  const label = (s: ApplicationStatus) => STATUS_LABELS[s] ?? s;
+
+  if (role === UserRole.REVIEWER) {
+    return { status: 403, error: "Reviewers are not authorized to advance or reject applicants" };
+  }
+
+  if (from === S.IN_PROGRESS && to !== S.SUBMITTED) {
+    return { status: 400, error: DRAFT_ACTION_ERROR };
+  }
+
+  if (from === S.COMMITTED || from === S.DECLINED) {
+    return {
+      status: 400,
+      error: `This applicant has already ${from === S.COMMITTED ? "committed" : "declined"}, so their application can't be changed. Ask an admin if that's wrong.`,
+    };
+  }
+
+  const rule = STAFF_TRANSITIONS[to];
+  if (!rule) {
+    const why = to === S.IN_PROGRESS ? "that would reopen it as a draft" : "that is the applicant's own decision";
+    return { status: 400, error: `Applications can't be set to ${label(to)} by staff — ${why}.` };
+  }
+
+  if (!rule.from.includes(from)) {
+    return { status: 400, error: `Can't move an application from ${label(from)} to ${label(to)}.` };
+  }
+
+  if (!isAtOrPast(step, rule.minStep)) {
+    return { status: 400, error: rule.stepError };
+  }
+
+  if (rule.roles && !rule.roles.includes(role)) {
+    return { status: 403, error: `Only admins and team captains can move an application back to ${label(to)}.` };
+  }
+
+  if (to === S.REJECTED && role === UserRole.SYSTEM_LEAD && !perSystemReject) {
+    return {
+      status: 403,
+      error: "System leads reject per system — use the Reject button, which records the rejection for your system only.",
+    };
+  }
+
+  return null;
+}

--- a/lib/utils/transitions.ts
+++ b/lib/utils/transitions.ts
@@ -45,9 +45,11 @@ interface TransitionRule {
 }
 
 export const STAFF_TRANSITIONS: Partial<Record<ApplicationStatus, TransitionRule>> = {
-  // "Revert to Submitted" — a fresh review. Also force-submits a draft.
+  // "Revert to Submitted" — a fresh review. Also force-submits a draft, and
+  // clears a partial per-system rejection (status still submitted), which is
+  // why SUBMITTED is its own valid source.
   [S.SUBMITTED]: {
-    from: [S.IN_PROGRESS, S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED, S.ACCEPTED],
+    from: [S.IN_PROGRESS, S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED, S.ACCEPTED],
     minStep: RecruitingStep.OPEN,
     stepError: "Applications can't be changed before the cycle opens.",
     roles: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB],
@@ -72,8 +74,9 @@ export const STAFF_TRANSITIONS: Partial<Record<ApplicationStatus, TransitionRule
     minStep: RecruitingStep.RELEASE_TRIAL,
     stepError: "Acceptances can't be issued until trial offers are released.",
   },
+  // SUBMITTED: "waitlisting a straggler still at SUBMITTED" (statusUtils).
   [S.WAITLISTED]: {
-    from: [S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
+    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
     minStep: RecruitingStep.RELEASE_TRIAL,
     stepError: "Waitlist decisions can't be made until trial offers are released.",
   },

--- a/lib/utils/transitions.ts
+++ b/lib/utils/transitions.ts
@@ -57,23 +57,30 @@ export const STAFF_TRANSITIONS: Partial<Record<ApplicationStatus, TransitionRule
     minStep: RecruitingStep.OPEN,
     stepError: "Interview offers can't be extended before the cycle opens.",
   },
+  // SUBMITTED is included so a straggler can be fast-tracked with an explicit
+  // system. WAITLISTED is deliberately not: a fresh trial offer clears the
+  // final decision, which would un-reveal a waitlist the applicant has seen.
   [S.TRIAL]: {
-    from: [S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED],
+    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.REJECTED],
     minStep: RecruitingStep.INTERVIEWING,
     stepError: "Trial offers can't be extended until the Interviewing step.",
   },
+  // Decision mode in the detail view starts at release_trial, so the floor
+  // matches it (bulk used to say trial_workday; the two now agree).
   [S.ACCEPTED]: {
     from: [S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
-    minStep: RecruitingStep.TRIAL_WORKDAY,
-    stepError: "Acceptances can't be issued until the Trial Workday step.",
+    minStep: RecruitingStep.RELEASE_TRIAL,
+    stepError: "Acceptances can't be issued until trial offers are released.",
   },
   [S.WAITLISTED]: {
     from: [S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
-    minStep: RecruitingStep.TRIAL_WORKDAY,
-    stepError: "Waitlist decisions can't be made until the Trial Workday step.",
+    minStep: RecruitingStep.RELEASE_TRIAL,
+    stepError: "Waitlist decisions can't be made until trial offers are released.",
   },
+  // REJECTED -> REJECTED keeps per-system rejections idempotent: a second
+  // system recording its rejection after the first made it final.
   [S.REJECTED]: {
-    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED],
+    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.WAITLISTED, S.ACCEPTED, S.REJECTED],
     minStep: RecruitingStep.OPEN,
     stepError: "Applications can't be rejected before the cycle opens.",
   },
@@ -133,7 +140,10 @@ export function validateStaffTransition(input: TransitionInput): TransitionRefus
   }
 
   if (rule.roles && !rule.roles.includes(role)) {
-    return { status: 403, error: `Only admins and team captains can move an application back to ${label(to)}.` };
+    const what = from === S.IN_PROGRESS
+      ? "submit an application on the applicant's behalf"
+      : `move an application back to ${label(to)}`;
+    return { status: 403, error: `Only admins and team captains can ${what}.` };
   }
 
   if (to === S.REJECTED && role === UserRole.SYSTEM_LEAD && !perSystemReject) {

--- a/scripts/qa/drafts-regress.mjs
+++ b/scripts/qa/drafts-regress.mjs
@@ -48,7 +48,7 @@ await db.doc("applications/dr-2").set(base("in_progress"));
 await db.doc("applications/dr-sub").set(base("submitted"));
 await db.doc("applications/dr-sub2").set(base("submitted"));
 await db.doc("users/u-draft").set({ applications: ["dr-1", "dr-2", "dr-sub", "dr-sub2"] }, { merge: true });
-let r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing" }); check("step -> reviewing", r.status === 200);
+let r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing", confirm: "reviewing" }); check("step -> reviewing", r.status === 200);
 
 // ---- single-application status route ----
 for (const [who, c, body] of [["admin", adminC, { status: "interview" }], ["lead", bodyC, { status: "interview", systems: ["Body"] }], ["captain", capC, { status: "interview", systems: ["Body", "Dynamics"] }]]) {
@@ -75,7 +75,7 @@ check("bulk interview: draft item refused with draft error", r.status === 200 &&
 check("bulk interview: submitted item still advanced", item("dr-sub")?.success === true && (await get("dr-sub")).status === "interview", JSON.stringify(item("dr-sub")));
 r = await api(bodyC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2"], action: "reject", systems: ["Body"] });
 check("bulk reject by lead: draft refused", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || ""), JSON.stringify(item("dr-2")));
-await api(adminC, "POST", "/api/admin/config/recruiting", { step: "interviewing" });
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "interviewing", confirm: "interviewing" });
 r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2"], action: "trial" });
 check("bulk trial: draft refused", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || ""), `${r.status} ${JSON.stringify(item("dr-2") ?? r.json)}`);
 check("drafts untouched after bulk attempts", untouched(await get("dr-1")) && untouched(await get("dr-2")), `${S(await get("dr-1"))} | ${S(await get("dr-2"))}`);
@@ -87,11 +87,11 @@ r = await api(bodyC, "POST", "/api/admin/applications/dr-sub2/reject", { systems
 check("lead rejecting a SUBMITTED app still works", r.status === 200, `${r.status} ${r.json?.error || ""}`);
 
 // ---- the applicant can still edit and submit their draft (applications open) ----
-await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open" });
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open", confirm: "open" });
 r = await api(appC, "PATCH", "/api/applications/dr-1", { formData: { whyJoin: "still editing" } });
 check("applicant can still save the draft", r.status === 200 && (await get("dr-1")).formData?.whyJoin === "still editing", `${r.status} ${r.json?.error || ""}`);
 
-await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open" });
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open", confirm: "open" });
 const fails = results.filter((x) => !x).length;
 console.log(`\n${results.length - fails}/${results.length} checks passed`);
 process.exit(fails ? 1 : 0);

--- a/scripts/qa/rejection-regress.mjs
+++ b/scripts/qa/rejection-regress.mjs
@@ -36,7 +36,7 @@ async function api(cookie, method, path, body) {
 const now = () => new Date();
 const get = async (id) => (await db.doc(`applications/${id}`).get()).data();
 const reject = (c, id, systems) => api(c, "POST", `/api/admin/applications/${id}/reject`, { systems });
-const setStep = (c, step) => api(c, "POST", "/api/admin/config/recruiting", { step });
+const setStep = (c, step) => api(c, "POST", "/api/admin/config/recruiting", { step, confirm: step });
 const S = (a) => `${a.status}/rd=${a.reviewDecision ?? "-"}/id=${a.interviewDecision ?? "-"}/td=${a.trialDecision ?? "-"}/rb=${(a.rejectedBySystems || []).join("+") || "-"}`;
 const isPartial = (a) => a.status === "submitted" && a.reviewDecision !== "rejected";
 const isFull = (a) => a.status === "rejected" && a.reviewDecision === "rejected";

--- a/scripts/qa/transitions-regress.mjs
+++ b/scripts/qa/transitions-regress.mjs
@@ -1,0 +1,133 @@
+// Staff transition table (lib/utils/transitions.ts) end to end: which status
+// changes each role may make from which status at which step, on the single
+// status route, the reject route, and bulk — plus the offer/decision hygiene
+// around them (#104 #105 #106 #107 #108 #109 #110 #116 #117). Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/transitions-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const get = async (id) => (await db.doc(`applications/${id}`).get()).data();
+const status = (c, id, body) => api(c, "POST", `/api/admin/applications/${id}/status`, body);
+const reject = (c, id, systems) => api(c, "POST", `/api/admin/applications/${id}/reject`, { systems });
+const bulk = (c, body) => api(c, "POST", "/api/admin/applications/bulk-status", body);
+const setStep = (c, step, confirm) => api(c, "POST", "/api/admin/config/recruiting", confirm === undefined ? { step } : { step, confirm });
+const S = (a) => `${a.status}/rd=${a.reviewDecision ?? "-"}/id=${a.interviewDecision ?? "-"}/td=${a.trialDecision ?? "-"}/day=${a.trialDecisionDay ?? "-"}/io=${(a.interviewOffers || []).length}/to=${(a.trialOffers || []).length}/ps=${(a.preferredSystems || []).join("+")}`;
+const err = (r) => `${r.status} ${r.json?.error || ""}`;
+
+await ensureUser({ uid: "u-cap", email: "cap.e@utexas.edu", name: "Electric Captain", role: "team_captain_ob", memberProfile: { team: "Electric", system: "Electronics" } });
+await ensureUser({ uid: "u-body", email: "lead.body@utexas.edu", name: "Body Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+await ensureUser({ uid: "u-rev", email: "rev.body@utexas.edu", name: "Body Reviewer", role: "reviewer", memberProfile: { team: "Electric", system: "Body" } });
+await ensureUser({ uid: "u-tr", email: "tr@utexas.edu", name: "Transitioner", role: "applicant" });
+const adminC = await session("admin@utexas.edu"), capC = await session("cap.e@utexas.edu"), bodyC = await session("lead.body@utexas.edu"), revC = await session("rev.body@utexas.edu");
+const submittedAt = new Date(Date.now() - 48 * 3600e3);
+const mk = async (id, st, extra = {}) => { await db.doc(`applications/${id}`).set({ userId: "u-tr", userEmail: "tr@utexas.edu", team: "Electric", preferredSystems: ["Body", "Dynamics"], status: st, formData: { whyJoin: "x" }, createdAt: now(), updatedAt: now(), ...(st !== "in_progress" ? { submittedAt } : {}), ...extra }); };
+const off = (system, st = "pending") => ({ system, status: st, createdAt: now() });
+
+// ================= step order (#116) =================
+let r = await setStep(adminC, "open", "open"); check("reset -> open (typed)", r.status === 200);
+r = await setStep(adminC, "reviewing"); check("#116 forward one step without confirm -> 200", r.status === 200, err(r));
+r = await setStep(adminC, "reviewing"); check("#116 re-saving current step without confirm -> 200", r.status === 200, err(r));
+r = await setStep(adminC, "release_trial"); check("#116 skipping ahead without confirm -> 400 requiresConfirmation", r.status === 400 && r.json?.requiresConfirmation === true, err(r));
+r = await setStep(adminC, "release_trial", "wrong"); check("#116 skipping ahead with wrong confirm -> 400", r.status === 400, err(r));
+r = await setStep(adminC, "open"); check("#116 going back without confirm -> 400", r.status === 400, err(r));
+r = await setStep(adminC, "open", "open"); check("#116 going back with typed name -> 200", r.status === 200, err(r));
+
+// ================= at OPEN =================
+await mk("tr-sub", "submitted"); await mk("tr-sub2", "submitted"); await mk("tr-sub3", "submitted"); await mk("tr-sub4", "submitted");
+await mk("tr-com", "committed", { commitment: { accepted: true, committedAt: now() }, offer: { system: "Body", role: "Member", issuedAt: now() }, trialDecision: "advanced" });
+await mk("tr-dec", "declined", { commitment: { accepted: false, committedAt: now() } });
+await mk("tr-rej", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Body", "Dynamics"] });
+
+r = await status(adminC, "tr-sub", { status: "interview", systems: ["Body"] }); check("open: submitted -> interview allowed (#118 policy a)", r.status === 200 && (await get("tr-sub")).status === "interview", err(r));
+r = await status(adminC, "tr-sub2", { status: "trial", systems: ["Body"] }); check("open: submitted -> trial refused", r.status === 400 && /Can't move|Interviewing/.test(r.json?.error || ""), err(r));
+r = await status(adminC, "tr-sub2", { status: "accepted", offer: { system: "Body", role: "Member" } }); check("open: submitted -> accepted refused", r.status === 400 && /Can't move|Trial Workday/.test(r.json?.error || ""), err(r));
+r = await status(adminC, "tr-sub2", { status: "waitlisted", offer: { system: "Body" } }); check("open: -> waitlisted refused (step floor)", r.status === 400, err(r));
+for (const to of ["in_progress", "committed", "declined"]) {
+  r = await status(adminC, "tr-sub2", { status: to }); check(`#106 admin cannot set ${to} via /status`, r.status === 400 && /can't be set/i.test(r.json?.error || ""), err(r));
+}
+check("tr-sub2 untouched after refusals", (await get("tr-sub2")).status === "submitted", S(await get("tr-sub2")));
+r = await status(adminC, "tr-com", { status: "rejected" }); check("#105 committed applicant cannot be rejected", r.status === 400 && /already committed/i.test(r.json?.error || ""), err(r));
+r = await status(adminC, "tr-com", { status: "waitlisted", offer: { system: "Body" } }); check("#105 committed applicant cannot be waitlisted", r.status === 400, err(r));
+r = await reject(capC, "tr-com", ["Body"]); check("#105 committed applicant cannot be rejected via /reject either", r.status === 400 && /already committed/i.test(r.json?.error || ""), err(r));
+check("committed record untouched", (await get("tr-com")).status === "committed" && !!(await get("tr-com")).commitment, S(await get("tr-com")));
+r = await status(adminC, "tr-dec", { status: "interview", systems: ["Body"] }); check("#105 declined applicant cannot be re-advanced", r.status === 400 && /already declined/i.test(r.json?.error || ""), err(r));
+r = await status(revC, "tr-sub2", { status: "interview", systems: ["Body"] }); check("reviewer refused (403)", r.status === 403, err(r));
+r = await status(bodyC, "tr-sub2", { status: "rejected" }); check("#107 lead cannot reject via /status", r.status === 403 && /per system/i.test(r.json?.error || ""), err(r));
+check("#107 nothing written by the refused lead reject", (await get("tr-sub2")).status === "submitted" && !(await get("tr-sub2")).rejectedBySystems);
+r = await reject(bodyC, "tr-sub2", ["Body"]); check("#107 lead per-system /reject still works", r.status === 200 && (await get("tr-sub2")).rejectedBySystems?.join() === "Body" && (await get("tr-sub2")).status === "submitted", `${err(r)} ${S(await get("tr-sub2"))}`);
+r = await status(adminC, "tr-sub3", { status: "rejected" }); check("admin full reject via /status -> rejected", r.status === 200 && (await get("tr-sub3")).status === "rejected", err(r));
+r = await status(adminC, "tr-rej", { status: "interview", systems: ["Body"] }); check("rejected -> interview (change of mind) allowed", r.status === 200 && (await get("tr-rej")).status === "interview", err(r));
+
+// #104: unranked system joins the ranking, original preserved
+r = await status(capC, "tr-sub4", { status: "interview", systems: ["Electronics"] });
+let a = await get("tr-sub4");
+check("#104 captain offers an UNRANKED system -> 200", r.status === 200, err(r));
+check("#104 offered system appended to preferredSystems; original kept", a.preferredSystems?.join("+") === "Body+Dynamics+Electronics" && a.originalPreferredSystems?.join("+") === "Body+Dynamics", S(a));
+
+// #108: revert to submitted is complete and keeps submittedAt / original ranking
+const before = (await get("tr-sub4")).submittedAt.toMillis();
+r = await status(bodyC, "tr-sub4", { status: "submitted" }); check("#108 lead cannot revert to submitted (403)", r.status === 403, err(r));
+r = await status(capC, "tr-sub4", { status: "submitted" }); a = await get("tr-sub4");
+check("#108 captain revert -> submitted, offers cleared, ranking restored", r.status === 200 && a.status === "submitted" && (a.interviewOffers || []).length === 0 && a.preferredSystems?.join("+") === "Body+Dynamics" && a.reviewDecision === "pending", `${err(r)} ${S(a)}`);
+check("#108 revert keeps the original submittedAt", a.submittedAt.toMillis() === before, `${a.submittedAt.toMillis()} vs ${before}`);
+r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "submitted" }); a = await get("tr-sub");
+check("#108 bulk revert -> full reset too", r.status === 200 && a.status === "submitted" && (a.interviewOffers || []).length === 0 && a.submittedAt.toMillis() === submittedAt.getTime(), S(a));
+
+// #110: bulk accept is gone
+r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "accept" }); check("#110 bulk accept -> 400 invalid action", r.status === 400, err(r));
+r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "waitlist" }); check("bulk waitlist at open -> 400 step floor", r.status === 400, err(r));
+
+// ================= INTERVIEWING =================
+r = await setStep(adminC, "interviewing", "interviewing"); check("step -> interviewing", r.status === 200);
+await mk("tr-int", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body", "completed")] });
+await mk("tr-int2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body", "completed")], trialDecision: "rejected", trialDecisionDay: 1 });
+r = await status(adminC, "tr-int", { status: "trial", systems: ["Body"] }); check("interviewing: interview -> trial allowed", r.status === 200 && (await get("tr-int")).status === "trial", err(r));
+r = await status(adminC, "tr-int2", { status: "trial", systems: ["Body"] }); a = await get("tr-int2");
+check("#109 trial offer clears an earlier trialDecision/day", r.status === 200 && a.trialDecision === undefined && a.trialDecisionDay === undefined && a.status === "trial", S(a));
+r = await status(adminC, "tr-sub", { status: "trial", systems: ["Body"] }); check("interviewing: submitted -> trial refused (from-status)", r.status === 400 && /Can't move/.test(r.json?.error || ""), err(r));
+r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "trial" }); check("bulk trial on a submitted app -> per-item refusal", r.status === 200 && r.json?.results?.[0]?.success === false && /Can't move/.test(r.json?.results?.[0]?.error || ""), JSON.stringify(r.json?.results?.[0]));
+r = await status(adminC, "tr-int", { status: "waitlisted", offer: { system: "Body" } }); check("interviewing: -> waitlisted refused (step floor)", r.status === 400, err(r));
+
+// ================= TRIAL WORKDAY =================
+r = await setStep(adminC, "trial_workday", "trial_workday"); check("step -> trial_workday (typed skip)", r.status === 200);
+r = await status(adminC, "tr-int", { status: "waitlisted", offer: { system: "Body" } }); a = await get("tr-int");
+check("#117 waitlist persists the chosen system", r.status === 200 && a.status === "waitlisted" && a.waitlistSystem === "Body" && a.trialDecision === "waitlisted", S(a) + ` ws=${a.waitlistSystem}`);
+r = await status(adminC, "tr-int", { status: "accepted", offer: { system: "Body", role: "Member" } }); a = await get("tr-int");
+check("waitlisted -> accepted with offer", r.status === 200 && a.status === "accepted" && a.offer?.system === "Body", S(a));
+r = await status(adminC, "tr-int", { status: "rejected" }); a = await get("tr-int");
+check("accepted -> rejected (rescind) withdraws the offer", r.status === 200 && a.status === "rejected" && !a.offer, S(a));
+r = await status(bodyC, "tr-int2", { status: "accepted", offer: { system: "Dynamics", role: "Member" } }); check("lead accepting into another system -> 403 (existing fence)", r.status === 403, err(r));
+r = await status(bodyC, "tr-int2", { status: "accepted", offer: { system: "Body", role: "Member" } }); check("lead accepting into own system -> 200", r.status === 200 && (await get("tr-int2")).status === "accepted", err(r));
+
+await setStep(adminC, "open", "open");
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);

--- a/scripts/qa/transitions-regress.mjs
+++ b/scripts/qa/transitions-regress.mjs
@@ -86,6 +86,8 @@ r = await reject(bodyC, "tr-sub2", ["Body"]); check("#107 lead per-system /rejec
 r = await status(adminC, "tr-sub3", { status: "rejected" }); check("admin full reject via /status -> rejected", r.status === 200 && (await get("tr-sub3")).status === "rejected", err(r));
 r = await status(adminC, "tr-rej", { status: "interview", systems: ["Body"] }); check("rejected -> interview (change of mind) allowed", r.status === 200 && (await get("tr-rej")).status === "interview", err(r));
 r = await reject(capC, "tr-sub3", ["Dynamics"]); check("F3 re-rejecting an already rejected application -> 200 (idempotent)", r.status === 200, err(r));
+r = await status(capC, "tr-sub2", { status: "submitted" }); const revA = await get("tr-sub2");
+check("C2 revert of a partially rejected (still submitted) application -> 200, rejectedBySystems cleared", r.status === 200 && revA.status === "submitted" && (revA.rejectedBySystems || []).length === 0, `${err(r)} ${S(revA)}`);
 const appC = await session("tr@utexas.edu");
 const stampBefore = (await get("tr-sub2")).submittedAt.toMillis();
 await new Promise((res) => setTimeout(res, 20));
@@ -120,6 +122,10 @@ await mk("tr-int2", "interview", { reviewDecision: "advanced", interviewOffers: 
 r = await status(adminC, "tr-int", { status: "trial", systems: ["Body"] }); check("interviewing: interview -> trial allowed", r.status === 200 && (await get("tr-int")).status === "trial", err(r));
 r = await status(adminC, "tr-int2", { status: "trial", systems: ["Body"] }); a = await get("tr-int2");
 check("#109 trial offer clears an earlier trialDecision/day", r.status === 200 && a.trialDecision === undefined && a.trialDecisionDay === undefined && a.status === "trial", S(a));
+await mk("tr-unrej", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Body", "Dynamics"] });
+r = await status(adminC, "tr-unrej", { status: "trial", systems: ["Body"] }); a = await get("tr-unrej");
+check("C3 rejected -> trial clears the stale reviewDecision", r.status === 200 && a.status === "trial" && a.reviewDecision === "advanced" && a.trialDecision === undefined, `${err(r)} ${S(a)}`);
+check("C5 trial-offer response does not carry the deleted decision", r.json?.application?.trialDecision === undefined && r.json?.application?.trialDecisionDay === undefined, JSON.stringify([r.json?.application?.trialDecision, r.json?.application?.trialDecisionDay]));
 await mk("tr-fast", "submitted");
 r = await status(adminC, "tr-fast", { status: "trial", systems: ["Body"] }); check("F8 interviewing: submitted -> trial fast-track with an explicit system", r.status === 200 && (await get("tr-fast")).status === "trial", err(r));
 r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "trial" }); check("bulk trial on a submitted app with no interview -> per-item refusal", r.status === 200 && r.json?.results?.[0]?.success === false, JSON.stringify(r.json?.results?.[0]));
@@ -131,6 +137,16 @@ r = await status(adminC, "tr-int", { status: "waitlisted", offer: { system: "Bod
 check("#117 waitlist persists the chosen system", r.status === 200 && a.status === "waitlisted" && a.waitlistSystem === "Body" && a.trialDecision === "waitlisted", S(a) + ` ws=${a.waitlistSystem}`);
 r = await status(adminC, "tr-int", { status: "accepted", offer: { system: "Body", role: "Member" } }); a = await get("tr-int");
 check("F1 waitlisted -> accepted with offer works at release_trial", r.status === 200 && a.status === "accepted" && a.offer?.system === "Body", S(a));
+const appTrC = await session("tr@utexas.edu");
+r = await api(appTrC, "GET", "/api/applications/tr-int");
+check("C1 waitlistSystem never reaches the applicant payload", r.status === 200 && !("waitlistSystem" in (r.json?.application || {})), JSON.stringify(Object.keys(r.json?.application || {}).filter((k) => /waitlist/i.test(k))));
+check("C1 waitlistSystem cleared once the applicant left the waitlist", (await get("tr-int")).waitlistSystem === undefined, JSON.stringify((await get("tr-int")).waitlistSystem));
+await mk("tr-strag", "submitted");
+r = await status(adminC, "tr-strag", { status: "waitlisted", offer: { system: "Body" } }); a = await get("tr-strag");
+check("C4 a straggler still at submitted can be waitlisted at release_trial", r.status === 200 && a.status === "waitlisted" && a.waitlistSystem === "Body", `${err(r)} ${S(a)}`);
+await mk("tr-unrej2", "rejected", { reviewDecision: "advanced", interviewDecision: "rejected", interviewOffers: [off("Body", "completed")] });
+r = await status(adminC, "tr-unrej2", { status: "accepted", offer: { system: "Body", role: "Member" } }); a = await get("tr-unrej2");
+check("C3 rejected -> accepted clears the stale interviewDecision", r.status === 200 && a.status === "accepted" && a.interviewDecision === "advanced" && a.trialDecision === "advanced", `${err(r)} ${S(a)}`);
 await mk("tr-wl", "waitlisted", { reviewDecision: "advanced", interviewDecision: "advanced", trialDecision: "waitlisted", trialDecisionDay: 1, trialOffers: [{ system: "Body", status: "completed", createdAt: now() }] });
 r = await status(adminC, "tr-wl", { status: "trial", systems: ["Body"] }); check("F6 waitlisted -> trial refused (would un-reveal the decision)", r.status === 400 && (await get("tr-wl")).trialDecision === "waitlisted", err(r));
 r = await status(adminC, "tr-int", { status: "rejected" }); a = await get("tr-int");

--- a/scripts/qa/transitions-regress.mjs
+++ b/scripts/qa/transitions-regress.mjs
@@ -85,6 +85,12 @@ check("#107 nothing written by the refused lead reject", (await get("tr-sub2")).
 r = await reject(bodyC, "tr-sub2", ["Body"]); check("#107 lead per-system /reject still works", r.status === 200 && (await get("tr-sub2")).rejectedBySystems?.join() === "Body" && (await get("tr-sub2")).status === "submitted", `${err(r)} ${S(await get("tr-sub2"))}`);
 r = await status(adminC, "tr-sub3", { status: "rejected" }); check("admin full reject via /status -> rejected", r.status === 200 && (await get("tr-sub3")).status === "rejected", err(r));
 r = await status(adminC, "tr-rej", { status: "interview", systems: ["Body"] }); check("rejected -> interview (change of mind) allowed", r.status === 200 && (await get("tr-rej")).status === "interview", err(r));
+r = await reject(capC, "tr-sub3", ["Dynamics"]); check("F3 re-rejecting an already rejected application -> 200 (idempotent)", r.status === 200, err(r));
+const appC = await session("tr@utexas.edu");
+const stampBefore = (await get("tr-sub2")).submittedAt.toMillis();
+await new Promise((res) => setTimeout(res, 20));
+r = await api(appC, "PATCH", "/api/applications/tr-sub2", { formData: { whyJoin: "edited after submit" } });
+check("F2 applicant edit while submitted re-stamps submittedAt", r.status === 200 && (await get("tr-sub2")).submittedAt.toMillis() > stampBefore, err(r));
 
 // #104: unranked system joins the ranking, original preserved
 r = await status(capC, "tr-sub4", { status: "interview", systems: ["Electronics"] });
@@ -93,11 +99,13 @@ check("#104 captain offers an UNRANKED system -> 200", r.status === 200, err(r))
 check("#104 offered system appended to preferredSystems; original kept", a.preferredSystems?.join("+") === "Body+Dynamics+Electronics" && a.originalPreferredSystems?.join("+") === "Body+Dynamics", S(a));
 
 // #108: revert to submitted is complete and keeps submittedAt / original ranking
+await db.doc("applications/tr-sub4").update({ emailsSent: ["interview_offer"] });
 const before = (await get("tr-sub4")).submittedAt.toMillis();
 r = await status(bodyC, "tr-sub4", { status: "submitted" }); check("#108 lead cannot revert to submitted (403)", r.status === 403, err(r));
 r = await status(capC, "tr-sub4", { status: "submitted" }); a = await get("tr-sub4");
 check("#108 captain revert -> submitted, offers cleared, ranking restored", r.status === 200 && a.status === "submitted" && (a.interviewOffers || []).length === 0 && a.preferredSystems?.join("+") === "Body+Dynamics" && a.reviewDecision === "pending", `${err(r)} ${S(a)}`);
 check("#108 revert keeps the original submittedAt", a.submittedAt.toMillis() === before, `${a.submittedAt.toMillis()} vs ${before}`);
+check("F5 revert clears emailsSent so stage emails re-send", a.emailsSent === undefined, JSON.stringify(a.emailsSent));
 r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "submitted" }); a = await get("tr-sub");
 check("#108 bulk revert -> full reset too", r.status === 200 && a.status === "submitted" && (a.interviewOffers || []).length === 0 && a.submittedAt.toMillis() === submittedAt.getTime(), S(a));
 
@@ -112,16 +120,19 @@ await mk("tr-int2", "interview", { reviewDecision: "advanced", interviewOffers: 
 r = await status(adminC, "tr-int", { status: "trial", systems: ["Body"] }); check("interviewing: interview -> trial allowed", r.status === 200 && (await get("tr-int")).status === "trial", err(r));
 r = await status(adminC, "tr-int2", { status: "trial", systems: ["Body"] }); a = await get("tr-int2");
 check("#109 trial offer clears an earlier trialDecision/day", r.status === 200 && a.trialDecision === undefined && a.trialDecisionDay === undefined && a.status === "trial", S(a));
-r = await status(adminC, "tr-sub", { status: "trial", systems: ["Body"] }); check("interviewing: submitted -> trial refused (from-status)", r.status === 400 && /Can't move/.test(r.json?.error || ""), err(r));
-r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "trial" }); check("bulk trial on a submitted app -> per-item refusal", r.status === 200 && r.json?.results?.[0]?.success === false && /Can't move/.test(r.json?.results?.[0]?.error || ""), JSON.stringify(r.json?.results?.[0]));
+await mk("tr-fast", "submitted");
+r = await status(adminC, "tr-fast", { status: "trial", systems: ["Body"] }); check("F8 interviewing: submitted -> trial fast-track with an explicit system", r.status === 200 && (await get("tr-fast")).status === "trial", err(r));
+r = await bulk(adminC, { applicationIds: ["tr-sub"], action: "trial" }); check("bulk trial on a submitted app with no interview -> per-item refusal", r.status === 200 && r.json?.results?.[0]?.success === false, JSON.stringify(r.json?.results?.[0]));
 r = await status(adminC, "tr-int", { status: "waitlisted", offer: { system: "Body" } }); check("interviewing: -> waitlisted refused (step floor)", r.status === 400, err(r));
 
-// ================= TRIAL WORKDAY =================
-r = await setStep(adminC, "trial_workday", "trial_workday"); check("step -> trial_workday (typed skip)", r.status === 200);
+// ================= RELEASE TRIAL (decision mode starts here) =================
+r = await setStep(adminC, "release_trial", "release_trial"); check("step -> release_trial (typed skip)", r.status === 200);
 r = await status(adminC, "tr-int", { status: "waitlisted", offer: { system: "Body" } }); a = await get("tr-int");
 check("#117 waitlist persists the chosen system", r.status === 200 && a.status === "waitlisted" && a.waitlistSystem === "Body" && a.trialDecision === "waitlisted", S(a) + ` ws=${a.waitlistSystem}`);
 r = await status(adminC, "tr-int", { status: "accepted", offer: { system: "Body", role: "Member" } }); a = await get("tr-int");
-check("waitlisted -> accepted with offer", r.status === 200 && a.status === "accepted" && a.offer?.system === "Body", S(a));
+check("F1 waitlisted -> accepted with offer works at release_trial", r.status === 200 && a.status === "accepted" && a.offer?.system === "Body", S(a));
+await mk("tr-wl", "waitlisted", { reviewDecision: "advanced", interviewDecision: "advanced", trialDecision: "waitlisted", trialDecisionDay: 1, trialOffers: [{ system: "Body", status: "completed", createdAt: now() }] });
+r = await status(adminC, "tr-wl", { status: "trial", systems: ["Body"] }); check("F6 waitlisted -> trial refused (would un-reveal the decision)", r.status === 400 && (await get("tr-wl")).trialDecision === "waitlisted", err(r));
 r = await status(adminC, "tr-int", { status: "rejected" }); a = await get("tr-int");
 check("accepted -> rejected (rescind) withdraws the offer", r.status === 200 && a.status === "rejected" && !a.offer, S(a));
 r = await status(bodyC, "tr-int2", { status: "accepted", offer: { system: "Dynamics", role: "Member" } }); check("lead accepting into another system -> 403 (existing fence)", r.status === 403, err(r));


### PR DESCRIPTION
Tier 1 of the landmine audit that followed the premature-advance incident (#103). One transition table, consulted by every staff route that changes an application's status, plus the offer/decision hygiene around it.

## What changes

**`lib/utils/transitions.ts` — the allowed-transition table.** For each target status: which statuses it may come from, the earliest recruiting step, and which roles. Consulted by the single-application status route, the bulk route, and the reject route. Never staff-settable: `in_progress`, `committed`, `declined`. Never changeable: applications already `committed` or `declined`.

| Issue | Fix |
|---|---|
| #105 | Source-status and step floors on the single route (bulk already had floors; the two now agree — accept/waitlist from `release_trial`, where the detail view's decision mode starts) |
| #106 | `committed` / `declined` / `in_progress` refused as targets |
| #107 | System leads can't reject through `/status` (team-wide); they use `/reject`, which is per-system. Bulk reject stays lead-scoped |
| #104 | Unranked-system offers are **kept** (intended per @dhairs) — the offered system now joins `preferredSystems` so its lead can see the applicant, with the applicant's own order preserved in `originalPreferredSystems`. Bulk stays strict on purpose (#54) |
| #108 | Revert-to-Submitted is a full reset (offers, decisions, decision day, commitment, waitlist system, `emailsSent`, `renegedFrom`, auto-reject marker), restores the applicant's original ranking, and **keeps `submittedAt`**. Captains and admins only (it wipes every system's work); the bulk button is hidden for leads |
| #109 | A trial offer clears a prior `trialDecision` / `trialDecisionDay` |
| #110 | Bulk Accept removed — an acceptance carries a per-applicant offer that someone has to choose |
| #117 | Waitlist modal's system persisted as `waitlistSystem` |
| #116 | Recruiting step order enforced server-side: forward one step at a time (light confirm in the UI), re-saving the current step allowed (sweep recovery), skipping ahead or going back requires typing the step name |

Policy decisions applied: #118 (a) advancing during `open` stays allowed. #113 is PR 2.

## Independent review

An Opus review pass on the first cut found 11 items; all addressed except one kept deliberately:
- Accept/waitlist floor was `trial_workday` while the UI offers decisions from `release_trial` → floor moved to `release_trial` (both routes)
- `submittedAt` no longer re-stamped on applicant edits → reverted; the applicant route relies on that. `revertToSubmitted` keeps the original date on its own
- `/reject` refused already-rejected applications → `rejected → rejected` allowed (idempotent per-system rejections)
- Bulk Revert shown to leads who'd always 403 → hidden; draft force-submit wording fixed
- Revert didn't clear `emailsSent` → re-advanced applicants would never get stage emails again → cleared
- `waitlisted → trial` would delete a released waitlist decision → removed from the table
- `submitted → trial` fast-track restored; `trial → interview` deliberately **not** added (would leave stale trial offers visible to the applicant — Revert is the undo path)
- Double confirmation on out-of-order moves to a release step → fixed
- Duplicate `waitlistSystem` block, reject route cache invalidation, toolbar naming → fixed
- Kept: bulk still intersects requested systems with the ranking (stamping an unranked system across a selection is the accident case; the single route is the deliberate one-off)

## Verification

- `scripts/qa/transitions-regress.mjs` (committed) — **50 checks**: every from×to×role×step cell that matters, the reject route, bulk per-item refusals, revert completeness and `submittedAt` preservation, unranked-offer ranking join, trial-decision clearing, waitlist system, step-order enforcement, applicant re-stamp, idempotent re-reject
- Existing harnesses unchanged in outcome: rejection 27/27, drafts 20/20, bulk 12/12, sweeps 20/20, stats 28/28
- `npx tsc --noEmit` and `npm run build` clean

## Migration / data

No data migration. Existing applications are unaffected until the next staff action on them.
