### PR TITLE
fix: applicant-side gates (landmine audit tier 2)

### DIFF
--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -33,6 +33,7 @@ import { useApplicationsLayout } from "./ApplicationsLayoutContext";
 import ApplicationScorecard from "./ApplicationScorecard";
 import InterviewScorecard from "./InterviewScorecard";
 import { TEAM_COLORS } from "@/lib/teamColors";
+import { getStaffDisplayStatus, formatElsewhere } from "@/lib/utils/staffDisplayStatus";
 
 // Helper to check if recruiting step is at or past a certain stage
 const RECRUITING_STEP_ORDER: RecruitingStep[] = [
@@ -929,6 +930,10 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
           </div>
 
           {(() => {
+            // Presentation only — the pipeline bar and status box show the
+            // viewer's per-system status (see getStaffDisplayStatus). Every
+            // action below still keys on the real selectedApp.status.
+            const display = getStaffDisplayStatus(selectedApp, currentUser);
             const statusOrder = [
               ApplicationStatus.IN_PROGRESS,
               ApplicationStatus.SUBMITTED,
@@ -936,8 +941,8 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
               ApplicationStatus.TRIAL,
               ApplicationStatus.ACCEPTED,
             ];
-            const currentIndex = statusOrder.indexOf(selectedApp.status);
-            const isRejected = selectedApp.status === ApplicationStatus.REJECTED;
+            const currentIndex = statusOrder.indexOf(display.status);
+            const isRejected = display.status === ApplicationStatus.REJECTED;
             const progressPercent = isRejected ? 0 : ((currentIndex + 1) / statusOrder.length) * 100;
 
             return (
@@ -957,22 +962,29 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                     }}
                   />
                 </div>
+                <div
+                  className="rounded-lg p-3 font-urbanist text-[13px] font-semibold flex justify-between items-center gap-3 mb-4"
+                  style={
+                    display.status === ApplicationStatus.REJECTED
+                      ? { backgroundColor: "rgba(239,68,68,0.08)", color: "rgba(239,68,68,0.8)", border: "1px solid rgba(239,68,68,0.18)" }
+                      : display.status === ApplicationStatus.ACCEPTED
+                        ? { backgroundColor: "rgba(34,197,94,0.08)", color: "rgba(34,197,94,0.8)", border: "1px solid rgba(34,197,94,0.18)" }
+                        : { backgroundColor: "rgba(255,255,255,0.03)", color: "white", border: "1px solid rgba(255,255,255,0.06)" }
+                  }
+                >
+                  <span>{getStatusLabel(display.status)}</span>
+                  {display.elsewhere && (
+                    <span
+                      className="text-[11px] font-normal text-white/40 truncate"
+                      title="Another system has taken this applicant further than yours has"
+                    >
+                      {formatElsewhere(display.elsewhere)}
+                    </span>
+                  )}
+                </div>
               </>
             );
           })()}
-
-          <div
-            className="rounded-lg p-3 font-urbanist text-[13px] font-semibold flex justify-between items-center mb-4"
-            style={
-              selectedApp.status === ApplicationStatus.REJECTED
-                ? { backgroundColor: "rgba(239,68,68,0.08)", color: "rgba(239,68,68,0.8)", border: "1px solid rgba(239,68,68,0.18)" }
-                : selectedApp.status === ApplicationStatus.ACCEPTED
-                  ? { backgroundColor: "rgba(34,197,94,0.08)", color: "rgba(34,197,94,0.8)", border: "1px solid rgba(34,197,94,0.18)" }
-                  : { backgroundColor: "rgba(255,255,255,0.03)", color: "white", border: "1px solid rgba(255,255,255,0.06)" }
-            }
-          >
-            <span>{getStatusLabel(selectedApp.status)}</span>
-          </div>
 
           {/* Only show Advance/Reject buttons for non-reviewers */}
           {currentUser?.role !== UserRole.REVIEWER && (() => {

--- a/app/admin/applications/_components/ApplicationsSidebar.tsx
+++ b/app/admin/applications/_components/ApplicationsSidebar.tsx
@@ -17,6 +17,7 @@ import FullScreenListView from "./FullScreenListView";
 import { createPortal } from "react-dom";
 import toast from "react-hot-toast";
 import { TEAM_COLORS as TEAM_DOT_COLORS } from "@/lib/teamColors";
+import { getStaffDisplayStatus, formatElsewhere } from "@/lib/utils/staffDisplayStatus";
 
 // Helper to check if recruiting step is at or past a certain stage
 const RECRUITING_STEP_ORDER: RecruitingStep[] = [
@@ -100,41 +101,6 @@ const STATUS_LABELS: Record<string, string> = {
 
 function getStatusLabel(status: string): string {
   return STATUS_LABELS[status] || status;
-}
-
-function getDisplayStatusForUser(
-  app: any,
-  user: any
-): ApplicationStatus {
-  if (!user ||
-      user.role === UserRole.ADMIN ||
-      user.role === UserRole.TEAM_CAPTAIN_OB) {
-    return app.status;
-  }
-
-  const userSystem = user.memberProfile?.system;
-  if (!userSystem) {
-    return app.status;
-  }
-
-  const rejectedBySystems = app.rejectedBySystems || [];
-  const userSystemRejected = rejectedBySystems.includes(userSystem);
-
-  if (userSystemRejected) {
-    return ApplicationStatus.REJECTED;
-  }
-
-  if (app.status === ApplicationStatus.REJECTED) {
-    if (app.trialOffers && app.trialOffers.length > 0) {
-      return ApplicationStatus.TRIAL;
-    }
-    if (app.interviewOffers && app.interviewOffers.length > 0) {
-      return ApplicationStatus.INTERVIEW;
-    }
-    return ApplicationStatus.SUBMITTED;
-  }
-
-  return app.status;
 }
 
 // Filter pill component
@@ -301,10 +267,12 @@ export default function ApplicationsSidebar() {
 
   const filteredApplications = applications.filter(app => {
     // Note: name/email search is now handled server-side
-    // Filter on the status the lead actually sees (their own system's
-    // rejection shows as Rejected even while the application is alive for
-    // other systems), otherwise the Rejected chip never matches those rows.
-    const matchesStatus = statusFilters.length === 0 || statusFilters.includes(getDisplayStatusForUser(app, currentUser));
+    // Filter on the status the viewer actually sees: for a lead/reviewer that
+    // is their own system's decision (see getStaffDisplayStatus), so the
+    // "Submitted" chip is their unreviewed queue even when another system has
+    // already advanced the applicant, and the "Rejected" chip matches their
+    // own rejections while the application is alive for other systems.
+    const matchesStatus = statusFilters.length === 0 || statusFilters.includes(getStaffDisplayStatus(app, currentUser).status);
     const appSystems = app.preferredSystems || [];
     const matchesSystem = systemFilters.length === 0 || appSystems.some(s => systemFilters.includes(s));
     const matchesTeam = teamFilters.length === 0 || teamFilters.includes(app.team);
@@ -668,6 +636,7 @@ export default function ApplicationsSidebar() {
       <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
          {filteredApplications.map(app => {
            const teamColor = TEAM_DOT_COLORS[app.team] || "var(--lhr-blue)";
+           const display = getStaffDisplayStatus(app, currentUser);
            return (
              <Link
                key={app.id}
@@ -704,7 +673,17 @@ export default function ApplicationsSidebar() {
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <StatusBadge status={getDisplayStatusForUser(app, currentUser)} />
+                  <StatusBadge status={display.status} />
+                  {display.elsewhere && (
+                    // Context the per-system badge no longer carries: another
+                    // system has taken this applicant further than ours has.
+                    <span
+                      className="text-[10px] font-urbanist text-white/35 truncate"
+                      title={`Another system has taken this applicant further: ${formatElsewhere(display.elsewhere)}`}
+                    >
+                      {formatElsewhere(display.elsewhere)}
+                    </span>
+                  )}
                   {/* Cross-team badges */}
                   {app.otherTeams && app.otherTeams.length > 0 && (
                     <span

--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -9,6 +9,7 @@ import { format } from "date-fns";
 import { Search, Star, MessageSquare, Users, X, CheckSquare, Square, Loader2, AlertCircle, Check, ChevronDown, ChevronRight, LayoutList, Layers } from "lucide-react";
 import clsx from "clsx";
 import { TEAM_COLORS as TEAM_DOT_COLORS } from "@/lib/teamColors";
+import { getStaffDisplayStatus, formatElsewhere } from "@/lib/utils/staffDisplayStatus";
 
 
 
@@ -47,17 +48,24 @@ function StatusBadge({ status }: { status: ApplicationStatus }) {
   );
 }
 
-function getDisplayStatusForUser(app: any, user: any): ApplicationStatus {
-  if (!user || user.role === UserRole.ADMIN || user.role === UserRole.TEAM_CAPTAIN_OB) return app.status;
-  const userSystem = user.memberProfile?.system;
-  if (!userSystem) return app.status;
-  if (app.rejectedBySystems?.includes(userSystem)) return ApplicationStatus.REJECTED;
-  if (app.status === ApplicationStatus.REJECTED) {
-    if (app.trialOffers?.length > 0) return ApplicationStatus.TRIAL;
-    if (app.interviewOffers?.length > 0) return ApplicationStatus.INTERVIEW;
-    return ApplicationStatus.SUBMITTED;
-  }
-  return app.status;
+// The viewer's per-system status (see getStaffDisplayStatus) plus the hint
+// when another system has taken the applicant further. Same rendering as the
+// sidebar rows.
+function StatusCell({ app, user }: { app: any; user: any }) {
+  const display = getStaffDisplayStatus(app, user);
+  return (
+    <span className="inline-flex items-center gap-2 min-w-0">
+      <StatusBadge status={display.status} />
+      {display.elsewhere && (
+        <span
+          className="font-urbanist text-[10px] text-white/35 truncate"
+          title={`Another system has taken this applicant further: ${formatElsewhere(display.elsewhere)}`}
+        >
+          {formatElsewhere(display.elsewhere)}
+        </span>
+      )}
+    </span>
+  );
 }
 
 type BulkAction = "reject" | "waitlist" | "interview" | "trial" | "submitted";
@@ -339,7 +347,7 @@ export default function FullScreenListView(props: Props) {
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <StatusBadge status={getDisplayStatusForUser(app, currentUser)} />
+                    <StatusCell app={app} user={currentUser} />
                   </td>
                   <td className="px-4 py-3">
                     {app.otherTeams?.length > 0 ? (
@@ -473,7 +481,7 @@ export default function FullScreenListView(props: Props) {
                           </span>
                         </td>
                         <td className="px-4 py-2">
-                          <StatusBadge status={getDisplayStatusForUser(app, currentUser)} />
+                          <StatusCell app={app} user={currentUser} />
                         </td>
                         <td className="px-4 py-2"></td>
                         {canSeeRatings && (

--- a/app/admin/users/_components/UsersPageClient.tsx
+++ b/app/admin/users/_components/UsersPageClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { User, UserRole, Team, ElectricSystem, SolarSystem, CombustionSystem } from "@/lib/models/User";
 import { Loader2, Search, Edit2, Users, Shield, X, ChevronDown } from "lucide-react";
+import { useUser } from "@/hooks/useUser";
 
 const teamColors: Record<string, { bg: string; border: string; text: string; dot: string }> = {
   Electric: {
@@ -63,6 +64,11 @@ const roleLabels: Record<string, string> = {
 };
 
 export function UsersPageClient() {
+  // Role changes are admin-only (server-enforced); captains manage their own
+  // team's roster. The form must not even offer the role field to a captain,
+  // and must never send it, or the server refuses the whole save.
+  const { user: me } = useUser();
+  const canEditRoles = me?.role === UserRole.ADMIN;
   const [users, setUsers] = useState<User[]>([]);
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -133,7 +139,7 @@ export function UsersPageClient() {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          role: editForm.role,
+          ...(canEditRoles && editForm.role !== editingUser.role ? { role: editForm.role } : {}),
           team: editForm.team || null,
           system: editForm.system || null,
         }),
@@ -144,7 +150,7 @@ export function UsersPageClient() {
           if (u.uid === editingUser.uid) {
             return {
               ...u,
-              role: editForm.role,
+              role: canEditRoles ? editForm.role : u.role,
               memberProfile: editForm.team
                 ? {
                     team: editForm.team as Team,
@@ -160,7 +166,10 @@ export function UsersPageClient() {
         setEditingUser(null);
         toast.success("User updated");
       } else {
-        toast.error("Failed to update user");
+        // Surface the server's reason — "only admins can update roles",
+        // "you can only manage users on your own team" — not a generic line.
+        const body = await res.json().catch(() => ({}));
+        toast.error(body?.error || "Failed to update user");
       }
     } catch (error) {
       console.error(error);
@@ -610,32 +619,48 @@ export function UsersPageClient() {
                   >
                     Role
                   </label>
-                  <div className="relative">
-                    <select
-                      value={editForm.role}
-                      onChange={(e) =>
-                        setEditForm({
-                          ...editForm,
-                          role: e.target.value as UserRole,
-                        })
-                      }
-                      className="w-full h-10 rounded-lg px-3 pr-9 text-[13px] font-urbanist text-white appearance-none focus:outline-none transition-colors duration-200"
+                  {canEditRoles ? (
+                    <div className="relative">
+                      <select
+                        value={editForm.role}
+                        onChange={(e) =>
+                          setEditForm({
+                            ...editForm,
+                            role: e.target.value as UserRole,
+                          })
+                        }
+                        className="w-full h-10 rounded-lg px-3 pr-9 text-[13px] font-urbanist text-white appearance-none focus:outline-none transition-colors duration-200"
+                        style={{
+                          backgroundColor: "rgba(255,255,255,0.03)",
+                          border: "1px solid rgba(255,255,255,0.08)",
+                        }}
+                      >
+                        {Object.values(UserRole).map((role) => (
+                          <option key={role} value={role} style={{ backgroundColor: "#0c1218", color: "white" }}>
+                            {roleLabels[role] || role}
+                          </option>
+                        ))}
+                      </select>
+                      <ChevronDown
+                        className="absolute right-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 pointer-events-none"
+                        style={{ color: "rgba(255,255,255,0.20)" }}
+                      />
+                    </div>
+                  ) : (
+                    <div
+                      className="w-full h-10 rounded-lg px-3 flex items-center gap-2 text-[13px] font-urbanist text-white/60"
                       style={{
                         backgroundColor: "rgba(255,255,255,0.03)",
                         border: "1px solid rgba(255,255,255,0.08)",
                       }}
+                      title="Only admins can change roles"
                     >
-                      {Object.values(UserRole).map((role) => (
-                        <option key={role} value={role} style={{ backgroundColor: "#0c1218", color: "white" }}>
-                          {roleLabels[role] || role}
-                        </option>
-                      ))}
-                    </select>
-                    <ChevronDown
-                      className="absolute right-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 pointer-events-none"
-                      style={{ color: "rgba(255,255,255,0.20)" }}
-                    />
-                  </div>
+                      {roleLabels[editForm.role] || editForm.role}
+                      <span className="ml-auto text-[10px] font-semibold tracking-widest uppercase text-white/30">
+                        Admin only
+                      </span>
+                    </div>
+                  )}
                 </div>
 
                 {/* Team */}

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -59,6 +59,11 @@ export async function PATCH(
       const valid =
         Array.isArray(ranking) &&
         ranking.length <= 3 &&
+        // Clearing the ranking on the same team stays allowed (matches the
+        // applicant route), but a team change must arrive with a ranking for
+        // the new team — an empty one is as invisible to its leads as an
+        // off-team one.
+        (!teamChanged || ranking.length > 0) &&
         new Set(ranking).size === ranking.length &&
         ranking.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
       if (!valid) {

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -48,21 +48,26 @@ export async function PATCH(
     const rankingChanged =
       preferredSystems !== undefined &&
       JSON.stringify(preferredSystems) !== JSON.stringify(currentData?.preferredSystems ?? []);
-    if (rankingChanged) {
+    const teamChanged = updates.team !== undefined && updates.team !== currentData?.team;
+    // A team change must not leave the old team's ranking behind either: the
+    // ranking scopes reviewer visibility, so an Electric ranking on a Solar
+    // application is invisible to every Solar lead.
+    if (rankingChanged || teamChanged) {
       const forTeam = (updates.team ?? currentData?.team) as Team;
+      const ranking = preferredSystems !== undefined ? preferredSystems : (currentData?.preferredSystems ?? []);
       const teamSystems = (TEAM_SYSTEMS[forTeam] || []).map((s) => s.value);
       const valid =
-        Array.isArray(preferredSystems) &&
-        preferredSystems.length <= 3 &&
-        new Set(preferredSystems).size === preferredSystems.length &&
-        preferredSystems.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
+        Array.isArray(ranking) &&
+        ranking.length <= 3 &&
+        new Set(ranking).size === ranking.length &&
+        ranking.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
       if (!valid) {
         return NextResponse.json(
-          { error: `Preferred systems must be up to 3 distinct ${forTeam ?? "team"} systems` },
+          { error: `Preferred systems must be up to 3 distinct ${forTeam ?? "team"} systems${teamChanged ? " — set a ranking for the new team in the same edit" : ""}` },
           { status: 400 }
         );
       }
-      updates.preferredSystems = preferredSystems;
+      if (preferredSystems !== undefined) updates.preferredSystems = preferredSystems;
     }
 
     // Update form data fields if provided

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -42,7 +42,13 @@ export async function PATCH(
 
     // preferredSystems drives reviewer visibility and several .map/.join call
     // sites; the applicant route validates its shape and this one didn't (#115).
-    if (preferredSystems !== undefined) {
+    // The edit modal resends the stored ranking alongside unrelated edits, so
+    // only a changed value is validated — a legacy off-team entry must not
+    // block a graduation-year fix.
+    const rankingChanged =
+      preferredSystems !== undefined &&
+      JSON.stringify(preferredSystems) !== JSON.stringify(currentData?.preferredSystems ?? []);
+    if (rankingChanged) {
       const forTeam = (updates.team ?? currentData?.team) as Team;
       const teamSystems = (TEAM_SYSTEMS[forTeam] || []).map((s) => s.value);
       const valid =
@@ -52,7 +58,7 @@ export async function PATCH(
         preferredSystems.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
       if (!valid) {
         return NextResponse.json(
-          { error: `Preferred systems must be up to 3 distinct ${forTeam} systems` },
+          { error: `Preferred systems must be up to 3 distinct ${forTeam ?? "team"} systems` },
           { status: 400 }
         );
       }

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/auth/guard";
 import { adminDb } from "@/lib/firebase/admin";
 import { Team } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
+import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 
 
 /**
@@ -39,8 +40,22 @@ export async function PATCH(
       updates.team = team;
     }
 
-    // Update preferred systems if provided
-    if (preferredSystems) {
+    // preferredSystems drives reviewer visibility and several .map/.join call
+    // sites; the applicant route validates its shape and this one didn't (#115).
+    if (preferredSystems !== undefined) {
+      const forTeam = (updates.team ?? currentData?.team) as Team;
+      const teamSystems = (TEAM_SYSTEMS[forTeam] || []).map((s) => s.value);
+      const valid =
+        Array.isArray(preferredSystems) &&
+        preferredSystems.length <= 3 &&
+        new Set(preferredSystems).size === preferredSystems.length &&
+        preferredSystems.every((s: unknown) => typeof s === "string" && teamSystems.includes(s));
+      if (!valid) {
+        return NextResponse.json(
+          { error: `Preferred systems must be up to 3 distinct ${forTeam} systems` },
+          { status: 400 }
+        );
+      }
       updates.preferredSystems = preferredSystems;
     }
 

--- a/app/api/admin/users/[uid]/route.ts
+++ b/app/api/admin/users/[uid]/route.ts
@@ -39,6 +39,11 @@ export async function PATCH(
 
     const updateData: Record<string, unknown> = {};
 
+    const target = await getUser(targetUid);
+    if (!target) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
     // Every scoping check in the app keys off memberProfile.team, so this
     // field is an access-control boundary, not a profile detail. Captains may
     // manage their own team's roster only: users already on their team, or
@@ -51,10 +56,6 @@ export async function PATCH(
       }
       if (targetUid === callerUid) {
         return NextResponse.json({ error: "You cannot change your own membership" }, { status: 403 });
-      }
-      const target = await getUser(targetUid);
-      if (!target) {
-        return NextResponse.json({ error: "User not found" }, { status: 404 });
       }
       const targetTeam = target.memberProfile?.team;
       if (targetTeam && targetTeam !== captainTeam) {
@@ -74,9 +75,12 @@ export async function PATCH(
       }
     }
 
-    if (role) {
-      // Only Admins can update roles
-      if (currentUser?.role !== UserRole.ADMIN) {
+    // The edit form sends the target's current role with every save, so an
+    // unchanged role is a no-op; only an actual change is admin-only. (Until
+    // this check compared against the stored role, every captain save was
+    // refused here regardless of what they had changed.)
+    if (role && role !== target.role) {
+      if (!isAdmin) {
         return NextResponse.json({ error: "Only admins can update roles" }, { status: 403 });
       }
 

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -112,11 +112,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const interviewOffers = application.interviewOffers || [];
     const selectedSystem = application.selectedInterviewSystem;
 
-    // For Combustion/Electric, check if they need to select a system
+    // For Combustion/Electric, check if they need to select a system. Selection
+    // closes with the booking window (#114), so past close_interviews the
+    // picker is never offered — the POST would refuse it.
     const needsSystemSelection =
       application.team !== Team.SOLAR &&
       interviewOffers.length > 1 &&
-      !selectedSystem;
+      !selectedSystem &&
+      !isAtOrPast(config.currentStep, RecruitingStep.CLOSE_INTERVIEWS);
 
     // Resolve the signup link for the relevant offer(s)
     const offersWithLinks = await Promise.all(

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -210,6 +210,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    // The booking window closes at close_interviews; after that a pick would
+    // only narrow preferredSystems on an application the sweep may already
+    // have rejected. A rejection still masked from the applicant ends
+    // selection too (#114).
+    if (isAtOrPast(config.currentStep, RecruitingStep.CLOSE_INTERVIEWS) || application.interviewDecision === "rejected") {
+      return NextResponse.json(
+        { error: "Interview selection is closed for this application" },
+        { status: 400 }
+      );
+    }
+
     // The choice is one-way. Selecting again cancels the offer they are
     // actually holding and narrows preferredSystems a second time, which is
     // what scopes reviewer and system-lead visibility — so a re-pick hides the

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -212,9 +212,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     // The booking window closes at close_interviews; after that a pick would
     // only narrow preferredSystems on an application the sweep may already
-    // have rejected. A rejection still masked from the applicant ends
-    // selection too (#114).
-    if (isAtOrPast(config.currentStep, RecruitingStep.CLOSE_INTERVIEWS) || application.interviewDecision === "rejected") {
+    // have rejected (#114). Deliberately not keyed on a masked rejection: a
+    // per-applicant refusal while peers succeed would reveal the decision.
+    if (isAtOrPast(config.currentStep, RecruitingStep.CLOSE_INTERVIEWS)) {
       return NextResponse.json(
         { error: "Interview selection is closed for this application" },
         { status: 400 }

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -174,24 +174,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
           { status: 400 }
         );
       }
-
-      // Once any system has acted (an offer or a rejection) the ranking is
-      // locked: changing it would revoke a reviewer's access mid-review and
-      // move the every-ranked-system-rejected line (#113). The form sends the
-      // unchanged ranking on every autosave, so only a change is refused.
-      const reviewStarted =
-        existingApplication.status !== ApplicationStatus.IN_PROGRESS &&
-        ((existingApplication.rejectedBySystems?.length ?? 0) > 0 ||
-        (existingApplication.interviewOffers?.length ?? 0) > 0 ||
-        (existingApplication.trialOffers?.length ?? 0) > 0);
-      const changed =
-        JSON.stringify(preferredSystems) !== JSON.stringify(existingApplication.preferredSystems ?? []);
-      if (reviewStarted && changed) {
-        return NextResponse.json(
-          { error: "Your system preferences are locked because review has started. Contact recruiting if they need to change." },
-          { status: 400 }
-        );
-      }
     }
 
     // A submission with no ranked system is invisible to every system lead and

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -174,6 +174,23 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
           { status: 400 }
         );
       }
+
+      // Once any system has acted (an offer or a rejection) the ranking is
+      // locked: changing it would revoke a reviewer's access mid-review and
+      // move the every-ranked-system-rejected line (#113). The form sends the
+      // unchanged ranking on every autosave, so only a change is refused.
+      const reviewStarted =
+        (existingApplication.rejectedBySystems?.length ?? 0) > 0 ||
+        (existingApplication.interviewOffers?.length ?? 0) > 0 ||
+        (existingApplication.trialOffers?.length ?? 0) > 0;
+      const changed =
+        JSON.stringify(preferredSystems) !== JSON.stringify(existingApplication.preferredSystems ?? []);
+      if (reviewStarted && changed) {
+        return NextResponse.json(
+          { error: "Your system preferences are locked because review has started. Contact recruiting if they need to change." },
+          { status: 400 }
+        );
+      }
     }
 
     // A submission with no ranked system is invisible to every system lead and

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -128,11 +128,24 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // Applicants may edit a draft *or* an application they already submitted —
     // the real gate is the recruiting step check above, which stops all edits
     // the moment applications close (and before reviewing begins, so answers
-    // can't change under a reviewer). Anything further along the pipeline is
-    // locked regardless.
-    const EDITABLE_STATUSES: ApplicationStatus[] = [
+    // can't change under a reviewer).
+    //
+    // A REJECTED application stays editable too, on purpose. Every rejection
+    // made while applications are open is masked until release_interviews, so
+    // a frozen form would tell the applicant a decision exists while their
+    // peers keep editing. Their edits can't reach that decision: `status` is
+    // never written for a rejected application (see nextStatus below), so the
+    // rejection and its decision fields survive the save untouched.
+    //
+    // INTERVIEW is locked: a lead who advances during `open` (#118) acts on
+    // the form as it stands, and the interview offer references the ranking.
+    const APPLICANT_STATUSES: ApplicationStatus[] = [
       ApplicationStatus.IN_PROGRESS,
       ApplicationStatus.SUBMITTED,
+    ];
+    const EDITABLE_STATUSES: ApplicationStatus[] = [
+      ...APPLICANT_STATUSES,
+      ApplicationStatus.REJECTED,
     ];
     if (!EDITABLE_STATUSES.includes(existingApplication.status)) {
       return NextResponse.json(
@@ -148,7 +161,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // they own. This value reaches Firestore unmodified, and nothing downstream
     // re-derives how it got there — `POST /commit` gates on status === ACCEPTED
     // alone, so an unvalidated status here is a self-accept.
-    if (status !== undefined && !EDITABLE_STATUSES.includes(status)) {
+    if (status !== undefined && !APPLICANT_STATUSES.includes(status)) {
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
 
@@ -239,6 +252,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // (updateApplication sets submittedAt whenever status is set to SUBMITTED.)
     const alreadySubmitted =
       existingApplication.status === ApplicationStatus.SUBMITTED;
+    // Never write `status` for a rejected application: a save from the form —
+    // including its Submit button — must not turn a masked rejection back into
+    // "submitted".
+    const isRejected = existingApplication.status === ApplicationStatus.REJECTED;
 
     // If only formData is being updated on a draft, use the merge function
     if (formData && !preferredSystems && !status && !alreadySubmitted) {
@@ -248,7 +265,9 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       const updates: Record<string, unknown> = {};
       if (formData) updates.formData = { ...existingApplication.formData, ...formData };
       if (preferredSystems !== undefined) updates.preferredSystems = preferredSystems;
-      const nextStatus = status || (alreadySubmitted ? ApplicationStatus.SUBMITTED : undefined);
+      const nextStatus = isRejected
+        ? undefined
+        : status || (alreadySubmitted ? ApplicationStatus.SUBMITTED : undefined);
       if (nextStatus) updates.status = nextStatus;
 
       application = await updateApplication(id, updates);

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -180,9 +180,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       // move the every-ranked-system-rejected line (#113). The form sends the
       // unchanged ranking on every autosave, so only a change is refused.
       const reviewStarted =
-        (existingApplication.rejectedBySystems?.length ?? 0) > 0 ||
+        existingApplication.status !== ApplicationStatus.IN_PROGRESS &&
+        ((existingApplication.rejectedBySystems?.length ?? 0) > 0 ||
         (existingApplication.interviewOffers?.length ?? 0) > 0 ||
-        (existingApplication.trialOffers?.length ?? 0) > 0;
+        (existingApplication.trialOffers?.length ?? 0) > 0);
       const changed =
         JSON.stringify(preferredSystems) !== JSON.stringify(existingApplication.preferredSystems ?? []);
       if (reviewStarted && changed) {

--- a/app/api/applications/[id]/trial/respond/route.ts
+++ b/app/api/applications/[id]/trial/respond/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { getApplication } from "@/lib/firebase/applications";
 import { getRecruitingConfig } from "@/lib/firebase/config";
-import { sanitizeApplicationForApplicant, isAtOrPast } from "@/lib/utils/statusUtils";
+import { sanitizeApplicationForApplicant, isAtOrPast, getUserVisibleStatus } from "@/lib/utils/statusUtils";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { RecruitingStep } from "@/lib/models/Config";
 import { appCache } from "@/lib/utils/appCache";
@@ -49,7 +49,11 @@ export async function POST(
     // must really be at Trial (not rejected with the decision still masked)
     // and the step must have released trial offers.
     const cfg = await getRecruitingConfig();
-    if (application.status !== ApplicationStatus.TRIAL || !isAtOrPast(cfg.currentStep, RecruitingStep.RELEASE_TRIAL)) {
+    if (
+      application.status !== ApplicationStatus.TRIAL ||
+      !isAtOrPast(cfg.currentStep, RecruitingStep.RELEASE_TRIAL) ||
+      getUserVisibleStatus(application, cfg.currentStep) !== ApplicationStatus.TRIAL
+    ) {
       return NextResponse.json({ error: "There is no trial offer to respond to right now" }, { status: 400 });
     }
 

--- a/app/api/applications/[id]/trial/respond/route.ts
+++ b/app/api/applications/[id]/trial/respond/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
 import { getApplication } from "@/lib/firebase/applications";
 import { getRecruitingConfig } from "@/lib/firebase/config";
-import { sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
+import { sanitizeApplicationForApplicant, isAtOrPast } from "@/lib/utils/statusUtils";
+import { ApplicationStatus } from "@/lib/models/Application";
+import { RecruitingStep } from "@/lib/models/Config";
+import { appCache } from "@/lib/utils/appCache";
 import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "@/lib/logger";
 
@@ -40,6 +43,14 @@ export async function POST(
     // Check if there's a trial offer
     if (!application.trialOffers || application.trialOffers.length === 0) {
       return NextResponse.json({ error: "No trial offer found" }, { status: 400 });
+    }
+
+    // Only a live, released trial offer can be answered (#112): the applicant
+    // must really be at Trial (not rejected with the decision still masked)
+    // and the step must have released trial offers.
+    const cfg = await getRecruitingConfig();
+    if (application.status !== ApplicationStatus.TRIAL || !isAtOrPast(cfg.currentStep, RecruitingStep.RELEASE_TRIAL)) {
+      return NextResponse.json({ error: "There is no trial offer to respond to right now" }, { status: 400 });
     }
 
     const body = await request.json();
@@ -84,6 +95,7 @@ export async function POST(
       trialOffers: [updatedTrialOffer],
       updatedAt: FieldValue.serverTimestamp(),
     });
+    appCache.invalidateApplications();
 
     // Refetch the updated application
     const updatedApp = await getApplication(id);

--- a/app/api/applications/[id]/trial/respond/route.ts
+++ b/app/api/applications/[id]/trial/respond/route.ts
@@ -45,12 +45,14 @@ export async function POST(
       return NextResponse.json({ error: "No trial offer found" }, { status: 400 });
     }
 
-    // Only a live, released trial offer can be answered (#112): the applicant
-    // must really be at Trial (not rejected with the decision still masked)
-    // and the step must have released trial offers.
+    // Only a released trial offer can be answered (#112). Gate on what the
+    // applicant can SEE, never on the real status: a rejection made during the
+    // trial stage is masked until its release day and leaves the offer in
+    // place, so refusing on real status would answer "am I rejected?" for
+    // anyone who clicks. Recording a response on an already-rejected
+    // application is harmless; the decision still releases on schedule.
     const cfg = await getRecruitingConfig();
     if (
-      application.status !== ApplicationStatus.TRIAL ||
       !isAtOrPast(cfg.currentStep, RecruitingStep.RELEASE_TRIAL) ||
       getUserVisibleStatus(application, cfg.currentStep) !== ApplicationStatus.TRIAL
     ) {
@@ -103,8 +105,7 @@ export async function POST(
 
     // Refetch the updated application
     const updatedApp = await getApplication(id);
-    const config = await getRecruitingConfig();
-    const sanitizedApp = sanitizeApplicationForApplicant(updatedApp!, config.currentStep);
+    const sanitizedApp = sanitizeApplicationForApplicant(updatedApp!, cfg.currentStep);
 
     return NextResponse.json({ 
       application: sanitizedApp,

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -348,7 +348,12 @@ export default function TeamApplicationPage() {
 
   // Add/remove a preferred system. Added systems go to the end of the ranking;
   // the applicant reorders with moveSystem.
+  // Once any system has acted on the application the ranking is locked
+  // server-side (#113); mirror that here so the controls don't pretend.
+  const systemsLocked = application?.systemsLocked === true;
+
   const toggleSystem = (system: string) => {
+    if (systemsLocked) return;
     setFormData((prev) => {
       const isSelected = prev.preferredSystems.includes(system);
       if (!isSelected && prev.preferredSystems.length >= 3) return prev;
@@ -365,6 +370,7 @@ export default function TeamApplicationPage() {
 
   // Move a preferred system up (-1) or down (+1) in the ranking.
   const moveSystem = (index: number, delta: number) => {
+    if (systemsLocked) return;
     setFormData((prev) => {
       const target = index + delta;
       if (target < 0 || target >= prev.preferredSystems.length) return prev;
@@ -760,7 +766,9 @@ export default function TeamApplicationPage() {
   // While applications are open a submitted application stays editable (the
   // form below switches to its "changes save automatically" mode); this
   // screen is for everything after the window closes.
-  if (application.status !== ApplicationStatus.IN_PROGRESS && !(isOpen && application.status === ApplicationStatus.SUBMITTED)) {
+  // `editable === false` is the server telling us the application is under
+  // review even though its visible status is still "Submitted" (#111).
+  if (application.editable === false || (application.status !== ApplicationStatus.IN_PROGRESS && !(isOpen && application.status === ApplicationStatus.SUBMITTED))) {
     return (
       <main className="min-h-screen pt-24 pb-20" style={{ background: "var(--pub-bg)" }}>
         <div className="container mx-auto px-4 max-w-2xl text-center">
@@ -779,6 +787,7 @@ export default function TeamApplicationPage() {
             </h1>
             <p className="font-urbanist text-[14px] mb-7" style={{ color: "var(--pub-text-2)" }}>
               Your application to <span style={{ color: teamInk }}>{teamInfo?.name}</span> has been submitted and is under review.
+              {application.editable === false && " It can no longer be edited."}
             </p>
             <Link
               href="/dashboard"
@@ -955,7 +964,7 @@ export default function TeamApplicationPage() {
               {systemOptions.map((option) => {
                 const rankIndex = formData.preferredSystems.indexOf(option.value);
                 const isSelected = rankIndex !== -1;
-                const isDisabled = !isSelected && formData.preferredSystems.length >= 3;
+                const isDisabled = systemsLocked || (!isSelected && formData.preferredSystems.length >= 3);
                 const rankNum = isSelected ? rankIndex + 1 : null;
 
                 return (

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -295,6 +295,13 @@ export default function TeamApplicationPage() {
         });
 
         if (!res.ok) {
+          // A tab left open while a lead advanced the application: the server
+          // now refuses every save. Flip to the read-only view rather than
+          // showing "Failed to save" forever (#111).
+          const body = await res.json().catch(() => ({}));
+          if (res.status === 400 && /no longer be edited/i.test(body?.error || "")) {
+            setApplication((prev) => (prev ? { ...prev, editable: false } : prev));
+          }
           throw new Error("Failed to save");
         }
 
@@ -894,6 +901,12 @@ export default function TeamApplicationPage() {
               use the arrows to rearrange. You may receive interview offers for any of these.
             </p>
 
+            {systemsLocked && (
+              <p className="font-urbanist text-[12px] mb-3" style={{ color: "var(--pub-text-2)" }}>
+                Your ranking is locked because review has started. Contact recruiting if it needs to change.
+              </p>
+            )}
+
             {/* Your ranking — ordinal list with reorder controls. This is the
                 authoritative view of the ranking; the grid below is just the
                 picker. */}
@@ -905,11 +918,6 @@ export default function TeamApplicationPage() {
                 <p className="font-urbanist text-[10px] font-semibold tracking-widest uppercase mb-1" style={{ color: "var(--pub-text-3)" }}>
                   Your ranking
                 </p>
-                {systemsLocked && (
-                  <p className="font-urbanist text-[12px] mb-2" style={{ color: "var(--pub-text-2)" }}>
-                    Your ranking is locked because review has started. Contact recruiting if it needs to change.
-                  </p>
-                )}
                 {formData.preferredSystems.map((sys, idx) => {
                   const rc = RANK_COLORS[idx];
                   const isFirst = idx === 0;

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -355,12 +355,7 @@ export default function TeamApplicationPage() {
 
   // Add/remove a preferred system. Added systems go to the end of the ranking;
   // the applicant reorders with moveSystem.
-  // Once any system has acted on the application the ranking is locked
-  // server-side (#113); mirror that here so the controls don't pretend.
-  const systemsLocked = application?.systemsLocked === true;
-
   const toggleSystem = (system: string) => {
-    if (systemsLocked) return;
     setFormData((prev) => {
       const isSelected = prev.preferredSystems.includes(system);
       if (!isSelected && prev.preferredSystems.length >= 3) return prev;
@@ -377,7 +372,6 @@ export default function TeamApplicationPage() {
 
   // Move a preferred system up (-1) or down (+1) in the ranking.
   const moveSystem = (index: number, delta: number) => {
-    if (systemsLocked) return;
     setFormData((prev) => {
       const target = index + delta;
       if (target < 0 || target >= prev.preferredSystems.length) return prev;
@@ -901,12 +895,6 @@ export default function TeamApplicationPage() {
               use the arrows to rearrange. You may receive interview offers for any of these.
             </p>
 
-            {systemsLocked && (
-              <p className="font-urbanist text-[12px] mb-3" style={{ color: "var(--pub-text-2)" }}>
-                Your ranking is locked because review has started. Contact recruiting if it needs to change.
-              </p>
-            )}
-
             {/* Your ranking — ordinal list with reorder controls. This is the
                 authoritative view of the ranking; the grid below is just the
                 picker. */}
@@ -941,7 +929,7 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Move ${sys} up`}
-                        disabled={systemsLocked || isFirst}
+                        disabled={isFirst}
                         onClick={() => moveSystem(idx, -1)}
                         className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-2)" }}
@@ -951,7 +939,7 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Move ${sys} down`}
-                        disabled={systemsLocked || isLast}
+                        disabled={isLast}
                         onClick={() => moveSystem(idx, 1)}
                         className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-2)" }}
@@ -961,9 +949,8 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Remove ${sys}`}
-                        disabled={systemsLocked}
                         onClick={() => toggleSystem(sys)}
-                        className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
+                        className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-3)" }}
                       >
                         <X className="h-3.5 w-3.5" />
@@ -978,7 +965,7 @@ export default function TeamApplicationPage() {
               {systemOptions.map((option) => {
                 const rankIndex = formData.preferredSystems.indexOf(option.value);
                 const isSelected = rankIndex !== -1;
-                const isDisabled = systemsLocked || (!isSelected && formData.preferredSystems.length >= 3);
+                const isDisabled = !isSelected && formData.preferredSystems.length >= 3;
                 const rankNum = isSelected ? rankIndex + 1 : null;
 
                 return (

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -905,6 +905,11 @@ export default function TeamApplicationPage() {
                 <p className="font-urbanist text-[10px] font-semibold tracking-widest uppercase mb-1" style={{ color: "var(--pub-text-3)" }}>
                   Your ranking
                 </p>
+                {systemsLocked && (
+                  <p className="font-urbanist text-[12px] mb-2" style={{ color: "var(--pub-text-2)" }}>
+                    Your ranking is locked because review has started. Contact recruiting if it needs to change.
+                  </p>
+                )}
                 {formData.preferredSystems.map((sys, idx) => {
                   const rc = RANK_COLORS[idx];
                   const isFirst = idx === 0;
@@ -928,7 +933,7 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Move ${sys} up`}
-                        disabled={isFirst}
+                        disabled={systemsLocked || isFirst}
                         onClick={() => moveSystem(idx, -1)}
                         className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-2)" }}
@@ -938,7 +943,7 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Move ${sys} down`}
-                        disabled={isLast}
+                        disabled={systemsLocked || isLast}
                         onClick={() => moveSystem(idx, 1)}
                         className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-2)" }}
@@ -948,8 +953,9 @@ export default function TeamApplicationPage() {
                       <button
                         type="button"
                         aria-label={`Remove ${sys}`}
+                        disabled={systemsLocked}
                         onClick={() => toggleSystem(sys)}
-                        className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors cursor-pointer"
+                        className="flex-shrink-0 w-7 h-7 rounded-md flex items-center justify-center transition-colors disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer"
                         style={{ backgroundColor: "var(--pub-surface-2)", color: "var(--pub-text-3)" }}
                       >
                         <X className="h-3.5 w-3.5" />

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -301,10 +301,16 @@ export default function TeamApplicationPage() {
           const body = await res.json().catch(() => ({}));
           if (res.status === 400 && /no longer be edited/i.test(body?.error || "")) {
             setApplication((prev) => (prev ? { ...prev, editable: false } : prev));
-          } else if (res.status === 403 && /closed/i.test(body?.error || "")) {
+            setSaveStatus("idle");
+            return;
+          }
+          if (res.status === 403 && /closed/i.test(body?.error || "")) {
             // The step moved past `open` while this tab was up: refetch it so
-            // the page switches to its "Applications are closed" screen.
+            // the page switches to its "Applications are closed" screen. Not a
+            // failure on the applicant's side, so no "Failed to save" flash.
             refreshStep();
+            setSaveStatus("idle");
+            return;
           }
           throw new Error("Failed to save");
         }

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -100,7 +100,7 @@ interface FormData {
 export default function TeamApplicationPage() {
   const params = useParams();
   const router = useRouter();
-  const { recruitingStep, isLoading: stepLoading } = useApplications();
+  const { recruitingStep, isLoading: stepLoading, mutate: refreshStep } = useApplications();
   const teamParam = (params.team as string)?.toLowerCase();
 
   // Validate team parameter
@@ -301,6 +301,10 @@ export default function TeamApplicationPage() {
           const body = await res.json().catch(() => ({}));
           if (res.status === 400 && /no longer be edited/i.test(body?.error || "")) {
             setApplication((prev) => (prev ? { ...prev, editable: false } : prev));
+          } else if (res.status === 403 && /closed/i.test(body?.error || "")) {
+            // The step moved past `open` while this tab was up: refetch it so
+            // the page switches to its "Applications are closed" screen.
+            refreshStep();
           }
           throw new Error("Failed to save");
         }
@@ -312,7 +316,7 @@ export default function TeamApplicationPage() {
         setSaveStatus("error");
       }
     },
-    [application]
+    [application, refreshStep]
   );
 
   // Debounced save

--- a/lib/models/Application.ts
+++ b/lib/models/Application.ts
@@ -151,6 +151,16 @@ export interface Application {
   // When this COMMITTED application replaced a prior acceptance on another
   // team (waitlist-promotion reneg), the team that was abandoned. Audit only.
   renegedFrom?: string;
+
+  /**
+   * Applicant-facing only, computed by sanitizeApplicationForApplicant and
+   * never stored: false once the application is under review, i.e. the real
+   * status is past `submitted` even though the applicant still sees
+   * "Submitted". The form uses it to go read-only instead of failing to save.
+   */
+  editable?: boolean;
+  /** Applicant-facing only, computed: true once any system has acted, which locks preferredSystems. */
+  systemsLocked?: boolean;
 }
 
 export interface ApplicationCreateData {

--- a/lib/models/Application.ts
+++ b/lib/models/Application.ts
@@ -159,8 +159,6 @@ export interface Application {
    * "Submitted". The form uses it to go read-only instead of failing to save.
    */
   editable?: boolean;
-  /** Applicant-facing only, computed: true once any system has acted, which locks preferredSystems. */
-  systemsLocked?: boolean;
 }
 
 export interface ApplicationCreateData {

--- a/lib/utils/staffDisplayStatus.ts
+++ b/lib/utils/staffDisplayStatus.ts
@@ -1,0 +1,119 @@
+import {
+  Application,
+  ApplicationStatus,
+  InterviewEventStatus,
+} from "@/lib/models/Application";
+import { UserRole } from "@/lib/models/User";
+
+/**
+ * The status a staff member should see on an application.
+ *
+ * `application.status` is the applicant's global pipeline stage: the moment
+ * *any* system offers an interview it becomes `interview`. Admins and captains
+ * want exactly that. A system lead or reviewer does not — to them the useful
+ * question is "what has MY system done with this applicant", and a badge that
+ * says "Interview" because Dynamics acted makes an application Powertrain has
+ * never opened fall out of Powertrain's "Submitted" queue.
+ *
+ * So for leads/reviewers the badge is per-system, symmetrically with how
+ * rejections already display: Rejected = we rejected, Trial = we offered a
+ * trial, Interview = we offered an interview, Submitted = we have not acted.
+ * Global end states (draft, globally rejected, accepted, waitlisted,
+ * committed, declined) describe the applicant as a whole and show as-is.
+ *
+ * `elsewhere` carries the context the per-system badge no longer does: the
+ * furthest stage another system has taken the applicant to, when that is
+ * further than the viewer's own system has. Solar applicants can hold offers
+ * from several systems at once, so a Solar lead sees "Submitted · interview
+ * with Aerodynamics" rather than a bare "Submitted".
+ *
+ * Presentation only. Every action gate keys on the real `status`.
+ */
+export type StaffDisplayStatus = {
+  status: ApplicationStatus;
+  elsewhere?: {
+    status: ApplicationStatus.INTERVIEW | ApplicationStatus.TRIAL;
+    systems: string[];
+  };
+};
+
+type Viewer = {
+  role?: UserRole | string;
+  memberProfile?: { system?: string | null } | null;
+} | null | undefined;
+
+// Structural, not Pick<Application>: the admin list and detail views carry
+// their own narrowed application shapes (offers typed loosely, dates as
+// strings) and this must accept all of them.
+type OfferLike = { system: string; status: InterviewEventStatus | string };
+type AppLike = {
+  status: Application["status"];
+  rejectedBySystems?: string[] | null;
+  interviewOffers?: OfferLike[] | null;
+  trialOffers?: OfferLike[] | null;
+};
+
+// Statuses that describe the applicant as a whole, not one system's decision.
+const GLOBAL_STATES = new Set<ApplicationStatus>([
+  ApplicationStatus.IN_PROGRESS,
+  ApplicationStatus.REJECTED,
+  ApplicationStatus.ACCEPTED,
+  ApplicationStatus.WAITLISTED,
+  ApplicationStatus.COMMITTED,
+  ApplicationStatus.DECLINED,
+]);
+
+const STAGE_RANK: Partial<Record<ApplicationStatus, number>> = {
+  [ApplicationStatus.SUBMITTED]: 0,
+  [ApplicationStatus.REJECTED]: 0,
+  [ApplicationStatus.INTERVIEW]: 1,
+  [ApplicationStatus.TRIAL]: 2,
+};
+
+const uniq = (xs: string[]) => Array.from(new Set(xs));
+
+export function getStaffDisplayStatus(app: AppLike, viewer: Viewer): StaffDisplayStatus {
+  const system = viewer?.memberProfile?.system;
+  const perSystem =
+    !!system &&
+    viewer?.role !== UserRole.ADMIN &&
+    viewer?.role !== UserRole.TEAM_CAPTAIN_OB;
+  if (!perSystem || GLOBAL_STATES.has(app.status)) {
+    return { status: app.status };
+  }
+
+  // A cancelled offer is no offer (staff cancellation, or the applicant chose
+  // another system's interview). Completed and no-show offers still place the
+  // applicant at that stage for the system that made them.
+  const live = (offers?: OfferLike[] | null) =>
+    (offers ?? []).filter((o) => o.status !== InterviewEventStatus.CANCELLED);
+  const interviews = live(app.interviewOffers);
+  const trials = live(app.trialOffers);
+
+  const mine: ApplicationStatus = (app.rejectedBySystems ?? []).includes(system)
+    ? ApplicationStatus.REJECTED
+    : trials.some((o) => o.system === system)
+      ? ApplicationStatus.TRIAL
+      : interviews.some((o) => o.system === system)
+        ? ApplicationStatus.INTERVIEW
+        : ApplicationStatus.SUBMITTED;
+
+  const othersTrial = uniq(trials.filter((o) => o.system !== system).map((o) => o.system));
+  const othersInterview = uniq(interviews.filter((o) => o.system !== system).map((o) => o.system));
+  const elsewhere: StaffDisplayStatus["elsewhere"] = othersTrial.length
+    ? { status: ApplicationStatus.TRIAL, systems: othersTrial }
+    : othersInterview.length
+      ? { status: ApplicationStatus.INTERVIEW, systems: othersInterview }
+      : undefined;
+
+  if (elsewhere && (STAGE_RANK[elsewhere.status] ?? 0) > (STAGE_RANK[mine] ?? 0)) {
+    return { status: mine, elsewhere };
+  }
+  return { status: mine };
+}
+
+/** "Interview · Dynamics, Body" — the hint rendered beside a per-system badge. */
+export function formatElsewhere(elsewhere: NonNullable<StaffDisplayStatus["elsewhere"]>): string {
+  const label = elsewhere.status === ApplicationStatus.TRIAL ? "Trial" : "Interview";
+  return `${label} · ${elsewhere.systems.join(", ")}`;
+}

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -254,6 +254,17 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     status: visibleStatus 
   };
 
+  // What the applicant may still do, without revealing why. The form keeps
+  // editing a "Submitted" application while the window is open, but once a
+  // lead has advanced it the real status is past submitted and every save
+  // would fail (#111). The ranking locks once any system has acted (#113).
+  sanitized.editable =
+    rawStatus === ApplicationStatus.IN_PROGRESS || rawStatus === ApplicationStatus.SUBMITTED;
+  sanitized.systemsLocked =
+    (rejectedBySystems?.length ?? 0) > 0 ||
+    (app.interviewOffers?.length ?? 0) > 0 ||
+    (app.trialOffers?.length ?? 0) > 0;
+
   // Hide interview offers until they are released
   if (!isAtOrPast(step, RecruitingStep.RELEASE_INTERVIEWS)) {
     delete sanitized.interviewOffers;

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -261,7 +261,12 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
   // save would fail (#111). Deliberately the only per-applicant signal here:
   // anything keyed on offers or rejections would leak a masked decision.
   sanitized.editable =
-    rawStatus === ApplicationStatus.IN_PROGRESS || rawStatus === ApplicationStatus.SUBMITTED;
+    rawStatus === ApplicationStatus.IN_PROGRESS ||
+    rawStatus === ApplicationStatus.SUBMITTED ||
+    // A rejection made while applications are open is masked, so the form
+    // must not freeze on it — the applicant PATCH accepts the edit and leaves
+    // the decision untouched. Only an early advance freezes the form (#118).
+    rawStatus === ApplicationStatus.REJECTED;
 
   // Hide interview offers until they are released
   if (!isAtOrPast(step, RecruitingStep.RELEASE_INTERVIEWS)) {

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -261,9 +261,10 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
   sanitized.editable =
     rawStatus === ApplicationStatus.IN_PROGRESS || rawStatus === ApplicationStatus.SUBMITTED;
   sanitized.systemsLocked =
-    (rejectedBySystems?.length ?? 0) > 0 ||
+    rawStatus !== ApplicationStatus.IN_PROGRESS &&
+    ((rejectedBySystems?.length ?? 0) > 0 ||
     (app.interviewOffers?.length ?? 0) > 0 ||
-    (app.trialOffers?.length ?? 0) > 0;
+    (app.trialOffers?.length ?? 0) > 0);
 
   // Hide interview offers until they are released
   if (!isAtOrPast(step, RecruitingStep.RELEASE_INTERVIEWS)) {

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -254,17 +254,13 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     status: visibleStatus 
   };
 
-  // What the applicant may still do, without revealing why. The form keeps
-  // editing a "Submitted" application while the window is open, but once a
-  // lead has advanced it the real status is past submitted and every save
-  // would fail (#111). The ranking locks once any system has acted (#113).
+  // Whether the applicant may still edit, without revealing why. The form
+  // keeps editing a "Submitted" application while the window is open, but
+  // once a lead has advanced it the real status is past submitted and every
+  // save would fail (#111). Deliberately the only per-applicant signal here:
+  // anything keyed on offers or rejections would leak a masked decision.
   sanitized.editable =
     rawStatus === ApplicationStatus.IN_PROGRESS || rawStatus === ApplicationStatus.SUBMITTED;
-  sanitized.systemsLocked =
-    rawStatus !== ApplicationStatus.IN_PROGRESS &&
-    ((rejectedBySystems?.length ?? 0) > 0 ||
-    (app.interviewOffers?.length ?? 0) > 0 ||
-    (app.trialOffers?.length ?? 0) > 0);
 
   // Hide interview offers until they are released
   if (!isAtOrPast(step, RecruitingStep.RELEASE_INTERVIEWS)) {

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -80,6 +80,13 @@ r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSyst
 check("#115 admin PATCH with a duplicate -> 400", r.status === 400, err(r));
 r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: ["Body", "Electronics"] });
 check("#115 admin PATCH with a valid ranking -> 200", r.status === 200 && (await get("ag-sub")).preferredSystems.join("+") === "Body+Electronics", err(r));
+await mk("ag-legacy", "submitted", { preferredSystems: ["Body", "Old System Name"] });
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-legacy", { team: "Electric", preferredSystems: ["Body", "Old System Name"], formData: { graduationYear: "2029" } });
+check("#115 admin edit that resends a legacy ranking unchanged still saves (M3)", r.status === 200 && (await get("ag-legacy")).formData.graduationYear === "2029", err(r));
+await mk("ag-draft-rb", "in_progress", { rejectedBySystems: ["Body"] });
+await db.doc("users/u-ag").set({ applications: ["ag-draft-rb"] }, { merge: true });
+r = await api(appC, "GET", "/api/applications/ag-draft-rb");
+check("H2 a draft is never systemsLocked, whatever rejectedBySystems says", r.json?.application?.systemsLocked === false && r.json?.application?.editable === true, JSON.stringify([r.json?.application?.systemsLocked, r.json?.application?.editable]));
 
 // ---- #112: trial response gate ----
 await mk("ag-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Body", "completed")], trialOffers: [off("Body")] });
@@ -99,7 +106,7 @@ await mk("ag-pick", "interview", { reviewDecision: "advanced", interviewOffers: 
 await mk("ag-pick-rej", "interview", { reviewDecision: "advanced", interviewDecision: "rejected", interviewOffers: [off("Body"), off("Dynamics")] });
 await db.doc("users/u-ag").set({ applications: ["ag-pick", "ag-pick-rej"] }, { merge: true });
 r = await api(appC, "POST", "/api/applications/ag-pick-rej/interview", { system: "Body" });
-check("#114 selecting after an (unreleased) interview rejection -> 400, ranking untouched", r.status === 400 && (await get("ag-pick-rej")).preferredSystems.join("+") === "Body+Dynamics", err(r));
+check("#114 a masked interview rejection does NOT change the response (no per-applicant signal)", r.status === 200, err(r));
 r = await api(appC, "POST", "/api/applications/ag-pick/interview", { system: "Body" });
 check("#114 selecting during interviewing works", r.status === 200 && (await get("ag-pick")).selectedInterviewSystem === "Body", err(r));
 await mk("ag-pick2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -1,7 +1,8 @@
-// Applicant-side gates (#111 #112 #113 #114 #115): the applicant API tells the
+// Applicant-side gates (#111 #112 #114 #115): the applicant API tells the
 // form when an application is no longer editable, trial responses need a live
-// released offer, system preferences lock once review has started, interview
-// selection closes with the window, and the admin PATCH validates the ranking.
+// released offer, interview selection closes with the window, and the admin
+// PATCH validates the ranking. (#113, locking the ranking once a system has
+// acted, was deliberately NOT done: it would reveal a masked rejection.)
 // Emulator only.
 //
 // Run against the emulator suite with the dev server up (README: local development):
@@ -57,19 +58,15 @@ check("#111 no internal fields leak alongside the flag", mine["ag-int"] && !("re
 r = await api(appC, "GET", "/api/applications/ag-int");
 check("#111 single-application GET carries editable=false too", r.status === 200 && r.json?.application?.editable === false, `${r.status} ${JSON.stringify(r.json?.application?.editable)}`);
 
-// ---- #113: preferredSystems lock once review has started ----
+// ---- ranking stays the applicant's to change while open, even after a (masked) rejection ----
 await mk("ag-lock", "submitted", { rejectedBySystems: ["Body"] });
 await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int", "ag-lock"] }, { merge: true });
 r = await api(appC, "PATCH", "/api/applications/ag-lock", { preferredSystems: ["Dynamics"] });
-check("#113 dropping the system that rejected you -> 400 locked", r.status === 400 && /locked/i.test(r.json?.error || "") && (await get("ag-lock")).preferredSystems.join("+") === "Body+Dynamics", err(r));
-r = await api(appC, "PATCH", "/api/applications/ag-lock", { preferredSystems: ["Body", "Dynamics"], formData: { whyJoin: "still fine" } });
-check("#113 autosave with the SAME ranking still saves", r.status === 200 && (await get("ag-lock")).formData.whyJoin === "still fine", err(r));
+check("ranking change after a masked rejection is allowed (no #113 lock, no signal)", r.status === 200 && (await get("ag-lock")).preferredSystems.join("+") === "Dynamics", err(r));
 r = await api(appC, "GET", "/api/applications/ag-lock");
-check("#113 payload says systemsLocked=true", r.json?.application?.systemsLocked === true, JSON.stringify(r.json?.application?.systemsLocked));
+check("payload carries no systemsLocked / rejectedBySystems", r.json?.application && !("systemsLocked" in r.json.application) && !("rejectedBySystems" in r.json.application));
 r = await api(appC, "PATCH", "/api/applications/ag-sub", { preferredSystems: ["Dynamics", "Body"] });
-check("#113 reordering is still allowed before any system has acted", r.status === 200 && (await get("ag-sub")).preferredSystems.join("+") === "Dynamics+Body", err(r));
-r = await api(appC, "GET", "/api/applications/ag-sub");
-check("#113 untouched app says systemsLocked=false", r.json?.application?.systemsLocked === false, JSON.stringify(r.json?.application?.systemsLocked));
+check("reordering allowed", r.status === 200 && (await get("ag-sub")).preferredSystems.join("+") === "Dynamics+Body", err(r));
 
 // ---- #115: admin PATCH validates preferredSystems ----
 r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: "Body" });
@@ -86,7 +83,7 @@ check("#115 admin edit that resends a legacy ranking unchanged still saves (M3)"
 await mk("ag-draft-rb", "in_progress", { rejectedBySystems: ["Body"] });
 await db.doc("users/u-ag").set({ applications: ["ag-draft-rb"] }, { merge: true });
 r = await api(appC, "GET", "/api/applications/ag-draft-rb");
-check("H2 a draft is never systemsLocked, whatever rejectedBySystems says", r.json?.application?.systemsLocked === false && r.json?.application?.editable === true, JSON.stringify([r.json?.application?.systemsLocked, r.json?.application?.editable]));
+check("a draft with a stale rejectedBySystems is still editable", r.json?.application?.editable === true, JSON.stringify(r.json?.application?.editable));
 
 // ---- #112: trial response gate ----
 await mk("ag-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Body", "completed")], trialOffers: [off("Body")] });

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -58,6 +58,21 @@ check("#111 no internal fields leak alongside the flag", mine["ag-int"] && !("re
 r = await api(appC, "GET", "/api/applications/ag-int");
 check("#111 single-application GET carries editable=false too", r.status === 200 && r.json?.application?.editable === false, `${r.status} ${JSON.stringify(r.json?.application?.editable)}`);
 
+// ---- a rejection made while open is masked, so it must NOT freeze the form (#121 review, finding 3) ----
+await mk("ag-rej-open", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Body", "Dynamics"] });
+await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int", "ag-rej-open"] }, { merge: true });
+r = await api(appC, "GET", "/api/applications/ag-rej-open");
+check("rejected while open: masked as submitted AND editable — indistinguishable from a peer", r.status === 200 && r.json?.application?.status === "submitted" && r.json?.application?.editable === true && !("reviewDecision" in (r.json?.application || {})) && !("rejectedBySystems" in (r.json?.application || {})), `${r.status} ${r.json?.application?.status} editable=${r.json?.application?.editable}`);
+r = await api(appC, "PATCH", "/api/applications/ag-rej-open", { formData: { whyJoin: "edited after masked rejection" } });
+let dr = await get("ag-rej-open");
+check("rejected while open: a formData edit saves (200) — same answer as a peer", r.status === 200 && dr.formData.whyJoin === "edited after masked rejection", err(r));
+check("rejected while open: the decision survives the edit", dr.status === "rejected" && dr.reviewDecision === "rejected" && dr.rejectedBySystems.join("+") === "Body+Dynamics", `${dr.status} ${dr.reviewDecision}`);
+r = await api(appC, "PATCH", "/api/applications/ag-rej-open", { status: "submitted", preferredSystems: ["Dynamics", "Body"], formData: { whyJoin: "resubmit" } });
+dr = await get("ag-rej-open");
+check("rejected while open: Submit from the form is accepted but never rewrites status", r.status === 200 && dr.status === "rejected" && dr.reviewDecision === "rejected" && dr.formData.whyJoin === "resubmit" && dr.preferredSystems.join("+") === "Dynamics+Body", `${err(r)} status=${dr.status}`);
+r = await api(appC, "PATCH", "/api/applications/ag-rej-open", { status: "interview" });
+check("rejected while open: still cannot set a status it doesn't own", r.status === 400 && (await get("ag-rej-open")).status === "rejected", err(r));
+
 // ---- ranking stays the applicant's to change while open, even after a (masked) rejection ----
 await mk("ag-lock", "submitted", { rejectedBySystems: ["Body"] });
 await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int", "ag-lock"] }, { merge: true });
@@ -85,6 +100,14 @@ check("#115 team change that would leave an off-team ranking behind -> 400", r.s
 r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { team: "Solar", preferredSystems: ["Powertrain", "TrackSim"] });
 check("#115 team change with a matching new ranking -> 200", r.status === 200 && (await get("ag-sub")).team === "Solar" && (await get("ag-sub")).preferredSystems.join("+") === "Powertrain+TrackSim", err(r));
 await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { team: "Electric", preferredSystems: ["Body", "Electronics"] });
+await mk("ag-noranking", "submitted", { preferredSystems: [] });
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-noranking", { team: "Solar" });
+check("#115 team change on an application with no ranking -> 400 (must set one for the new team)", r.status === 400 && (await get("ag-noranking")).team === "Electric", err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-noranking", { team: "Solar", preferredSystems: [] });
+check("#115 team change with an explicitly empty ranking -> 400", r.status === 400 && (await get("ag-noranking")).team === "Electric", err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: [] });
+check("#115 clearing the ranking on the same team is still allowed (matches the applicant route)", r.status === 200 && (await get("ag-sub")).preferredSystems.length === 0, err(r));
+await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: ["Body", "Electronics"] });
 await mk("ag-draft-rb", "in_progress", { rejectedBySystems: ["Body"] });
 await db.doc("users/u-ag").set({ applications: ["ag-draft-rb"] }, { merge: true });
 r = await api(appC, "GET", "/api/applications/ag-draft-rb");

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -80,6 +80,11 @@ check("#115 admin PATCH with a valid ranking -> 200", r.status === 200 && (await
 await mk("ag-legacy", "submitted", { preferredSystems: ["Body", "Old System Name"] });
 r = await api(adminC, "PATCH", "/api/admin/applications/ag-legacy", { team: "Electric", preferredSystems: ["Body", "Old System Name"], formData: { graduationYear: "2029" } });
 check("#115 admin edit that resends a legacy ranking unchanged still saves (M3)", r.status === 200 && (await get("ag-legacy")).formData.graduationYear === "2029", err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { team: "Solar" });
+check("#115 team change that would leave an off-team ranking behind -> 400", r.status === 400 && (await get("ag-sub")).team === "Electric", err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { team: "Solar", preferredSystems: ["Powertrain", "TrackSim"] });
+check("#115 team change with a matching new ranking -> 200", r.status === 200 && (await get("ag-sub")).team === "Solar" && (await get("ag-sub")).preferredSystems.join("+") === "Powertrain+TrackSim", err(r));
+await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { team: "Electric", preferredSystems: ["Body", "Electronics"] });
 await mk("ag-draft-rb", "in_progress", { rejectedBySystems: ["Body"] });
 await db.doc("users/u-ag").set({ applications: ["ag-draft-rb"] }, { merge: true });
 r = await api(appC, "GET", "/api/applications/ag-draft-rb");
@@ -93,7 +98,7 @@ r = await api(appC, "POST", "/api/applications/ag-trial/trial/respond", { accept
 check("#112 responding before trial offers are released -> 400", r.status === 400 && (await get("ag-trial")).trialOffers[0].accepted === undefined, err(r));
 for (const s of ["reviewing", "release_interviews", "interviewing", "close_interviews", "release_trial"]) { r = await setStep(adminC, s); if (r.status !== 200) console.log("step", s, err(r)); }
 r = await api(appC, "POST", "/api/applications/ag-trial-rej/trial/respond", { accepted: true });
-check("#112 a rejected applicant cannot accept the (masked) trial offer", r.status === 400 && (await get("ag-trial-rej")).trialOffers[0].accepted === undefined, err(r));
+check("#112 an applicant rejected during trial (decision masked) gets the SAME answer as a peer — no oracle", r.status === 200 && (await get("ag-trial-rej")).status === "rejected" && (await get("ag-trial-rej")).trialDecision === "rejected", `${err(r)} status=${(await get("ag-trial-rej")).status}`);
 r = await api(appC, "POST", "/api/applications/ag-trial/trial/respond", { accepted: true });
 check("#112 a live released trial offer can be accepted", r.status === 200 && (await get("ag-trial")).trialOffers[0].accepted === true, err(r));
 
@@ -104,11 +109,15 @@ await mk("ag-pick-rej", "interview", { reviewDecision: "advanced", interviewDeci
 await db.doc("users/u-ag").set({ applications: ["ag-pick", "ag-pick-rej"] }, { merge: true });
 r = await api(appC, "POST", "/api/applications/ag-pick-rej/interview", { system: "Body" });
 check("#114 a masked interview rejection does NOT change the response (no per-applicant signal)", r.status === 200, err(r));
+r = await api(appC, "GET", "/api/applications/ag-pick/interview");
+check("#114 GET offers the picker during interviewing", r.status === 200 && r.json?.needsSystemSelection === true, `${r.status} ${JSON.stringify(r.json?.needsSystemSelection)}`);
 r = await api(appC, "POST", "/api/applications/ag-pick/interview", { system: "Body" });
 check("#114 selecting during interviewing works", r.status === 200 && (await get("ag-pick")).selectedInterviewSystem === "Body", err(r));
 await mk("ag-pick2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });
 await db.doc("users/u-ag").set({ applications: ["ag-pick2"] }, { merge: true });
 await setStep(adminC, "close_interviews");
+r = await api(appC, "GET", "/api/applications/ag-pick2/interview");
+check("#114 GET no longer offers the picker after close_interviews (no dead-end UI)", r.status === 200 && r.json?.needsSystemSelection === false, `${r.status} ${JSON.stringify(r.json?.needsSystemSelection)}`);
 r = await api(appC, "POST", "/api/applications/ag-pick2/interview", { system: "Body" });
 check("#114 selecting after close_interviews -> 400, ranking untouched", r.status === 400 && (await get("ag-pick2")).preferredSystems.join("+") === "Body+Dynamics" && !(await get("ag-pick2")).selectedInterviewSystem, err(r));
 

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -1,0 +1,114 @@
+// Applicant-side gates (#111 #112 #113 #114 #115): the applicant API tells the
+// form when an application is no longer editable, trial responses need a live
+// released offer, system preferences lock once review has started, interview
+// selection closes with the window, and the admin PATCH validates the ranking.
+// Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/applicant-gates-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const get = async (id) => (await db.doc(`applications/${id}`).get()).data();
+const setStep = (c, step) => api(c, "POST", "/api/admin/config/recruiting", { step, confirm: step });
+const err = (r) => `${r.status} ${r.json?.error || ""}`;
+
+await ensureUser({ uid: "u-ag", email: "ag@utexas.edu", name: "Gated Applicant", role: "applicant" });
+const adminC = await session("admin@utexas.edu"), appC = await session("ag@utexas.edu");
+const mk = async (id, st, extra = {}) => { await db.doc(`applications/${id}`).set({ userId: "u-ag", userEmail: "ag@utexas.edu", team: "Electric", preferredSystems: ["Body", "Dynamics"], status: st, formData: { whyJoin: "x" }, createdAt: now(), updatedAt: now(), ...(st !== "in_progress" ? { submittedAt: now() } : {}), ...extra }); };
+const off = (system, st = "pending") => ({ system, status: st, createdAt: now() });
+let r = await setStep(adminC, "open"); check("step -> open", r.status === 200);
+
+// ---- #111: editable flag on the applicant payload ----
+await mk("ag-draft", "in_progress"); await mk("ag-sub", "submitted"); await mk("ag-int", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body")] });
+await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int"] }, { merge: true });
+r = await api(appC, "GET", "/api/applications");
+const mine = Object.fromEntries((r.json?.applications || []).map((a) => [a.id, a]));
+check("#111 draft is editable", mine["ag-draft"]?.editable === true, JSON.stringify(mine["ag-draft"]?.editable));
+check("#111 submitted (untouched) is editable while open", mine["ag-sub"]?.editable === true, JSON.stringify(mine["ag-sub"]?.editable));
+check("#111 advanced app: status still masked as submitted BUT editable=false", mine["ag-int"]?.status === "submitted" && mine["ag-int"]?.editable === false, `${mine["ag-int"]?.status} editable=${mine["ag-int"]?.editable}`);
+check("#111 no internal fields leak alongside the flag", mine["ag-int"] && !("reviewDecision" in mine["ag-int"]) && !("rejectedBySystems" in mine["ag-int"]));
+r = await api(appC, "GET", "/api/applications/ag-int");
+check("#111 single-application GET carries editable=false too", r.status === 200 && r.json?.application?.editable === false, `${r.status} ${JSON.stringify(r.json?.application?.editable)}`);
+
+// ---- #113: preferredSystems lock once review has started ----
+await mk("ag-lock", "submitted", { rejectedBySystems: ["Body"] });
+await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int", "ag-lock"] }, { merge: true });
+r = await api(appC, "PATCH", "/api/applications/ag-lock", { preferredSystems: ["Dynamics"] });
+check("#113 dropping the system that rejected you -> 400 locked", r.status === 400 && /locked/i.test(r.json?.error || "") && (await get("ag-lock")).preferredSystems.join("+") === "Body+Dynamics", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-lock", { preferredSystems: ["Body", "Dynamics"], formData: { whyJoin: "still fine" } });
+check("#113 autosave with the SAME ranking still saves", r.status === 200 && (await get("ag-lock")).formData.whyJoin === "still fine", err(r));
+r = await api(appC, "GET", "/api/applications/ag-lock");
+check("#113 payload says systemsLocked=true", r.json?.application?.systemsLocked === true, JSON.stringify(r.json?.application?.systemsLocked));
+r = await api(appC, "PATCH", "/api/applications/ag-sub", { preferredSystems: ["Dynamics", "Body"] });
+check("#113 reordering is still allowed before any system has acted", r.status === 200 && (await get("ag-sub")).preferredSystems.join("+") === "Dynamics+Body", err(r));
+r = await api(appC, "GET", "/api/applications/ag-sub");
+check("#113 untouched app says systemsLocked=false", r.json?.application?.systemsLocked === false, JSON.stringify(r.json?.application?.systemsLocked));
+
+// ---- #115: admin PATCH validates preferredSystems ----
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: "Body" });
+check("#115 admin PATCH with a string -> 400", r.status === 400, err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: ["Body", "TrackSim"] });
+check("#115 admin PATCH with an off-team system -> 400", r.status === 400, err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: ["Body", "Body"] });
+check("#115 admin PATCH with a duplicate -> 400", r.status === 400, err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-sub", { preferredSystems: ["Body", "Electronics"] });
+check("#115 admin PATCH with a valid ranking -> 200", r.status === 200 && (await get("ag-sub")).preferredSystems.join("+") === "Body+Electronics", err(r));
+
+// ---- #112: trial response gate ----
+await mk("ag-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Body", "completed")], trialOffers: [off("Body")] });
+await mk("ag-trial-rej", "rejected", { reviewDecision: "advanced", interviewDecision: "advanced", trialDecision: "rejected", trialDecisionDay: 1, interviewOffers: [off("Body", "completed")], trialOffers: [off("Body")] });
+await db.doc("users/u-ag").set({ applications: ["ag-trial", "ag-trial-rej", "ag-int"] }, { merge: true });
+r = await api(appC, "POST", "/api/applications/ag-trial/trial/respond", { accepted: true });
+check("#112 responding before trial offers are released -> 400", r.status === 400 && (await get("ag-trial")).trialOffers[0].accepted === undefined, err(r));
+for (const s of ["reviewing", "release_interviews", "interviewing", "close_interviews", "release_trial"]) { r = await setStep(adminC, s); if (r.status !== 200) console.log("step", s, err(r)); }
+r = await api(appC, "POST", "/api/applications/ag-trial-rej/trial/respond", { accepted: true });
+check("#112 a rejected applicant cannot accept the (masked) trial offer", r.status === 400 && (await get("ag-trial-rej")).trialOffers[0].accepted === undefined, err(r));
+r = await api(appC, "POST", "/api/applications/ag-trial/trial/respond", { accepted: true });
+check("#112 a live released trial offer can be accepted", r.status === 200 && (await get("ag-trial")).trialOffers[0].accepted === true, err(r));
+
+// ---- #114: interview selection closes with the window ----
+await setStep(adminC, "interviewing");
+await mk("ag-pick", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });
+await mk("ag-pick-rej", "interview", { reviewDecision: "advanced", interviewDecision: "rejected", interviewOffers: [off("Body"), off("Dynamics")] });
+await db.doc("users/u-ag").set({ applications: ["ag-pick", "ag-pick-rej"] }, { merge: true });
+r = await api(appC, "POST", "/api/applications/ag-pick-rej/interview", { system: "Body" });
+check("#114 selecting after an (unreleased) interview rejection -> 400, ranking untouched", r.status === 400 && (await get("ag-pick-rej")).preferredSystems.join("+") === "Body+Dynamics", err(r));
+r = await api(appC, "POST", "/api/applications/ag-pick/interview", { system: "Body" });
+check("#114 selecting during interviewing works", r.status === 200 && (await get("ag-pick")).selectedInterviewSystem === "Body", err(r));
+await mk("ag-pick2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });
+await db.doc("users/u-ag").set({ applications: ["ag-pick2"] }, { merge: true });
+await setStep(adminC, "close_interviews");
+r = await api(appC, "POST", "/api/applications/ag-pick2/interview", { system: "Body" });
+check("#114 selecting after close_interviews -> 400, ranking untouched", r.status === 400 && (await get("ag-pick2")).preferredSystems.join("+") === "Body+Dynamics" && !(await get("ag-pick2")).selectedInterviewSystem, err(r));
+
+await setStep(adminC, "open");
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);

--- a/scripts/qa/staff-status-regress.ts
+++ b/scripts/qa/staff-status-regress.ts
@@ -1,0 +1,100 @@
+// Per-system display status for leads/reviewers (getStaffDisplayStatus):
+// the badge answers "what has MY system done with this applicant", with a hint
+// when another system has taken them further. Pure function — no emulator.
+//
+//   npx -y tsx scripts/qa/staff-status-regress.ts
+import { getStaffDisplayStatus, formatElsewhere } from "@/lib/utils/staffDisplayStatus";
+import { ApplicationStatus as S, InterviewEventStatus as E } from "@/lib/models/Application";
+import { UserRole } from "@/lib/models/User";
+
+const results: boolean[] = [];
+const check = (name: string, ok: boolean, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+const off = (system: string, status: E = E.PENDING) => ({ system, status, createdAt: new Date() });
+const show = (d: ReturnType<typeof getStaffDisplayStatus>) => `${d.status}${d.elsewhere ? " [" + formatElsewhere(d.elsewhere) + "]" : ""}`;
+
+const powertrain = { role: UserRole.REVIEWER, memberProfile: { team: "Electric", system: "Powertrain" } };
+const dynamics = { role: UserRole.SYSTEM_LEAD, memberProfile: { team: "Electric", system: "Dynamics" } };
+const captain = { role: UserRole.TEAM_CAPTAIN_OB, memberProfile: { team: "Electric", system: "Electronics" } };
+const admin = { role: UserRole.ADMIN };
+const leadNoProfile = { role: UserRole.SYSTEM_LEAD };
+
+// ---- the report: Dynamics advanced; Powertrain never opened it ----
+let app: Parameters<typeof getStaffDisplayStatus>[0] = { status: S.INTERVIEW, interviewOffers: [off("Dynamics")] };
+let d = getStaffDisplayStatus(app, powertrain);
+check("report: Powertrain sees Submitted, not Interview", d.status === S.SUBMITTED, show(d));
+check("report: with the hint 'Interview · Dynamics'", !!d.elsewhere && formatElsewhere(d.elsewhere) === "Interview · Dynamics", show(d));
+d = getStaffDisplayStatus(app, dynamics);
+check("Dynamics (the system that acted) sees Interview, no hint", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+d = getStaffDisplayStatus(app, captain);
+check("captain keeps the global view: Interview, no hint", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+d = getStaffDisplayStatus(app, admin);
+check("admin keeps the global view: Interview, no hint", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+d = getStaffDisplayStatus(app, leadNoProfile);
+check("a lead with no system profile falls back to the global view", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+d = getStaffDisplayStatus(app, null);
+check("no viewer -> global view", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+
+// ---- both systems offered ----
+app = { status: S.INTERVIEW, interviewOffers: [off("Dynamics"), off("Powertrain")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("both offered: Powertrain sees Interview, no hint (same stage)", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+
+// ---- trial elsewhere ----
+app = { status: S.TRIAL, interviewOffers: [off("Dynamics", E.COMPLETED)], trialOffers: [off("Dynamics")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("Dynamics at trial, Powertrain never acted: Submitted + 'Trial · Dynamics'", d.status === S.SUBMITTED && !!d.elsewhere && formatElsewhere(d.elsewhere) === "Trial · Dynamics", show(d));
+d = getStaffDisplayStatus(app, dynamics);
+check("Dynamics sees Trial", d.status === S.TRIAL && !d.elsewhere, show(d));
+app = { status: S.TRIAL, interviewOffers: [off("Dynamics", E.COMPLETED), off("Powertrain", E.COMPLETED)], trialOffers: [off("Dynamics")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("Powertrain interviewed, Dynamics went to trial: Interview + 'Trial · Dynamics'", d.status === S.INTERVIEW && !!d.elsewhere && formatElsewhere(d.elsewhere) === "Trial · Dynamics", show(d));
+app = { status: S.TRIAL, interviewOffers: [off("Dynamics", E.COMPLETED), off("Powertrain", E.COMPLETED)], trialOffers: [off("Powertrain")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("Powertrain at trial, Dynamics only interviewed: Trial, no hint (nobody is ahead of us)", d.status === S.TRIAL && !d.elsewhere, show(d));
+
+// ---- our rejection while the application is alive elsewhere (#102 behaviour kept) ----
+app = { status: S.INTERVIEW, rejectedBySystems: ["Powertrain"], interviewOffers: [off("Dynamics")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("we rejected, Dynamics interviewing: Rejected + 'Interview · Dynamics'", d.status === S.REJECTED && !!d.elsewhere && formatElsewhere(d.elsewhere) === "Interview · Dynamics", show(d));
+d = getStaffDisplayStatus(app, dynamics);
+check("Dynamics unaffected by Powertrain's rejection", d.status === S.INTERVIEW && !d.elsewhere, show(d));
+app = { status: S.SUBMITTED, rejectedBySystems: ["Powertrain"] };
+d = getStaffDisplayStatus(app, powertrain);
+check("we rejected, nobody else acted: Rejected, no hint", d.status === S.REJECTED && !d.elsewhere, show(d));
+app = { status: S.INTERVIEW, rejectedBySystems: ["Powertrain"], interviewOffers: [off("Powertrain", E.COMPLETED), off("Dynamics")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("rejected after our own interview: rejection wins", d.status === S.REJECTED, show(d));
+
+// ---- cancelled offers are not offers ----
+app = { status: S.SUBMITTED, interviewOffers: [off("Dynamics", E.CANCELLED)] };
+d = getStaffDisplayStatus(app, powertrain);
+check("a cancelled Dynamics offer produces no hint", d.status === S.SUBMITTED && !d.elsewhere, show(d));
+d = getStaffDisplayStatus(app, dynamics);
+check("a cancelled offer of our own: Submitted", d.status === S.SUBMITTED && !d.elsewhere, show(d));
+app = { status: S.INTERVIEW, interviewOffers: [off("Dynamics", E.NO_SHOW)] };
+d = getStaffDisplayStatus(app, dynamics);
+check("a no-show offer still places the applicant at Interview for us", d.status === S.INTERVIEW, show(d));
+
+// ---- global end states pass through for everyone ----
+app = { status: S.REJECTED, rejectedBySystems: ["Dynamics", "Powertrain"] };
+check("fully rejected: Rejected for Powertrain", getStaffDisplayStatus(app, powertrain).status === S.REJECTED);
+app = { status: S.REJECTED, rejectedBySystems: [], interviewOffers: [off("Dynamics")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("admin/sweep rejection with a stale offer: Rejected (dead applicant), no hint", d.status === S.REJECTED && !d.elsewhere, show(d));
+for (const st of [S.ACCEPTED, S.WAITLISTED, S.COMMITTED, S.DECLINED, S.IN_PROGRESS]) {
+  app = { status: st, trialOffers: [off("Dynamics")], interviewOffers: [off("Dynamics", E.COMPLETED)] };
+  d = getStaffDisplayStatus(app, powertrain);
+  check(`${st}: shown as-is to Powertrain, no hint`, d.status === st && !d.elsewhere, show(d));
+}
+
+// ---- hint formatting ----
+app = { status: S.INTERVIEW, interviewOffers: [off("Dynamics"), off("Body"), off("Dynamics", E.NO_SHOW), off("Powertrain", E.CANCELLED)] };
+d = getStaffDisplayStatus(app, powertrain);
+check("hint lists other systems once each, in offer order, never ours", !!d.elsewhere && formatElsewhere(d.elsewhere) === "Interview · Dynamics, Body" && d.status === S.SUBMITTED, show(d));
+app = { status: S.TRIAL, interviewOffers: [off("Dynamics", E.COMPLETED), off("Body", E.COMPLETED)], trialOffers: [off("Body")] };
+d = getStaffDisplayStatus(app, powertrain);
+check("hint shows the furthest stage only", !!d.elsewhere && formatElsewhere(d.elsewhere) === "Trial · Body", show(d));
+
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);

--- a/scripts/qa/users-regress.mjs
+++ b/scripts/qa/users-regress.mjs
@@ -1,0 +1,119 @@
+// Users page (PATCH /api/admin/users/[uid]): captains manage their own team's
+// roster; only admins change roles; an unchanged role is a no-op, not a 403.
+// Regression for the "Failed to update user" every captain save used to hit —
+// the edit form always sends the target's current role, and the route refused
+// any non-admin request that carried one. Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/users-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : { memberProfile: admin.firestore.FieldValue.delete() }) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const user = async (uid) => (await db.doc(`users/${uid}`).get()).data();
+const err = (r) => `${r.status} ${r.json?.error || ""}`;
+const patch = (c, uid, body) => api(c, "PATCH", `/api/admin/users/${uid}`, body);
+
+await ensureUser({ uid: "u-cap-c", email: "cap.c@utexas.edu", name: "Combustion Captain", role: "team_captain_ob", memberProfile: { team: "Combustion", system: "Powertrain" } });
+await ensureUser({ uid: "u-cap-none", email: "cap.none@utexas.edu", name: "Teamless Captain", role: "team_captain_ob" });
+await ensureUser({ uid: "u-lead-c", email: "lead.c@utexas.edu", name: "Combustion Lead", role: "system_lead", memberProfile: { team: "Combustion", system: "Body" } });
+await ensureUser({ uid: "u-lead-e", email: "lead.e@utexas.edu", name: "Electric Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+await ensureUser({ uid: "u-new", email: "new.member@utexas.edu", name: "New Member", role: "applicant" });
+await ensureUser({ uid: "u-app-x", email: "app.x@utexas.edu", name: "Plain Applicant", role: "applicant" });
+const adminC = await session("admin@utexas.edu");
+const capC = await session("cap.c@utexas.edu");
+const capNoneC = await session("cap.none@utexas.edu");
+const leadC = await session("lead.c@utexas.edu");
+const appC = await session("app.x@utexas.edu");
+let r, u;
+
+// ---- the report: a captain saves a team-mate's system with the role left as-is ----
+r = await patch(capC, "u-lead-c", { role: "system_lead", team: "Combustion", system: "Dynamics" });
+u = await user("u-lead-c");
+check("captain updates a team-mate's system, role sent unchanged -> 200 (the reported failure)", r.status === 200 && u.memberProfile.system === "Dynamics" && u.role === "system_lead", err(r));
+r = await patch(capC, "u-lead-c", { team: "Combustion", system: "Body" });
+u = await user("u-lead-c");
+check("captain save without a role field -> 200", r.status === 200 && u.memberProfile.system === "Body", err(r));
+
+// ---- role changes stay admin-only, and say so ----
+r = await patch(capC, "u-lead-c", { role: "reviewer", team: "Combustion", system: "Dynamics" });
+u = await user("u-lead-c");
+check("captain changing a role -> 403 naming admins; nothing written", r.status === 403 && /admin/i.test(r.json?.error || "") && u.role === "system_lead" && u.memberProfile.system === "Body", err(r));
+r = await patch(capC, "u-new", { role: "system_lead", team: "Combustion", system: "Body" });
+u = await user("u-new");
+check("captain cannot promote an unteamed user while adding them", r.status === 403 && u.role === "applicant" && !u.memberProfile, err(r));
+
+// ---- roster scoping ----
+r = await patch(capC, "u-new", { role: "applicant", team: "Combustion", system: "Body" });
+u = await user("u-new");
+check("captain adds an unteamed user to their own team -> 200, isMember true", r.status === 200 && u.memberProfile?.team === "Combustion" && u.memberProfile?.system === "Body" && u.isMember === true, err(r));
+r = await patch(capC, "u-lead-e", { role: "system_lead", team: "Combustion", system: "Body" });
+u = await user("u-lead-e");
+check("captain touching another team's member -> 403; untouched", r.status === 403 && u.memberProfile.team === "Electric", err(r));
+r = await patch(capC, "u-lead-c", { role: "system_lead", team: "Electric", system: "Body" });
+u = await user("u-lead-c");
+check("captain moving a team-mate to another team -> 403; untouched", r.status === 403 && u.memberProfile.team === "Combustion", err(r));
+r = await patch(capC, "u-cap-c", { role: "team_captain_ob", team: "Combustion", system: "Body" });
+u = await user("u-cap-c");
+check("captain editing themselves -> 403; untouched", r.status === 403 && u.memberProfile.system === "Powertrain", err(r));
+r = await patch(capNoneC, "u-lead-c", { role: "system_lead", team: "Combustion", system: "Dynamics" });
+u = await user("u-lead-c");
+check("captain with no team -> 403 that says so", r.status === 403 && /no team/i.test(r.json?.error || "") && u.memberProfile.system === "Body", err(r));
+r = await patch(capC, "u-lead-c", { role: "system_lead", team: "Combustion", system: "TrackSim" });
+check("captain setting a system that isn't on the team -> 400", r.status === 400 && (await user("u-lead-c")).memberProfile.system === "Body", err(r));
+r = await patch(capC, "u-new", { role: "applicant", team: null, system: null });
+u = await user("u-new");
+check("captain removes a team-mate from the team -> 200, membership cleared", r.status === 200 && !u.memberProfile && u.isMember === false, err(r));
+r = await patch(capC, "u-missing-xyz", { role: "applicant", team: "Combustion", system: "Body" });
+check("captain targeting an unknown uid -> 404", r.status === 404, err(r));
+
+// ---- admin ----
+r = await patch(adminC, "u-lead-c", { role: "reviewer", team: "Combustion", system: "Body" });
+u = await user("u-lead-c");
+check("admin changes a role -> 200", r.status === 200 && u.role === "reviewer", err(r));
+r = await patch(adminC, "u-lead-c", { role: "reviewer", team: "Combustion", system: "Powertrain" });
+u = await user("u-lead-c");
+check("admin save with an unchanged role -> 200", r.status === 200 && u.role === "reviewer" && u.memberProfile.system === "Powertrain", err(r));
+r = await patch(adminC, "u-lead-c", { role: "system_lead", team: "Electric", system: "Body" });
+u = await user("u-lead-c");
+check("admin moves a user across teams -> 200", r.status === 200 && u.role === "system_lead" && u.memberProfile.team === "Electric", err(r));
+r = await patch(adminC, "u-lead-c", { role: "superuser", team: "Combustion", system: "Body" });
+check("admin with an invalid role -> 400", r.status === 400 && (await user("u-lead-c")).role === "system_lead", err(r));
+r = await patch(adminC, "u-missing-xyz", { role: "applicant" });
+check("admin targeting an unknown uid -> 404", r.status === 404, err(r));
+
+// ---- everyone else ----
+r = await patch(leadC, "u-new", { role: "applicant", team: "Combustion", system: "Body" });
+check("system lead -> 403", r.status === 403 && !(await user("u-new")).memberProfile, err(r));
+r = await patch(appC, "u-new", { role: "applicant", team: "Combustion", system: "Body" });
+check("applicant -> 401/403", (r.status === 401 || r.status === 403) && !(await user("u-new")).memberProfile, err(r));
+
+// restore
+await patch(adminC, "u-lead-c", { role: "system_lead", team: "Combustion", system: "Body" });
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Tier 2 of the landmine audit that followed the premature-advance incident (#103): the applicant-facing gates. Plus two staff-console fixes reported while this was in review and riding along: #124 (Users page) and #126 (per-system status badge).

## What changes

| Issue | Fix |
|---|---|
| #111 | The applicant payload now carries `editable` (computed in `sanitizeApplicationForApplicant`, never stored). It is false once a lead has advanced the application (`interview`), even though the visible status is still "Submitted"; the apply form uses it to render the "under review — can no longer be edited" view instead of an editable form whose every autosave fails, and an already-open tab flips to that view on the first refused save. A rejection made during `open` is masked and deliberately does **not** freeze the form: the applicant route accepts those saves like any peer's and never writes `status` for a rejected application, so the decision is unreachable. The only per-applicant signal exposed is therefore "advanced early", which is the residual #118(a) accepts |
| #112 | Trial responses require a live, released offer: step ≥ `release_trial` and visible status `trial` (what the dashboard renders the Accept button on). Gated on the visible status only, never the real one — a masked rejection gets the same answer as a peer, and recording a response on an already-rejected application is harmless because the write never touches a decision field. Cache invalidated after the write |
| #114 | Interview-system selection refused once the step reaches `close_interviews`, and the GET stops offering the picker at the same point so there is no dead-end UI. Deliberately **not** keyed on a masked interview rejection: refusing one applicant while peers succeed would reveal the decision |
| #115 | Admin `PATCH /api/admin/applications/[id]` validates `preferredSystems` the way the applicant route does (array, ≤3, distinct, on-team). Only a *changed* ranking is validated — the edit modal resends the stored ranking with unrelated edits, and a legacy off-team entry must not block a graduation-year fix. A team change revalidates whichever ranking will remain against the *new* team and must arrive with a non-empty one; clearing the ranking on the same team stays allowed |
| #124 | Captains could never save from `/admin/users`: the edit modal always sent `role` and the route treated any present `role` as an admin-only change → 403 behind a generic "Failed to update user". An unchanged role is now a no-op; the role field is only offered to admins (captains see a read-only chip) and only sent when changed; the toast shows the server's reason; an unknown uid is a 404 rather than a 500 |
| #126 | For system leads and reviewers the status badge, chips, pipeline bar and status box now mean "what has *my* system done with this applicant" — Submitted = not acted, Interview / Trial = we offered, Rejected = we rejected — instead of the applicant's global stage, which made an application Dynamics advanced fall out of Powertrain's "Submitted" queue. Global end states (draft, fully rejected, accepted, waitlisted, committed, declined) show as-is; admins and captains keep the global view. A muted hint ("Interview · Dynamics") shows when another system has taken the applicant further than ours. One shared helper (`lib/utils/staffDisplayStatus.ts`) replaces the two diverging copies in the sidebar and the full-screen list; presentation only — every action gate still keys on the real status |

## #113 — decided against, with reasons

The plan was to lock `preferredSystems` once any system has acted. Built, reviewed, then **reverted**: during `open`, interview offers essentially don't exist yet, so "your ranking is locked" is in practice a readout of `rejectedBySystems` — a masked field — visible passively by comparing with a peer. Decision (product owner): applicants own their ranking until applications close. If someone drops the system that rejected them, that lead loses an applicant who withdrew from their system, and the per-system rejection rule (#92) recomputes correctly. Issue closed with this rationale.

## Independent review

Opus review pass found 6 items: the #113 leak (above — resolved by reverting), a draft with stale `rejectedBySystems` becoming unsubmittable (moot after the revert), the admin-PATCH legacy-ranking regression (fixed), the interview-selection per-applicant refusal (removed), the trial gate using real vs visible status, and the open-tab "Failed to save" residual.

Celina's review, two rounds: the trial gate was itself a masked-decision oracle (fixed — visible status only), interview GET/POST mismatch (fixed), `editable` freezing masked rejections during `open` (fixed — rejected stays editable, see #111), team change bypassing ranking validation and the empty-ranking gap (fixed), 403 handling and its toast flash (fixed), duplicate config read (fixed).

## Verification

- `scripts/qa/applicant-gates-regress.mjs` (committed) — **33 checks**: `editable` on list and single GET across draft / submitted / advanced / rejected-while-open, no internal fields alongside it; a rejected-while-open applicant can edit, re-submit and re-rank with the decision untouched; ranking changes still allowed after a masked rejection with nothing leaked; admin PATCH string / off-team / duplicate / valid / unchanged-legacy / team change with off-team, matching, empty and explicitly-empty rankings / clearing on the same team; trial response before release, on a masked trial rejection (same answer as a peer), and on a live offer; interview picker offered during `interviewing` and withdrawn after `close_interviews`, selection after a masked rejection (unchanged response), and after `close_interviews`
- `scripts/qa/users-regress.mjs` (committed) — **19 checks**: captain own-team edit with the role sent unchanged (the report), without a role, role change refused with the reason, other team / move / self / no team / invalid system / remove membership / unknown uid; admin role change, unchanged role, cross-team move, invalid role, unknown uid; lead and applicant refused. Against the pre-fix route it reproduces the report verbatim
- `scripts/qa/staff-status-regress.ts` (committed, pure function, `npx tsx`) — **28 checks**: the report (Dynamics advanced → Powertrain sees Submitted + hint; Dynamics, captain, admin, profile-less lead see Interview), both-offered, trial elsewhere at each combination of our stage vs theirs, our rejection while alive elsewhere (with and without hint), cancelled / no-show offers, every global end state passing through untouched, hint formatting (de-duplicated, ours excluded, furthest stage only)
- Existing harnesses unchanged in outcome: transitions 57/57, rejection 27/27, drafts 20/20, bulk 12/12, sweeps 20/20
- Browser-verified in the emulator: an advanced applicant's `/apply/electric` shows the under-review view; a submitted applicant's form and ranking behave as before. As a Powertrain reviewer, all six badge/hint states render in the sidebar and detail header in both themes, and the "Submitted" chip alone lists exactly the three applications Powertrain has not acted on
- `npx tsc --noEmit` and `npm run build` clean

## Migration / data

None.
