### PR TITLE
feat: staff audit log (#119)

### DIFF
--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { downloadCsv } from "@/lib/utils/downloadFile";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import clsx from "clsx";
@@ -13,14 +14,6 @@ function actorLabel(e: AuditEntryDto): string {
   const who = e.actor?.name || e.actor?.email || e.actor?.uid || "unknown";
   const scope = e.actor?.system || e.actor?.team;
   return scope ? `${who} · ${scope}` : who;
-}
-
-function downloadCsv(filename: string, rows: (string | number)[][]) {
-  const esc = (v: string | number) => { const s = String(v); return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s; };
-  const blob = new Blob([rows.map((r) => r.map(esc).join(",")).join("\n")], { type: "text/csv" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a"); a.href = url; a.download = filename; a.click();
-  URL.revokeObjectURL(url);
 }
 
 export function ActivityView() {
@@ -99,7 +92,7 @@ export function ActivityView() {
         </div>
 
         {error && <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-300">{error}</div>}
-        {truncated && <div className="mb-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-[12px] text-white/60">Showing the newest 1,000 events only — filters apply within that window. Look up a specific application from its detail page for its full history.</div>}
+        {truncated && <div className="mb-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-[12px] text-white/60">Not every event is loaded — this list holds the newest {entries.length}, and the staff / application filters only search those. Narrow with the action filter, or open a specific application for its full History.</div>}
 
         <div className="rounded-xl border border-white/10 bg-white/[0.04] overflow-x-auto">
           <table className="w-full text-[13px]">
@@ -118,8 +111,12 @@ export function ActivityView() {
                   <td className="py-2.5 px-3 whitespace-nowrap text-white/60">{fmtWhen(e.at)}</td>
                   <td className="py-2.5 px-3 text-white/80"><div className="font-semibold text-white">{e.actor?.name || e.actor?.email || e.actor?.uid}</div><div className="text-[11px] text-white/40">{[e.actor?.role, e.actor?.system || e.actor?.team].filter(Boolean).join(" · ")}</div></td>
                   <td className="py-2.5 px-3 whitespace-nowrap">
-                    <span className={clsx("inline-block px-2 py-0.5 rounded-md text-[11px] font-semibold", e.outcome === "refused" ? "bg-red-500/10 text-red-300 border border-red-500/20" : "bg-white/5 text-white/70 border border-white/10")}>
-                      {e.outcome === "refused" ? "Refused · " : ""}{AUDIT_ACTION_LABELS[e.action] ?? e.action}
+                    <span
+                      className={clsx("inline-block px-2 py-0.5 rounded-md text-[11px] font-semibold", e.outcome === "ok" && "bg-white/5 text-white/70 border border-white/10")}
+                      // Inline colours (like the sidebar badges) so refused/error read in both themes.
+                      style={e.outcome === "refused" ? { backgroundColor: "rgba(239,68,68,0.10)", border: "1px solid rgba(239,68,68,0.25)", color: "rgba(220,38,38,0.95)" } : e.outcome === "error" ? { backgroundColor: "rgba(245,158,11,0.12)", border: "1px solid rgba(245,158,11,0.30)", color: "rgba(217,119,6,0.95)" } : undefined}
+                    >
+                      {e.outcome === "refused" ? "Refused · " : e.outcome === "error" ? "Error · " : ""}{AUDIT_ACTION_LABELS[e.action] ?? e.action}
                     </span>
                   </td>
                   <td className="py-2.5 px-3 whitespace-nowrap text-white/60">

--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import clsx from "clsx";
+import { Download, Loader2, RefreshCw } from "lucide-react";
+import { AUDIT_ACTION_LABELS, type AuditAction, type AuditEntryDto } from "@/lib/models/Audit";
+
+const fmtWhen = (iso: string) =>
+  new Date(iso).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+
+function actorLabel(e: AuditEntryDto): string {
+  const who = e.actor?.name || e.actor?.email || e.actor?.uid || "unknown";
+  const scope = e.actor?.system || e.actor?.team;
+  return scope ? `${who} · ${scope}` : who;
+}
+
+function downloadCsv(filename: string, rows: (string | number)[][]) {
+  const esc = (v: string | number) => { const s = String(v); return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s; };
+  const blob = new Blob([rows.map((r) => r.map(esc).join(",")).join("\n")], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a"); a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ActivityView() {
+  const [entries, setEntries] = useState<AuditEntryDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [action, setAction] = useState<string>("");
+  const [actorQuery, setActorQuery] = useState("");
+  const [appQuery, setAppQuery] = useState("");
+  const [refusedOnly, setRefusedOnly] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      const q = new URLSearchParams({ limit: "300" });
+      if (action) q.set("action", action);
+      const res = await fetch(`/api/admin/audit?${q}`);
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || `HTTP ${res.status}`);
+      setEntries(((await res.json()).entries || []) as AuditEntryDto[]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [action]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const rows = useMemo(() => {
+    const a = actorQuery.trim().toLowerCase(), p = appQuery.trim().toLowerCase();
+    return entries.filter((e) =>
+      (!a || actorLabel(e).toLowerCase().includes(a) || (e.actor?.email || "").toLowerCase().includes(a)) &&
+      (!p || (e.applicationId || "").toLowerCase().includes(p) || (e.targetUid || "").toLowerCase().includes(p)) &&
+      (!refusedOnly || e.outcome === "refused")
+    );
+  }, [entries, actorQuery, appQuery, refusedOnly]);
+
+  const exportCsv = () => downloadCsv("activity.csv", [
+    ["time", "actor", "email", "role", "action", "outcome", "application", "team", "systems", "detail"],
+    ...rows.map((e) => [e.at, e.actor?.name || "", e.actor?.email || "", e.actor?.role || "", e.action, e.outcome, e.applicationId || e.targetUid || "", e.applicantTeam || "", (e.systems || []).join("+"), e.detail || ""]),
+  ]);
+
+  return (
+    <div className="min-h-screen pt-24 pb-20 relative">
+      <div className="fixed inset-0 -z-10" style={{ background: "radial-gradient(ellipse at 20% 0%, rgba(4,95,133,0.07) 0%, transparent 50%), #030608" }} />
+      <div className="container mx-auto px-6 md:px-10 max-w-6xl">
+        <div className="mb-6 flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold tracking-[0.3em] uppercase mb-3" style={{ color: "var(--lhr-gray-blue)" }}>Admin</p>
+            <h1 className="text-3xl md:text-4xl font-bold text-white tracking-tight">Activity</h1>
+            <p className="text-[12px] text-white/35 mt-2">Every staff action on applications, users and configuration — who, what, when. Refused attempts are recorded too. No applicant names or emails appear here.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={exportCsv} disabled={rows.length === 0} className="inline-flex items-center gap-2 px-3 h-10 rounded-lg text-[13px] font-semibold bg-white/5 border border-white/10 text-white/60 hover:bg-white/10 hover:text-white disabled:opacity-40">
+              <Download className="h-3.5 w-3.5" /> CSV
+            </button>
+            <button onClick={load} disabled={loading} className={clsx("inline-flex items-center gap-2 px-4 h-10 rounded-lg text-[13px] font-semibold transition-all", loading ? "bg-white/5 border border-white/5 text-white/20" : "bg-white/5 border border-white/10 text-white/60 hover:bg-white/10 hover:text-white")}>
+              {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5 opacity-60" />} Refresh
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <select value={action} onChange={(e) => setAction(e.target.value)} className="h-8 px-2 rounded-md text-[12px] bg-white/5 border border-white/10 text-white/80">
+            <option value="">All actions</option>
+            {(Object.keys(AUDIT_ACTION_LABELS) as AuditAction[]).map((a) => <option key={a} value={a}>{AUDIT_ACTION_LABELS[a]}</option>)}
+          </select>
+          <input value={actorQuery} onChange={(e) => setActorQuery(e.target.value)} placeholder="Filter by staff name / email" className="h-8 px-2.5 rounded-md text-[12px] bg-white/5 border border-white/10 text-white/80 placeholder:text-white/30 w-56" />
+          <input value={appQuery} onChange={(e) => setAppQuery(e.target.value)} placeholder="Application or user id" className="h-8 px-2.5 rounded-md text-[12px] bg-white/5 border border-white/10 text-white/80 placeholder:text-white/30 w-48" />
+          <label className="inline-flex items-center gap-1.5 text-[12px] text-white/60 select-none"><input type="checkbox" checked={refusedOnly} onChange={(e) => setRefusedOnly(e.target.checked)} /> Refused only</label>
+          <span className="text-[12px] text-white/30 ml-auto">{rows.length} of {entries.length} loaded</span>
+        </div>
+
+        {error && <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-300">{error}</div>}
+
+        <div className="rounded-xl border border-white/10 bg-white/[0.04] overflow-x-auto">
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                <th className="text-left font-semibold py-2.5 px-3">When</th>
+                <th className="text-left font-semibold py-2.5 px-3">Who</th>
+                <th className="text-left font-semibold py-2.5 px-3">Action</th>
+                <th className="text-left font-semibold py-2.5 px-3">Target</th>
+                <th className="text-left font-semibold py-2.5 px-3">Detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((e) => (
+                <tr key={e.id} onClick={() => setExpanded(expanded === e.id ? null : e.id ?? null)} className="border-t border-white/5 align-top cursor-pointer hover:bg-white/[0.03]">
+                  <td className="py-2.5 px-3 whitespace-nowrap text-white/60">{fmtWhen(e.at)}</td>
+                  <td className="py-2.5 px-3 text-white/80"><div className="font-semibold text-white">{e.actor?.name || e.actor?.email || e.actor?.uid}</div><div className="text-[11px] text-white/40">{[e.actor?.role, e.actor?.system || e.actor?.team].filter(Boolean).join(" · ")}</div></td>
+                  <td className="py-2.5 px-3 whitespace-nowrap">
+                    <span className={clsx("inline-block px-2 py-0.5 rounded-md text-[11px] font-semibold", e.outcome === "refused" ? "bg-red-500/10 text-red-300 border border-red-500/20" : "bg-white/5 text-white/70 border border-white/10")}>
+                      {e.outcome === "refused" ? "Refused · " : ""}{AUDIT_ACTION_LABELS[e.action] ?? e.action}
+                    </span>
+                  </td>
+                  <td className="py-2.5 px-3 whitespace-nowrap text-white/60">
+                    {e.applicationId ? <Link href={`/admin/applications?id=${e.applicationId}`} onClick={(ev) => ev.stopPropagation()} className="hover:text-white underline-offset-2 hover:underline">{e.applicationId.slice(0, 8)}…</Link> : e.targetUid ? <span title={e.targetUid}>user {e.targetUid.slice(0, 8)}…</span> : <span className="text-white/25">—</span>}
+                    {e.applicantTeam && <span className="ml-1.5 text-[11px] text-white/35">{e.applicantTeam}</span>}
+                  </td>
+                  <td className="py-2.5 px-3 text-white/60">
+                    <div>{e.detail || ""}{e.systems?.length ? <span className="text-white/35"> · {e.systems.join(", ")}</span> : null}</div>
+                    {expanded === e.id && (e.before || e.after) && (
+                      <pre className="mt-2 text-[11px] leading-snug text-white/50 bg-black/30 rounded-md p-2 overflow-x-auto">{JSON.stringify({ before: e.before, after: e.after }, null, 1)}</pre>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {!loading && rows.length === 0 && <tr><td colSpan={5} className="py-8 text-center text-white/30 text-[13px]">Nothing recorded yet.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -32,6 +32,7 @@ export function ActivityView() {
   const [appQuery, setAppQuery] = useState("");
   const [refusedOnly, setRefusedOnly] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true); setError(null);
@@ -40,7 +41,9 @@ export function ActivityView() {
       if (action) q.set("action", action);
       const res = await fetch(`/api/admin/audit?${q}`);
       if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || `HTTP ${res.status}`);
-      setEntries(((await res.json()).entries || []) as AuditEntryDto[]);
+      const data = await res.json();
+      setEntries((data.entries || []) as AuditEntryDto[]);
+      setTruncated(Boolean(data.truncated));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -96,6 +99,7 @@ export function ActivityView() {
         </div>
 
         {error && <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-300">{error}</div>}
+        {truncated && <div className="mb-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-[12px] text-white/60">Showing the newest 1,000 events only — filters apply within that window. Look up a specific application from its detail page for its full history.</div>}
 
         <div className="rounded-xl border border-white/10 bg-white/[0.04] overflow-x-auto">
           <table className="w-full text-[13px]">
@@ -125,7 +129,7 @@ export function ActivityView() {
                   <td className="py-2.5 px-3 text-white/60">
                     <div>{e.detail || ""}{e.systems?.length ? <span className="text-white/35"> · {e.systems.join(", ")}</span> : null}</div>
                     {expanded === e.id && (e.before || e.after) && (
-                      <pre className="mt-2 text-[11px] leading-snug text-white/50 bg-black/30 rounded-md p-2 overflow-x-auto">{JSON.stringify({ before: e.before, after: e.after }, null, 1)}</pre>
+                      <pre className="mt-2 text-[11px] leading-snug text-white/60 bg-white/5 border border-white/10 rounded-md p-2 overflow-x-auto">{JSON.stringify({ before: e.before, after: e.after }, null, 1)}</pre>
                     )}
                   </td>
                 </tr>

--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -119,7 +119,7 @@ export function ActivityView() {
                     </span>
                   </td>
                   <td className="py-2.5 px-3 whitespace-nowrap text-white/60">
-                    {e.applicationId ? <Link href={`/admin/applications?id=${e.applicationId}`} onClick={(ev) => ev.stopPropagation()} className="hover:text-white underline-offset-2 hover:underline">{e.applicationId.slice(0, 8)}…</Link> : e.targetUid ? <span title={e.targetUid}>user {e.targetUid.slice(0, 8)}…</span> : <span className="text-white/25">—</span>}
+                    {e.applicationId ? <Link href={`/admin/applications/${e.applicationId}`} onClick={(ev) => ev.stopPropagation()} className="hover:text-white underline-offset-2 hover:underline">{e.applicationId.slice(0, 8)}…</Link> : e.targetUid ? <span title={e.targetUid}>user {e.targetUid.slice(0, 8)}…</span> : <span className="text-white/25">—</span>}
                     {e.applicantTeam && <span className="ml-1.5 text-[11px] text-white/35">{e.applicantTeam}</span>}
                   </td>
                   <td className="py-2.5 px-3 text-white/60">

--- a/app/admin/activity/page.tsx
+++ b/app/admin/activity/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { requireRoles } from "@/lib/auth/guard";
+import { UserRole } from "@/lib/models/User";
+import { ActivityView } from "./ActivityView";
+
+export const metadata: Metadata = { title: "Activity" };
+
+// Admins and team captains only — the nav hides the link, the URL doesn't.
+export default async function AdminActivityPage() {
+  try {
+    await requireRoles([UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB]);
+  } catch {
+    redirect("/admin/dashboard");
+  }
+  return <ActivityView />;
+}

--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -1221,7 +1221,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                   <span className="font-urbanist text-[10px] text-white/15 shrink-0">{format(new Date(h.at), "MMM d, h:mm a")}</span>
                 </div>
                 <p className="font-urbanist text-[12px] text-white/40 leading-snug">
-                  {h.outcome === "refused" ? "Refused — " : ""}{h.detail || h.action}
+                  {h.outcome === "refused" ? "Refused — " : h.outcome === "error" ? "Error — " : ""}{h.detail || h.action}
                 </p>
               </div>
             ))}

--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -102,6 +102,14 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
 
   // Extras State
   const [notes, setNotes] = useState<Note[]>([]);
+  type HistoryRow = { id?: string; at: string; actor?: { uid?: string; name?: string; email?: string; role?: string; system?: string; team?: string }; action: string; outcome: string; detail?: string; systems?: string[] };
+  const [history, setHistory] = useState<HistoryRow[]>([]);
+  const loadHistory = () => {
+    fetch(`/api/admin/applications/${applicationId}/audit`)
+      .then((res) => (res.ok ? res.json() : { entries: [] }))
+      .then((data) => setHistory(data.entries || []))
+      .catch(() => setHistory([]));
+  };
   const [tasks, setTasks] = useState<ReviewTask[]>([]);
   const [newNote, setNewNote] = useState("");
   const [sendingNote, setSendingNote] = useState(false);
@@ -156,6 +164,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
     fetch(`/api/admin/applications/${applicationId}/notes`)
       .then(res => res.json())
       .then(data => setNotes(data.notes || []));
+    loadHistory();
 
     fetch(`/api/admin/applications/${applicationId}/tasks`)
       .then(res => res.json())
@@ -221,6 +230,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
             ? { ...a, ...data.application, user: a.user }
             : a
         ));
+        loadHistory();
         posthog.capture("application_status_updated", {
           application_team: selectedApp?.team,
           status,
@@ -344,6 +354,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
             ? { ...a, ...data.application, user: a.user }
             : a
         ));
+        loadHistory();
         posthog.capture("application_rejected", {
           application_team: selectedApp?.team,
           system_count: selectedRejectSystems.length,
@@ -1168,6 +1179,42 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
               </div>
             </div>
           )}
+        </div>
+
+        <div className="h-px" style={{ backgroundColor: "rgba(255,255,255,0.04)" }} />
+
+        {/* History — who did what to this application (#119) */}
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-montserrat text-[11px] font-semibold tracking-widest uppercase" style={{ color: "var(--lhr-gray-blue)" }}>History</h3>
+            <span
+              className="text-[10px] font-semibold font-urbanist px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: "rgba(4,95,133,0.1)", color: "var(--lhr-blue)", border: "1px solid rgba(4,95,133,0.2)" }}
+            >
+              {history.length}
+            </span>
+          </div>
+          <div className="space-y-2 mb-2 max-h-60 overflow-y-auto">
+            {history.map((h, i) => (
+              <div
+                key={h.id ?? i}
+                className="rounded-lg px-3 py-2"
+                style={{ backgroundColor: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.04)" }}
+              >
+                <div className="flex justify-between items-center gap-2">
+                  <span className="font-montserrat text-[11px] font-bold text-white/60 truncate">
+                    {h.actor?.name || h.actor?.email || h.actor?.uid}
+                    {h.actor?.system ? ` · ${h.actor.system}` : h.actor?.role ? ` · ${h.actor.role}` : ""}
+                  </span>
+                  <span className="font-urbanist text-[10px] text-white/15 shrink-0">{format(new Date(h.at), "MMM d, h:mm a")}</span>
+                </div>
+                <p className="font-urbanist text-[12px] text-white/40 leading-snug">
+                  {h.outcome === "refused" ? "Refused — " : ""}{h.detail || h.action}
+                </p>
+              </div>
+            ))}
+            {history.length === 0 && <p className="font-urbanist text-[12px] text-white/20 italic text-center py-2">No recorded actions yet.</p>}
+          </div>
         </div>
 
         <div className="h-px" style={{ backgroundColor: "rgba(255,255,255,0.04)" }} />

--- a/app/admin/applications/_components/CsvExportButton.tsx
+++ b/app/admin/applications/_components/CsvExportButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { downloadBlob } from "@/lib/utils/downloadFile";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Download, Loader2, ChevronDown } from "lucide-react";
 import { toast } from "react-hot-toast";
@@ -153,16 +154,9 @@ export default function CsvExportButton({ currentUser }: CsvExportButtonProps) {
 
       // Trigger download
       const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
       const disposition = res.headers.get("Content-Disposition") || "";
       const filenameMatch = disposition.match(/filename="([^"]+)"/);
-      a.download = filenameMatch ? filenameMatch[1] : "applicants_export.csv";
-      a.href = url;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(filenameMatch ? filenameMatch[1] : "applicants_export.csv", blob);
       
       posthog.capture("applications_csv_exported", {
         selected_team_count: selectedTeams.length,

--- a/app/admin/stats/StatsView.tsx
+++ b/app/admin/stats/StatsView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { downloadCsv } from "@/lib/utils/downloadFile";
 import { useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { Download, Loader2, RefreshCw } from "lucide-react";
@@ -69,18 +70,6 @@ function fmtWhen(ms: number, bucket: BucketMinutes): string {
   const d = new Date(ms);
   if (bucket === 1440) return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
   return d.toLocaleString("en-US", { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
-}
-
-function downloadCsv(filename: string, rows: (string | number)[][]) {
-  const esc = (v: string | number) => {
-    const s = String(v);
-    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-  };
-  const blob = new Blob([rows.map((r) => r.map(esc).join(",")).join("\n")], { type: "text/csv" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url; a.download = filename; a.click();
-  URL.revokeObjectURL(url);
 }
 
 // ---------------------------------------------------------------------------

--- a/app/api/admin/applications/[id]/audit/route.ts
+++ b/app/api/admin/applications/[id]/audit/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireStaffForApplication } from "@/lib/auth/guard";
+import { listAudit } from "@/lib/firebase/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/applications/[id]/audit
+ * Who did what to this application, newest first. Same per-record scoping as
+ * every other single-application route. Entries carry no applicant PII.
+ */
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await requireStaffForApplication(id);
+    const entries = await listAudit({ applicationId: id, limit: 200 });
+    return NextResponse.json(
+      { entries: entries.map((e) => ({ ...e, at: e.at.toISOString() })) },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  } catch (error) {
+    if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
+    }
+    if (error instanceof Error && error.message === "Application not found") {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    logger.error({ err: error, applicationId: id }, "Failed to load application audit");
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/admin/applications/[id]/audit/route.ts
+++ b/app/api/admin/applications/[id]/audit/route.ts
@@ -14,7 +14,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   const { id } = await params;
   try {
     await requireStaffForApplication(id);
-    const entries = await listAudit({ applicationId: id, limit: 200 });
+    const { entries } = await listAudit({ applicationId: id, limit: 200 });
     return NextResponse.json(
       { entries: entries.map((e) => ({ ...e, at: e.at.toISOString() })) },
       { headers: { "Cache-Control": "private, no-store" } }

--- a/app/api/admin/applications/[id]/interview/[system]/route.ts
+++ b/app/api/admin/applications/[id]/interview/[system]/route.ts
@@ -92,7 +92,7 @@ export async function PATCH(
       systems: [targetSystem],
       before: snapshotApplication(application),
       after: snapshotApplication(updatedApp),
-      detail: `${targetSystem} interview → ${status}${cancelReason ? ` (${cancelReason})` : ""}`,
+      detail: `${targetSystem} interview → ${status}${cancelReason ? ` (${String(cancelReason).slice(0, 200)})` : ""}`,
     });
 
     return NextResponse.json({ application: updatedApp }, { status: 200 });

--- a/app/api/admin/applications/[id]/interview/[system]/route.ts
+++ b/app/api/admin/applications/[id]/interview/[system]/route.ts
@@ -5,6 +5,7 @@ import { InterviewEventStatus } from "@/lib/models/Application";
 import { getUser } from "@/lib/firebase/users";
 import { checkTeamAccess, resolveScorecardSystem, STAFF_ROLES } from "@/lib/auth/teamAccess";
 import { logger } from "@/lib/logger";
+import { recordAudit, snapshotApplication } from "@/lib/firebase/audit";
 
 
 /**
@@ -83,6 +84,16 @@ export async function PATCH(
     if (!updatedApp) {
       return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
+
+    await recordAudit(request, currentUser ?? { uid }, {
+      action: "application.interview_offer",
+      applicationId: id,
+      applicantTeam: application?.team,
+      systems: [targetSystem],
+      before: snapshotApplication(application),
+      after: snapshotApplication(updatedApp),
+      detail: `${targetSystem} interview → ${status}${cancelReason ? ` (${cancelReason})` : ""}`,
+    });
 
     return NextResponse.json({ application: updatedApp }, { status: 200 });
 

--- a/app/api/admin/applications/[id]/notes/[noteId]/route.ts
+++ b/app/api/admin/applications/[id]/notes/[noteId]/route.ts
@@ -4,6 +4,7 @@ import { getApplication } from "@/lib/firebase/applications";
 import { getUser } from "@/lib/firebase/users";
 import { checkTeamAccess } from "@/lib/auth/teamAccess";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 // DELETE a note
@@ -36,6 +37,8 @@ export async function DELETE(
       .collection("notes")
       .doc(noteId)
       .delete();
+
+    await recordAudit(request, user ?? { uid: decodedToken.uid }, { action: "application.note_deleted", applicationId: id, applicantTeam: application.team, detail: `deleted note ${noteId}` });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -9,6 +9,7 @@ import { requireStaffForApplication } from "@/lib/auth/guard";
 import { UserRole, User } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
 import { appCache } from "@/lib/utils/appCache";
+import { recordAudit, snapshotApplication } from "@/lib/firebase/audit";
 
 
 /**
@@ -59,6 +60,7 @@ export async function POST(
     const { currentStep } = await getRecruitingConfig();
     const refusal = validateStaffTransition({ from: application.status, to: ApplicationStatus.REJECTED, role: currentUser.role, step: currentStep, perSystemReject: true });
     if (refusal) {
+      await recordAudit(request, currentUser, { action: "application.reject", outcome: "refused", applicationId: id, applicantTeam: application.team, detail: refusal.error });
       return NextResponse.json({ error: refusal.error }, { status: refusal.status });
     }
 
@@ -100,6 +102,16 @@ export async function POST(
     }
 
     appCache.invalidateApplications();
+
+    await recordAudit(request, currentUser, {
+      action: "application.reject",
+      applicationId: id,
+      applicantTeam: application.team,
+      systems,
+      before: snapshotApplication(application),
+      after: snapshotApplication(updatedApp),
+      detail: fullyRejected ? `rejected by ${systems.join(", ")} — now fully rejected` : `rejected by ${systems.join(", ")}`,
+    });
 
     return NextResponse.json({
       application: updatedApp,

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -91,8 +91,10 @@ export async function PATCH(
       action: "application.edit",
       applicationId: id,
       applicantTeam: currentData?.team,
+      // `after` must describe the resulting record, not the request body:
+      // a formData-only edit leaves team and ranking exactly as they were.
       before: { team: currentData?.team, preferredSystems: currentData?.preferredSystems },
-      after: { team: updates.team, preferredSystems: updates.preferredSystems },
+      after: { team: updates.team ?? currentData?.team, preferredSystems: updates.preferredSystems ?? currentData?.preferredSystems },
       detail: `edited ${Object.keys(updates).filter((k) => k !== "updatedAt").join(", ")}${formData ? ` (${Object.keys(formData).join(", ")})` : ""}`,
     });
 

--- a/app/api/admin/applications/[id]/route.ts
+++ b/app/api/admin/applications/[id]/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/auth/guard";
 import { adminDb } from "@/lib/firebase/admin";
 import { Team } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -14,7 +15,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
     const { id } = await params;
     
     const body = await request.json();
@@ -54,6 +55,15 @@ export async function PATCH(
     }
 
     await docRef.update(updates);
+
+    await recordAudit(request, actor, {
+      action: "application.edit",
+      applicationId: id,
+      applicantTeam: currentData?.team,
+      before: { team: currentData?.team, preferredSystems: currentData?.preferredSystems },
+      after: { team: updates.team, preferredSystems: updates.preferredSystems },
+      detail: `edited ${Object.keys(updates).filter((k) => k !== "updatedAt").join(", ")}${formData ? ` (${Object.keys(formData).join(", ")})` : ""}`,
+    });
 
     // Fetch updated application
     const updatedDoc = await docRef.get();

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -45,12 +45,16 @@ export async function POST(
     if (!current) {
       return NextResponse.json({ error: "Application not found" }, { status: 404 });
     }
+    // Every refusal on this route is recorded — the role fences below
+    // included: a lead repeatedly trying to act on another system's behalf is
+    // exactly what those fences exist to catch.
+    const refuse = async (httpStatus: number, error: string) => {
+      await recordAudit(request, currentUser, { action: "application.status", outcome: "refused", applicationId: id, applicantTeam: current.team, detail: `${current.status} → ${status}: ${error}` });
+      return NextResponse.json({ error }, { status: httpStatus });
+    };
     const { currentStep: stepNow } = await getRecruitingConfig();
     const refusal = validateStaffTransition({ from: current.status, to: status, role: currentUser.role, step: stepNow });
-    if (refusal) {
-      await recordAudit(request, currentUser, { action: "application.status", outcome: "refused", applicationId: id, applicantTeam: current.team, detail: `${current.status} → ${status}: ${refusal.error}` });
-      return NextResponse.json({ error: refusal.error }, { status: refusal.status });
-    }
+    if (refusal) return refuse(refusal.status, refusal.error);
 
     // A system lead may only extend interview offers for their own system.
     // Captains and admins can offer on behalf of any system on the team (the
@@ -60,9 +64,7 @@ export async function POST(
       const leadSystem = currentUser.memberProfile?.system;
 
       if (!leadSystem) {
-        return NextResponse.json({
-          error: "Your account has no system assigned. Ask an admin to set your system before extending interview offers."
-        }, { status: 403 });
+        return refuse(403, "Your account has no system assigned. Ask an admin to set your system before extending interview offers.");
       }
 
       // No explicit systems means the route would fall back to every preferred
@@ -75,9 +77,7 @@ export async function POST(
 
       const foreign = systems.filter((s: string) => s !== leadSystem);
       if (foreign.length > 0) {
-        return NextResponse.json({
-          error: `System leads can only extend interview offers for their own system (${leadSystem}). Ask your team captain to offer for ${foreign.join(", ")}.`
-        }, { status: 403 });
+        return refuse(403, `System leads can only extend interview offers for their own system (${leadSystem}). Ask your team captain to offer for ${foreign.join(", ")}.`);
       }
     }
 
@@ -89,15 +89,11 @@ export async function POST(
       const offerSystem = offer?.system;
 
       if (!leadSystem) {
-        return NextResponse.json({
-          error: "Your account has no system assigned. Ask an admin to set your system before accepting applicants."
-        }, { status: 403 });
+        return refuse(403, "Your account has no system assigned. Ask an admin to set your system before accepting applicants.");
       }
 
       if (!offerSystem || offerSystem !== leadSystem) {
-        return NextResponse.json({
-          error: `System leads can only accept applicants into their own system (${leadSystem}). Ask your team captain to accept into ${offerSystem || "another system"}.`
-        }, { status: 403 });
+        return refuse(403, `System leads can only accept applicants into their own system (${leadSystem}). Ask your team captain to accept into ${offerSystem || "another system"}.`);
       }
     }
 
@@ -132,17 +128,13 @@ export async function POST(
       if (currentUser.role === UserRole.SYSTEM_LEAD) {
         const userSystem = currentUser.memberProfile?.system;
         if (!userSystem) {
-          return NextResponse.json({
-            error: "System lead profile not configured properly"
-          }, { status: 403 });
+          return refuse(403, "System lead profile not configured properly");
         }
         // Filter to only their system - they cannot offer for other systems
         const originalSystems = [...systemsToOffer];
         systemsToOffer = systemsToOffer.filter(s => s === userSystem);
         if (systemsToOffer.length === 0) {
-          return NextResponse.json({
-            error: `System leads can only extend interview offers for their own system (${userSystem}). None of the selected systems match.`
-          }, { status: 403 });
+          return refuse(403, `System leads can only extend interview offers for their own system (${userSystem}). None of the selected systems match.`);
         }
         if (systemsToOffer.length < originalSystems.length) {
           logger.info({
@@ -187,17 +179,13 @@ export async function POST(
       if (currentUser.role === UserRole.SYSTEM_LEAD) {
         const userSystem = currentUser.memberProfile?.system;
         if (!userSystem) {
-          return NextResponse.json({
-            error: "System lead profile not configured properly"
-          }, { status: 403 });
+          return refuse(403, "System lead profile not configured properly");
         }
         // Filter to only their system - they cannot offer for other systems
         const originalSystems = [...systemsToOffer];
         systemsToOffer = systemsToOffer.filter(s => s === userSystem);
         if (systemsToOffer.length === 0) {
-          return NextResponse.json({
-            error: `System leads can only extend trial offers for their own system (${userSystem}). None of the selected systems match.`
-          }, { status: 403 });
+          return refuse(403, `System leads can only extend trial offers for their own system (${userSystem}). None of the selected systems match.`);
         }
         if (systemsToOffer.length < originalSystems.length) {
           logger.info({

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -13,6 +13,7 @@ import { sendStatusEmail } from "@/lib/email/send";
 import type { EmailTrigger } from "@/lib/models/EmailTemplate";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
+import { recordAudit, snapshotApplication } from "@/lib/firebase/audit";
 
 
 export async function POST(
@@ -47,6 +48,7 @@ export async function POST(
     const { currentStep: stepNow } = await getRecruitingConfig();
     const refusal = validateStaffTransition({ from: current.status, to: status, role: currentUser.role, step: stepNow });
     if (refusal) {
+      await recordAudit(request, currentUser, { action: "application.status", outcome: "refused", applicationId: id, applicantTeam: current.team, detail: `${current.status} → ${status}: ${refusal.error}` });
       return NextResponse.json({ error: refusal.error }, { status: refusal.status });
     }
 
@@ -309,6 +311,16 @@ export async function POST(
 
     // Invalidate global application cache after successful status change
     appCache.invalidateApplications();
+
+    await recordAudit(request, currentUser, {
+      action: "application.status",
+      applicationId: id,
+      applicantTeam: current.team,
+      systems: Array.isArray(systems) && systems.length ? systems : offer?.system ? [offer.system] : undefined,
+      before: snapshotApplication(current),
+      after: snapshotApplication(updatedApp),
+      detail: `${current.status} → ${status}`,
+    });
 
     return NextResponse.json({ application: updatedApp }, { status: 200 });
 

--- a/app/api/admin/applications/backfill-ratings/route.ts
+++ b/app/api/admin/applications/backfill-ratings/route.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase/admin";
 import { updateAggregateRating } from "@/lib/firebase/updateAggregateRating";
 import { Team } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -13,7 +14,7 @@ import { logger } from "@/lib/logger";
  */
 export async function POST(request: NextRequest) {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
 
     // Get all applications
     const applicationsSnapshot = await adminDb.collection("applications").get();
@@ -77,6 +78,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    await recordAudit(null, actor, { action: "application.backfill_ratings", detail: "backfilled aggregate ratings" });
     return NextResponse.json({ 
       success: true, 
       processed,

--- a/app/api/admin/applications/backfill-ratings/route.ts
+++ b/app/api/admin/applications/backfill-ratings/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    await recordAudit(null, actor, { action: "application.backfill_ratings", detail: "backfilled aggregate ratings" });
+    await recordAudit(request, actor, { action: "application.backfill_ratings", detail: "backfilled aggregate ratings" });
     return NextResponse.json({ 
       success: true, 
       processed,

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -11,7 +11,7 @@ import { getRecruitingConfig } from "@/lib/firebase/config";
 import { getStageDecisionForStatus, isAtOrPast } from "@/lib/utils/statusUtils";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
-import { recordAudit } from "@/lib/firebase/audit";
+import { recordAuditMany } from "@/lib/firebase/audit";
 
 
 // No bulk accept: an acceptance carries a per-applicant offer (system, role)
@@ -158,8 +158,12 @@ export async function POST(request: NextRequest) {
     const teamsById: Record<string, string> = {};
 
     // Process each application
+    // `refused` marks a rule stopping the actor (team access, drafts, the
+    // transition table, per-system targeting); everything else that fails is
+    // an error, and the audit log keeps the two apart.
+    type BulkResult = { id: string; success: boolean; error?: string; refused?: boolean };
     const results = await Promise.allSettled(
-      applicationIds.map(async (appId) => {
+      applicationIds.map(async (appId): Promise<BulkResult> => {
         try {
           const application = await getApplication(appId);
           if (!application) {
@@ -174,12 +178,12 @@ export async function POST(request: NextRequest) {
           // looked at preferredSystems for leads.
           const accessError = checkTeamAccess(currentUser, application);
           if (accessError) {
-            return { id: appId, success: false, error: accessError };
+            return { id: appId, success: false, error: accessError, refused: true };
           }
 
           // Drafts are not reviewable; see the single-application status route.
           if (application.status === ApplicationStatus.IN_PROGRESS && action !== "submitted") {
-            return { id: appId, success: false, error: DRAFT_ACTION_ERROR };
+            return { id: appId, success: false, error: DRAFT_ACTION_ERROR, refused: true };
           }
 
           // Same transition table as the single-application route, per item.
@@ -191,20 +195,20 @@ export async function POST(request: NextRequest) {
             perSystemReject: true, // bulk reject is already scoped to the lead's own system
           });
           if (refusal) {
-            return { id: appId, success: false, error: refusal.error };
+            return { id: appId, success: false, error: refusal.error, refused: true };
           }
 
           switch (action) {
             case "interview": {
               const target = resolveBulkSystems(application, effectiveSystems, "interview");
-              if (target.error) return { id: appId, success: false, error: target.error };
+              if (target.error) return { id: appId, success: false, error: target.error, refused: true };
               await addMultipleInterviewOffers(appId, target.systems, 'advanced');
               return { id: appId, success: true };
             }
 
             case "trial": {
               const target = resolveBulkSystems(application, effectiveSystems, "trial");
-              if (target.error) return { id: appId, success: false, error: target.error };
+              if (target.error) return { id: appId, success: false, error: target.error, refused: true };
               await addMultipleTrialOffers(appId, target.systems, 'advanced');
               return { id: appId, success: true };
             }
@@ -262,7 +266,7 @@ export async function POST(request: NextRequest) {
     );
 
     // Extract results from Promise.allSettled
-    const processedResults = results.map((result, index) => {
+    const processedResults: BulkResult[] = results.map((result, index) => {
       if (result.status === "fulfilled") {
         return result.value;
       }
@@ -276,11 +280,11 @@ export async function POST(request: NextRequest) {
     const successCount = processedResults.filter(r => r.success).length;
     const failCount = processedResults.filter(r => !r.success).length;
 
-    // One audit entry per application: bulk is where "who rejected 50 people"
-    // has to be answerable.
-    await Promise.all(processedResults.map((r) => recordAudit(request, currentUser, {
+    // One audit entry per application — bulk is where "who rejected 50 people"
+    // has to be answerable — written as one batch, not N parallel adds.
+    await recordAuditMany(request, currentUser, processedResults.map((r) => ({
       action: "application.bulk",
-      outcome: r.success ? "ok" : "refused",
+      outcome: r.success ? "ok" : r.refused ? "refused" : "error",
       applicationId: r.id,
       applicantTeam: teamsById[r.id],
       systems: effectiveSystems.length ? effectiveSystems : undefined,

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -11,6 +11,7 @@ import { getRecruitingConfig } from "@/lib/firebase/config";
 import { getStageDecisionForStatus, isAtOrPast } from "@/lib/utils/statusUtils";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 // No bulk accept: an acceptance carries a per-applicant offer (system, role)
@@ -146,6 +147,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Waitlist decisions can't be made until trial offers are released" }, { status: 400 });
     }
 
+    // Team of each application, for the audit entries written after the loop.
+    const teamsById: Record<string, string> = {};
+
     // Process each application
     const results = await Promise.allSettled(
       applicationIds.map(async (appId) => {
@@ -154,6 +158,7 @@ export async function POST(request: NextRequest) {
           if (!application) {
             return { id: appId, success: false, error: "Application not found" };
           }
+          teamsById[appId] = application.team;
 
           // Same per-record scoping as every single-application route: captains
           // are limited to their team, leads to their team and to applications
@@ -260,6 +265,17 @@ export async function POST(request: NextRequest) {
 
     const successCount = processedResults.filter(r => r.success).length;
     const failCount = processedResults.filter(r => !r.success).length;
+
+    // One audit entry per application: bulk is where "who rejected 50 people"
+    // has to be answerable.
+    await Promise.all(processedResults.map((r) => recordAudit(request, currentUser, {
+      action: "application.bulk",
+      outcome: r.success ? "ok" : "refused",
+      applicationId: r.id,
+      applicantTeam: teamsById[r.id],
+      systems: effectiveSystems.length ? effectiveSystems : undefined,
+      detail: r.success ? `bulk ${action}` : `bulk ${action}: ${r.error}`,
+    })));
 
     // Invalidate application cache on success
     if (successCount > 0) {

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -129,7 +129,15 @@ export async function POST(request: NextRequest) {
     if (applications.length === 0) {
       // Return empty CSV with just headers
       const csv = "Name,Email\n";
-      await recordAudit(null, user, { action: "application.export", detail: `${applications.length} applications exported` });
+      {
+      const exportedTeams = [...new Set(applications.map((a) => a.team))];
+      await recordAudit(request, user, {
+        action: "application.export",
+        applicantTeam: exportedTeams.length === 1 ? exportedTeams[0] : undefined,
+        after: { count: applications.length, teams: exportedTeams, systems: requestedSystems },
+        detail: `${applications.length} applications exported (${exportedTeams.join(", ") || "none"})`,
+      });
+    }
     return new NextResponse(csv, {
         status: 200,
         headers: {
@@ -401,7 +409,15 @@ export async function POST(request: NextRequest) {
     const timestamp = now.toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const filename = `applicants_export_${timestamp}.csv`;
 
-    await recordAudit(null, user, { action: "application.export", detail: `${applications.length} applications exported` });
+    {
+      const exportedTeams = [...new Set(applications.map((a) => a.team))];
+      await recordAudit(request, user, {
+        action: "application.export",
+        applicantTeam: exportedTeams.length === 1 ? exportedTeams[0] : undefined,
+        after: { count: applications.length, teams: exportedTeams, systems: requestedSystems },
+        detail: `${applications.length} applications exported (${exportedTeams.join(", ") || "none"})`,
+      });
+    }
     return new NextResponse(csv, {
       status: 200,
       headers: {

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -8,6 +8,7 @@ import { Note } from "@/lib/models/ApplicationExtras";
 import { getApplicationQuestions } from "@/lib/firebase/config";
 import { getSystemQuestionKeyLabel } from "@/lib/models/teamQuestions";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 // ---------------------------------------------------------------------------
@@ -128,7 +129,8 @@ export async function POST(request: NextRequest) {
     if (applications.length === 0) {
       // Return empty CSV with just headers
       const csv = "Name,Email\n";
-      return new NextResponse(csv, {
+      await recordAudit(null, user, { action: "application.export", detail: `${applications.length} applications exported` });
+    return new NextResponse(csv, {
         status: 200,
         headers: {
           "Content-Type": "text/csv",
@@ -399,6 +401,7 @@ export async function POST(request: NextRequest) {
     const timestamp = now.toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const filename = `applicants_export_${timestamp}.csv`;
 
+    await recordAudit(null, user, { action: "application.export", detail: `${applications.length} applications exported` });
     return new NextResponse(csv, {
       status: 200,
       headers: {

--- a/app/api/admin/applications/seed/route.ts
+++ b/app/api/admin/applications/seed/route.ts
@@ -7,6 +7,7 @@ import { adminDb } from "@/lib/firebase/admin";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { Team, ElectricSystem, SolarSystem, CombustionSystem } from "@/lib/models/User";
 import { FieldValue } from "firebase-admin/firestore";
+import { recordAudit } from "@/lib/firebase/audit";
 
 const APPLICATIONS_COLLECTION = "applications";
 const USERS_COLLECTION = "users";
@@ -154,7 +155,7 @@ function generateFakeApplication(userId: string, name: string, email: string) {
 
 export async function POST() {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
 
     // This writes 1000 applications and 1000 users into whatever project the
     // server is pointed at. Only before the cycle opens, and only for admins.
@@ -229,6 +230,7 @@ export async function POST() {
       await batch.commit();
     }
 
+    await recordAudit(null, actor, { action: "application.seed", detail: `seeded ${createdIds.length} fake applications` });
     return NextResponse.json({
       success: true,
       created: count,
@@ -250,7 +252,7 @@ export async function POST() {
 // DELETE endpoint to clean up fake data
 export async function DELETE() {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
 
 
     // Find and delete all fake users and their applications
@@ -301,6 +303,7 @@ export async function DELETE() {
       await batch.commit();
     }
 
+    await recordAudit(null, actor, { action: "application.seed", detail: `deleted fake data (${deletedUsers} users)` });
     return NextResponse.json({
       success: true,
       deletedUsers,

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRoles } from "@/lib/auth/guard";
+import { UserRole } from "@/lib/models/User";
+import { listAudit } from "@/lib/firebase/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/audit?action=&actor=&applicationId=&limit=
+ * Recent staff activity, newest first. Admins see everything; team captains
+ * see entries about their own team's applications (config and user changes
+ * carry no application, so those stay admin-only).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { user } = await requireRoles([UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB]);
+    const p = request.nextUrl.searchParams;
+    const limit = Math.min(Number(p.get("limit")) || 200, 500);
+    const scope: { team?: string } = {};
+    if (user?.role === UserRole.TEAM_CAPTAIN_OB) {
+      const team = user.memberProfile?.team;
+      if (!team) return NextResponse.json({ error: "Team profile missing" }, { status: 403 });
+      scope.team = team;
+    }
+    const entries = await listAudit({
+      ...scope,
+      action: p.get("action") || undefined,
+      actorUid: p.get("actor") || undefined,
+      applicationId: p.get("applicationId") || undefined,
+      limit,
+    });
+    // A captain asking for a specific application still only gets their team.
+    const visible = scope.team ? entries.filter((e) => e.applicantTeam === scope.team) : entries;
+    return NextResponse.json(
+      { entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })) },
+      { headers: { "Cache-Control": "private, no-store" } }
+    );
+  } catch (error) {
+    if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
+    }
+    logger.error({ err: error }, "Failed to load audit log");
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireRoles } from "@/lib/auth/guard";
 import { UserRole } from "@/lib/models/User";
-import { listAudit } from "@/lib/firebase/audit";
+import { listAudit, isVisibleToTeam } from "@/lib/firebase/audit";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
       if (!team) return NextResponse.json({ error: "Team profile missing" }, { status: 403 });
       scope.team = team;
     }
-    const entries = await listAudit({
+    const { entries, truncated } = await listAudit({
       ...scope,
       action: p.get("action") || undefined,
       actorUid: p.get("actor") || undefined,
@@ -31,9 +31,9 @@ export async function GET(request: NextRequest) {
       limit,
     });
     // A captain asking for a specific application still only gets their team.
-    const visible = scope.team ? entries.filter((e) => e.applicantTeam === scope.team) : entries;
+    const visible = scope.team ? entries.filter((e) => isVisibleToTeam(e, scope.team!)) : entries;
     return NextResponse.json(
-      { entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })) },
+      { entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })), truncated },
       { headers: { "Cache-Control": "private, no-store" } }
     );
   } catch (error) {

--- a/app/api/admin/config/about/route.ts
+++ b/app/api/admin/config/about/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth/guard";
 import { getAboutPageConfig, updateAboutPageConfig } from "@/lib/firebase/config";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -45,6 +46,8 @@ export async function PUT(request: NextRequest) {
       { title, subtitle, missionStatement, sections: sections || [] },
       uid
     );
+    
+    await recordAudit(request, { uid }, { action: "config.update", detail: "about" });
     
     return NextResponse.json({ success: true });
 

--- a/app/api/admin/config/announcement/route.ts
+++ b/app/api/admin/config/announcement/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin, requireStaff } from "@/lib/auth/guard";
 import { getAnnouncement, updateAnnouncement } from "@/lib/firebase/config";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 export async function GET(request: NextRequest) {
@@ -34,6 +35,8 @@ export async function POST(request: NextRequest) {
     }
 
     await updateAnnouncement(message, enabled, uid);
+    
+    await recordAudit(request, { uid }, { action: "config.update", detail: "announcement" });
     
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/admin/config/contact/route.ts
+++ b/app/api/admin/config/contact/route.ts
@@ -5,6 +5,7 @@ import { requireAdmin } from "@/lib/auth/guard";
 import { getContactPageConfig, updateContactPageConfig } from "@/lib/firebase/config";
 import { ContactChannel } from "@/lib/models/Config";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 /**
  * GET /api/admin/config/contact
@@ -62,6 +63,8 @@ export async function PUT(request: NextRequest) {
       },
       uid
     );
+
+    await recordAudit(request, { uid }, { action: "config.update", detail: "contact" });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/admin/config/dashboard/route.ts
+++ b/app/api/admin/config/dashboard/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin, requireStaff } from "@/lib/auth/guard";
 import { getDashboardConfig, updateDashboardConfig } from "@/lib/firebase/config";
 import { DashboardDeadline, DashboardResource } from "@/lib/models/Config";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 export async function GET() {
@@ -78,6 +79,8 @@ export async function POST(request: NextRequest) {
       },
       uid
     );
+    
+    await recordAudit(request, { uid }, { action: "config.update", detail: "dashboard" });
     
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/admin/config/email/route.ts
+++ b/app/api/admin/config/email/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth/guard";
 import { getEmailTemplatesConfig, updateEmailTemplatesConfig } from "@/lib/firebase/config";
+import { recordAudit } from "@/lib/firebase/audit";
 
 export async function GET() {
   try {
@@ -20,6 +21,7 @@ export async function PUT(request: Request) {
     const { user } = await requireAdmin();
     const body = await request.json();
     await updateEmailTemplatesConfig(body, user.uid);
+    await recordAudit(request, user, { action: "config.update", detail: "email_templates" });
     return new NextResponse("Config updated successfully", { status: 200 });
   } catch (error: any) {
     console.error("Failed to update email templates config:", error);

--- a/app/api/admin/config/email/test/route.ts
+++ b/app/api/admin/config/email/test/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth/guard";
 import { sendTestEmail } from "@/lib/email/send";
+import { recordAudit } from "@/lib/firebase/audit";
 
 export async function POST(request: Request) {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
     const body = await request.json();
     const { to, subject, body: emailBody, variables } = body;
     
@@ -13,6 +14,7 @@ export async function POST(request: Request) {
     }
 
     await sendTestEmail({ to, subject, body: emailBody, variables: variables || {} });
+    await recordAudit(request, actor, { action: "emails.trigger", detail: `test email to @${String(to).split("@")[1] ?? "?"}` });
     return new NextResponse("Test email sent", { status: 200 });
   } catch (error: any) {
     console.error("Failed to send test email:", error);

--- a/app/api/admin/config/faq/route.ts
+++ b/app/api/admin/config/faq/route.ts
@@ -5,6 +5,7 @@ import { requireAdmin } from "@/lib/auth/guard";
 import { getFaqConfig, updateFaqConfig } from "@/lib/firebase/config";
 import { FaqItem } from "@/lib/models/Config";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -52,6 +53,8 @@ export async function PUT(request: NextRequest) {
       }));
 
     await updateFaqConfig(cleaned, uid);
+
+    await recordAudit(request, { uid }, { action: "config.update", detail: "faq" });
 
     return NextResponse.json({ success: true, count: cleaned.length });
   } catch (error) {

--- a/app/api/admin/config/questions/route.ts
+++ b/app/api/admin/config/questions/route.ts
@@ -78,7 +78,7 @@ export async function PUT(request: NextRequest) {
     // Admin can do everything
     if (userRole === UserRole.ADMIN) {
       await handleUpdate(scope, uid, { team, system, questions, config });
-      await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
+      await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
       return NextResponse.json({ success: true });
     }
 
@@ -86,7 +86,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.TEAM_CAPTAIN_OB) {
       if (scope === "team" && team === userTeam) {
         await updateTeamQuestions(team, questions, uid);
-        await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
+        await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own team's questions" }, { status: 403 });
@@ -96,7 +96,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.SYSTEM_LEAD) {
       if (scope === "system" && system === userSystem && userTeam && (!team || team === userTeam)) {
         await updateSystemQuestions(system, questions, uid, userTeam);
-        await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
+        await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own system's questions" }, { status: 403 });

--- a/app/api/admin/config/questions/route.ts
+++ b/app/api/admin/config/questions/route.ts
@@ -13,6 +13,7 @@ import { UserRole, Team } from "@/lib/models/User";
 import { ApplicationQuestion } from "@/lib/models/Config";
 import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 // Cache the questions for 2 hours (7200 seconds), with stale-while-revalidate for 1 hour
@@ -77,6 +78,7 @@ export async function PUT(request: NextRequest) {
     // Admin can do everything
     if (userRole === UserRole.ADMIN) {
       await handleUpdate(scope, uid, { team, system, questions, config });
+      await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
       return NextResponse.json({ success: true });
     }
 
@@ -84,6 +86,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.TEAM_CAPTAIN_OB) {
       if (scope === "team" && team === userTeam) {
         await updateTeamQuestions(team, questions, uid);
+        await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own team's questions" }, { status: 403 });
@@ -93,6 +96,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.SYSTEM_LEAD) {
       if (scope === "system" && system === userSystem && userTeam && (!team || team === userTeam)) {
         await updateSystemQuestions(system, questions, uid, userTeam);
+        await recordAudit(request, { uid }, { action: "config.update", detail: "questions" });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own system's questions" }, { status: 403 });

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -6,6 +6,7 @@ import { autoRejectUnscheduledInterviewApplicants, sweepOnDecisionAdvance } from
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
 import { STEP_ORDER } from "@/lib/utils/statusUtils";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 export async function GET(request: NextRequest) {
@@ -66,6 +67,7 @@ export async function POST(request: NextRequest) {
     }
 
     await updateRecruitingStep(step, uid);
+    await recordAudit(request, { uid }, { action: "config.recruiting_step", before: { step: before }, after: { step }, detail: `${before} → ${step}${confirm ? " (typed confirmation)" : ""}` });
 
     // Sweep failures are reported back, not just logged: the step itself has
     // already been written, so a silent failure looks like success while the

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
     // Reneg toggle can be flipped on its own, without a step change.
     if (step === undefined && typeof renegEnabled === "boolean") {
       await updateRenegEnabled(renegEnabled, uid);
+      await recordAudit(request, { uid }, { action: "config.update", detail: `renegEnabled → ${renegEnabled}` });
       return NextResponse.json({ success: true, renegEnabled }, { status: 200 });
     }
 
@@ -60,6 +61,7 @@ export async function POST(request: NextRequest) {
     const isNext = toIdx === fromIdx + 1;
     if (!isCurrent && !isNext && confirm !== step) {
       const direction = toIdx < fromIdx ? "back" : "ahead";
+      await recordAudit(request, { uid }, { action: "config.recruiting_step", outcome: "refused", before: { step: before }, after: { step }, detail: `${before} → ${step}: skipped the order without typed confirmation` });
       return NextResponse.json({
         error: `Moving ${direction} from ${before} to ${step} skips the normal order. Type the step name to confirm.`,
         requiresConfirmation: true,

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -8,13 +8,14 @@ import { EmailTrigger } from "@/lib/models/EmailTemplate";
 import { sendStatusEmail } from "@/lib/email/send";
 import { updateApplication } from "@/lib/firebase/applications";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 export async function POST(request: NextRequest) {
   try {
-    await requireAdmin();
+    const { user: actor } = await requireAdmin();
     
     const body = await request.json();
     const { step, force = false, applicationIds } = body;
@@ -23,6 +24,8 @@ export async function POST(request: NextRequest) {
     const currentStep = step || config.currentStep;
 
     const results = await triggerEmails(currentStep, force, applicationIds);
+
+    await recordAudit(request, actor, { action: "emails.trigger", detail: `step ${currentStep}${force ? " (force)" : ""}${applicationIds?.length ? ` for ${applicationIds.length} applications` : ""}`, after: results as unknown as Record<string, unknown> });
 
     return NextResponse.json({ success: true, ...results });
   } catch (error) {

--- a/app/api/admin/config/teams/route.ts
+++ b/app/api/admin/config/teams/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/firebase/config";
 import { UserRole, Team } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -84,6 +85,7 @@ export async function PUT(request: NextRequest) {
       } else if (scope === "rejectionMessage") {
         await updateTeamRejectionMessage(team as Team, rejectionMessage, uid);
       }
+      await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
       return NextResponse.json({ success: true });
     }
 
@@ -92,6 +94,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.TEAM_CAPTAIN_OB) {
       if (scope === "team" && team === userTeam) {
         await updateTeamDescription(team as Team, description, uid);
+        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
         return NextResponse.json({ success: true });
       }
       if (scope === "subsystem" && team === userTeam) {
@@ -99,10 +102,12 @@ export async function PUT(request: NextRequest) {
           return NextResponse.json({ error: "Subsystem name required" }, { status: 400 });
         }
         await updateSubsystemDescription(team as Team, subsystem, description, uid);
+        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
         return NextResponse.json({ success: true });
       }
       if (scope === "rejectionMessage" && team === userTeam) {
         await updateTeamRejectionMessage(team as Team, rejectionMessage, uid);
+        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own team's content" }, { status: 403 });

--- a/app/api/admin/config/teams/route.ts
+++ b/app/api/admin/config/teams/route.ts
@@ -85,7 +85,7 @@ export async function PUT(request: NextRequest) {
       } else if (scope === "rejectionMessage") {
         await updateTeamRejectionMessage(team as Team, rejectionMessage, uid);
       }
-      await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
+      await recordAudit(request, { uid }, { action: "config.update", detail: `teams: ${scope}${team ? ` ${team}` : ""}${subsystem ? ` / ${subsystem}` : ""}` });
       return NextResponse.json({ success: true });
     }
 
@@ -94,7 +94,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.TEAM_CAPTAIN_OB) {
       if (scope === "team" && team === userTeam) {
         await updateTeamDescription(team as Team, description, uid);
-        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
+        await recordAudit(request, { uid }, { action: "config.update", detail: `teams: ${scope}${team ? ` ${team}` : ""}${subsystem ? ` / ${subsystem}` : ""}` });
         return NextResponse.json({ success: true });
       }
       if (scope === "subsystem" && team === userTeam) {
@@ -102,12 +102,12 @@ export async function PUT(request: NextRequest) {
           return NextResponse.json({ error: "Subsystem name required" }, { status: 400 });
         }
         await updateSubsystemDescription(team as Team, subsystem, description, uid);
-        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
+        await recordAudit(request, { uid }, { action: "config.update", detail: `teams: ${scope}${team ? ` ${team}` : ""}${subsystem ? ` / ${subsystem}` : ""}` });
         return NextResponse.json({ success: true });
       }
       if (scope === "rejectionMessage" && team === userTeam) {
         await updateTeamRejectionMessage(team as Team, rejectionMessage, uid);
-        await recordAudit(request, { uid }, { action: "config.update", detail: "teams" });
+        await recordAudit(request, { uid }, { action: "config.update", detail: `teams: ${scope}${team ? ` ${team}` : ""}${subsystem ? ` / ${subsystem}` : ""}` });
         return NextResponse.json({ success: true });
       }
       return NextResponse.json({ error: "Forbidden: Can only edit your own team's content" }, { status: 403 });

--- a/app/api/admin/scorecards/[id]/route.ts
+++ b/app/api/admin/scorecards/[id]/route.ts
@@ -9,6 +9,7 @@ import {
 import { adminDb } from "@/lib/firebase/admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 /**
@@ -70,6 +71,7 @@ export async function PUT(
     // Fetch updated config
     const updated = await getScorecardConfigById(id);
 
+    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `updated ${id}` });
     return NextResponse.json({ config: updated }, { status: 200 });
   } catch (error) {
     logger.error(error, "Failed to update scorecard config");
@@ -168,6 +170,7 @@ export async function DELETE(
       logger.info({ system, team, type: existing.scorecardType }, "Cleared aggregate ratings for deleted config");
     }
 
+    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `deleted ${id}` });
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
     logger.error(error, "Failed to delete scorecard config");

--- a/app/api/admin/scorecards/[id]/route.ts
+++ b/app/api/admin/scorecards/[id]/route.ts
@@ -71,7 +71,7 @@ export async function PUT(
     // Fetch updated config
     const updated = await getScorecardConfigById(id);
 
-    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `updated ${id}` });
+    await recordAudit(request, { uid }, { action: "scorecard_config.update", detail: `updated ${id}` });
     return NextResponse.json({ config: updated }, { status: 200 });
   } catch (error) {
     logger.error(error, "Failed to update scorecard config");
@@ -170,7 +170,7 @@ export async function DELETE(
       logger.info({ system, team, type: existing.scorecardType }, "Cleared aggregate ratings for deleted config");
     }
 
-    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `deleted ${id}` });
+    await recordAudit(request, { uid }, { action: "scorecard_config.update", detail: `deleted ${id}` });
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
     logger.error(error, "Failed to delete scorecard config");

--- a/app/api/admin/scorecards/route.ts
+++ b/app/api/admin/scorecards/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
       fields: fields || [],
     }, uid);
 
-    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `created ${config.id ?? "scorecard config"}` });
+    await recordAudit(request, { uid }, { action: "scorecard_config.update", detail: `created ${config.id ?? "scorecard config"}` });
     return NextResponse.json({ config }, { status: 201 });
   } catch (error) {
     logger.error(error, "Failed to create scorecard config");

--- a/app/api/admin/scorecards/route.ts
+++ b/app/api/admin/scorecards/route.ts
@@ -8,6 +8,7 @@ import {
 import { Team } from "@/lib/models/User";
 import { ScorecardType } from "@/lib/models/Scorecard";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 // Cache scorecard configs for 5 minutes
@@ -90,6 +91,7 @@ export async function POST(request: NextRequest) {
       fields: fields || [],
     }, uid);
 
+    await recordAudit(null, { uid }, { action: "scorecard_config.update", detail: `created ${config.id ?? "scorecard config"}` });
     return NextResponse.json({ config }, { status: 201 });
   } catch (error) {
     logger.error(error, "Failed to create scorecard config");

--- a/app/api/admin/users/[uid]/route.ts
+++ b/app/api/admin/users/[uid]/route.ts
@@ -103,7 +103,7 @@ export async function PATCH(
     const targetBefore = await getUser(targetUid);
     await updateUser(targetUid, updateData);
 
-    await recordAudit(null, currentUser, {
+    await recordAudit(request, currentUser, {
       action: "user.update",
       targetUid,
       before: { role: targetBefore?.role, team: targetBefore?.memberProfile?.team, system: targetBefore?.memberProfile?.system, isMember: targetBefore?.isMember },

--- a/app/api/admin/users/[uid]/route.ts
+++ b/app/api/admin/users/[uid]/route.ts
@@ -5,6 +5,7 @@ import { UserRole, Team } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "@/lib/logger";
+import { recordAudit } from "@/lib/firebase/audit";
 
 
 const ALLOWED_CALLER_ROLES = new Set<UserRole>([
@@ -99,7 +100,16 @@ export async function PATCH(
       updateData.memberProfile = FieldValue.delete();
     }
 
+    const targetBefore = await getUser(targetUid);
     await updateUser(targetUid, updateData);
+
+    await recordAudit(null, currentUser, {
+      action: "user.update",
+      targetUid,
+      before: { role: targetBefore?.role, team: targetBefore?.memberProfile?.team, system: targetBefore?.memberProfile?.system, isMember: targetBefore?.isMember },
+      after: { role, team, system, isMember },
+      detail: `updated ${Object.keys(updateData).join(", ")}`,
+    });
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,6 +26,7 @@ const ADMIN_NAV: AdminNavItem[] = [
   { href: '/admin/applications', label: 'Applicants' },
   { href: '/admin/stats', label: 'Stats' },
   { href: '/admin/users', label: 'Users', restrictTo: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB] },
+  { href: '/admin/activity', label: 'Activity', restrictTo: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB] },
   { href: '/admin/configuration', label: 'Configuration' },
   { href: '/admin/settings', label: 'Settings', restrictTo: [UserRole.ADMIN] },
 ];

--- a/lib/firebase/audit.ts
+++ b/lib/firebase/audit.ts
@@ -106,6 +106,21 @@ export async function recordAudit(
   }
 }
 
+/**
+ * Which entries a team captain may see: their own team's applications, plus
+ * CSV exports that included their team — the one action that moves applicant
+ * data off-platform must not be invisible to the captain whose applicants
+ * were in it.
+ */
+export function isVisibleToTeam(e: AuditEntry, team: string): boolean {
+  if (e.applicantTeam === team) return true;
+  const teams = (e.after as { teams?: unknown } | undefined)?.teams;
+  return e.action === "application.export" && Array.isArray(teams) && teams.includes(team);
+}
+
+/** Newest-first window the feed reads before filtering in memory. */
+export const AUDIT_FEED_WINDOW = 1000;
+
 export interface ListAuditOptions {
   applicationId?: string;
   actorUid?: string;
@@ -115,17 +130,23 @@ export interface ListAuditOptions {
   limit?: number;
 }
 
-/** Newest first. */
-export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditEntry[]> {
+/**
+ * Newest first. Exact lookups (one application, one actor) read every matching
+ * entry; the feed reads the newest AUDIT_FEED_WINDOW entries and filters in
+ * memory, and says so when that window was full — a filter over a truncated
+ * window would otherwise look like "nothing happened".
+ */
+export async function listAudit(opts: ListAuditOptions = {}): Promise<{ entries: AuditEntry[]; truncated: boolean }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
   let docs;
+  let truncated = false;
   if (opts.applicationId) {
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).get()).docs;
   } else if (opts.actorUid) {
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).get()).docs;
   } else {
-    // Over-fetch so in-memory filters still fill the page.
-    docs = (await adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").limit(Math.max(limit * 3, 300)).get()).docs;
+    docs = (await adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").limit(AUDIT_FEED_WINDOW).get()).docs;
+    truncated = docs.length >= AUDIT_FEED_WINDOW;
   }
   let entries: AuditEntry[] = docs.map((d) => {
     const data = d.data();
@@ -133,7 +154,7 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditEntry
   });
   if (opts.action) entries = entries.filter((e) => e.action === opts.action);
   if (opts.actorUid) entries = entries.filter((e) => e.actor?.uid === opts.actorUid);
-  if (opts.team) entries = entries.filter((e) => e.applicantTeam === opts.team);
+  if (opts.team) entries = entries.filter((e) => isVisibleToTeam(e, opts.team!));
   entries.sort((a, b) => b.at.getTime() - a.at.getTime());
-  return entries.slice(0, limit);
+  return { entries: entries.slice(0, limit), truncated };
 }

--- a/lib/firebase/audit.ts
+++ b/lib/firebase/audit.ts
@@ -107,6 +107,38 @@ export async function recordAudit(
 }
 
 /**
+ * Record many entries by one actor from one request — bulk actions — as
+ * WriteBatch commits of up to 500, instead of N parallel adds on the slowest
+ * route in the app. Never throws.
+ */
+export async function recordAuditMany(
+  request: Request | null,
+  actor: ActorInput,
+  entries: Array<Omit<AuditEntry, "id" | "at" | "actor" | "outcome" | "userAgent"> & { outcome?: AuditEntry["outcome"] }>
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    const who = await resolveActor(actor);
+    const userAgent = request?.headers.get("user-agent")?.slice(0, 200) ?? undefined;
+    for (let i = 0; i < entries.length; i += 500) {
+      const batch = adminDb.batch();
+      for (const entry of entries.slice(i, i + 500)) {
+        batch.set(adminDb.collection(AUDIT_COLLECTION).doc(), clean({
+          ...entry,
+          outcome: entry.outcome ?? "ok",
+          actor: who,
+          userAgent,
+          at: FieldValue.serverTimestamp(),
+        }));
+      }
+      await batch.commit();
+    }
+  } catch (error) {
+    logger.error({ err: error, count: entries.length, action: entries[0]?.action }, "Failed to write audit entries");
+  }
+}
+
+/**
  * Which entries a team captain may see: their own team's applications, plus
  * CSV exports that included their team — the one action that moves applicant
  * data off-platform must not be invisible to the captain whose applicants
@@ -131,23 +163,25 @@ export interface ListAuditOptions {
 }
 
 /**
- * Newest first. Exact lookups (one application, one actor) read every matching
- * entry; the feed reads the newest AUDIT_FEED_WINDOW entries and filters in
- * memory, and says so when that window was full — a filter over a truncated
- * window would otherwise look like "nothing happened".
+ * Newest first. Every read is bounded by AUDIT_FEED_WINDOW — the feed by
+ * `orderBy(at)`, the exact lookups (one application, one actor) by a plain
+ * `limit` so they need no composite index. `truncated` is true whenever the
+ * caller did not get everything that matched: the window filled, or more
+ * matched than `limit` — the UI filters client-side over what it received,
+ * and a filter over a silently truncated set looks like "nothing happened".
  */
 export async function listAudit(opts: ListAuditOptions = {}): Promise<{ entries: AuditEntry[]; truncated: boolean }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
   let docs;
   let truncated = false;
   if (opts.applicationId) {
-    docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).get()).docs;
+    docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).limit(AUDIT_FEED_WINDOW).get()).docs;
   } else if (opts.actorUid) {
-    docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).get()).docs;
+    docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).limit(AUDIT_FEED_WINDOW).get()).docs;
   } else {
     docs = (await adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").limit(AUDIT_FEED_WINDOW).get()).docs;
-    truncated = docs.length >= AUDIT_FEED_WINDOW;
   }
+  truncated = docs.length >= AUDIT_FEED_WINDOW;
   let entries: AuditEntry[] = docs.map((d) => {
     const data = d.data();
     return { ...(data as Omit<AuditEntry, "id" | "at">), id: d.id, at: data.at?.toDate?.() ?? new Date(0) } as AuditEntry;
@@ -156,5 +190,6 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<{ entries:
   if (opts.actorUid) entries = entries.filter((e) => e.actor?.uid === opts.actorUid);
   if (opts.team) entries = entries.filter((e) => isVisibleToTeam(e, opts.team!));
   entries.sort((a, b) => b.at.getTime() - a.at.getTime());
+  if (entries.length > limit) truncated = true;
   return { entries: entries.slice(0, limit), truncated };
 }

--- a/lib/firebase/audit.ts
+++ b/lib/firebase/audit.ts
@@ -1,0 +1,139 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { adminDb } from "./admin";
+import { getUser } from "./users";
+import { logger } from "@/lib/logger";
+import type { Application } from "@/lib/models/Application";
+import type { User } from "@/lib/models/User";
+import type { AuditAction, AuditActor, AuditEntry } from "@/lib/models/Audit";
+
+export type { AuditAction, AuditActor, AuditEntry } from "@/lib/models/Audit";
+
+/**
+ * Staff action audit log (#119).
+ *
+ * Every mutating staff route records one entry per action: who (uid, email,
+ * name, role, team/system), what (action + outcome), on which application
+ * (id + team only — never an applicant's name or email, so the log is safe
+ * for any staff member to read), and a compact before/after of the fields
+ * that gate the pipeline. Refusals are recorded too: "who tried what" is
+ * half of accountability.
+ *
+ * Writes never fail the request: a logging outage must not block a lead
+ * from working, so recordAudit swallows its own errors (they still reach
+ * error monitoring through logger.error).
+ *
+ * Reads are index-free on purpose: a single-field query plus in-memory
+ * sort/filter over the most recent few hundred entries. This log is small
+ * (hundreds of actions a day at peak) and a composite index would turn a
+ * code change into a Firestore deploy.
+ */
+
+export const AUDIT_COLLECTION = "audit_log";
+
+type ActorInput = AuditActor | User | { uid: string } | null | undefined;
+
+async function resolveActor(input: ActorInput): Promise<AuditActor> {
+  if (!input) return { uid: "unknown" };
+  const anyInput = input as Partial<User> & Partial<AuditActor>;
+  if (anyInput.email || anyInput.role || anyInput.name) {
+    return {
+      uid: anyInput.uid ?? "unknown",
+      email: anyInput.email,
+      name: anyInput.name,
+      role: anyInput.role,
+      team: anyInput.team ?? anyInput.memberProfile?.team,
+      system: anyInput.system ?? anyInput.memberProfile?.system,
+    };
+  }
+  // Only a uid: look the staff member up so the log reads as a person.
+  try {
+    const u = await getUser(anyInput.uid ?? "");
+    if (u) return { uid: u.uid, email: u.email, name: u.name, role: u.role, team: u.memberProfile?.team, system: u.memberProfile?.system };
+  } catch { /* fall through */ }
+  return { uid: anyInput.uid ?? "unknown" };
+}
+
+/** The pipeline-gating fields, compact enough to diff by eye. */
+export function snapshotApplication(app: Partial<Application> | null | undefined): Record<string, unknown> | undefined {
+  if (!app) return undefined;
+  return clean({
+    status: app.status,
+    reviewDecision: app.reviewDecision,
+    interviewDecision: app.interviewDecision,
+    trialDecision: app.trialDecision,
+    trialDecisionDay: app.trialDecisionDay,
+    preferredSystems: app.preferredSystems,
+    rejectedBySystems: app.rejectedBySystems,
+    interviewOffers: app.interviewOffers?.map((o) => `${o.system}:${o.status}`),
+    trialOffers: app.trialOffers?.map((o) => `${o.system}:${o.status}${o.accepted === undefined ? "" : o.accepted ? ":accepted" : ":declined"}`),
+    selectedInterviewSystem: app.selectedInterviewSystem,
+    offerSystem: app.offer?.system,
+    waitlistSystem: app.waitlistSystem,
+  }) as Record<string, unknown>;
+}
+
+/** Firestore rejects undefined; strip it recursively (plain objects and arrays only). */
+function clean<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(clean) as T;
+  if (value && typeof value === "object" && !(value instanceof Date) && (value as object).constructor === Object) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v !== undefined) out[k] = clean(v);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+/** Record one staff action. Never throws. */
+export async function recordAudit(
+  request: Request | null,
+  actor: ActorInput,
+  entry: Omit<AuditEntry, "id" | "at" | "actor" | "outcome" | "userAgent"> & { outcome?: AuditEntry["outcome"] }
+): Promise<void> {
+  try {
+    const who = await resolveActor(actor);
+    const doc = clean({
+      ...entry,
+      outcome: entry.outcome ?? "ok",
+      actor: who,
+      userAgent: request?.headers.get("user-agent")?.slice(0, 200) ?? undefined,
+      at: FieldValue.serverTimestamp(),
+    });
+    await adminDb.collection(AUDIT_COLLECTION).add(doc);
+  } catch (error) {
+    logger.error({ err: error, action: entry.action, applicationId: entry.applicationId }, "Failed to write audit entry");
+  }
+}
+
+export interface ListAuditOptions {
+  applicationId?: string;
+  actorUid?: string;
+  action?: AuditAction | string;
+  /** Restrict to entries about this team's applications (captains). Entries with no application are excluded. */
+  team?: string;
+  limit?: number;
+}
+
+/** Newest first. */
+export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditEntry[]> {
+  const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  let docs;
+  if (opts.applicationId) {
+    docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).get()).docs;
+  } else if (opts.actorUid) {
+    docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).get()).docs;
+  } else {
+    // Over-fetch so in-memory filters still fill the page.
+    docs = (await adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").limit(Math.max(limit * 3, 300)).get()).docs;
+  }
+  let entries: AuditEntry[] = docs.map((d) => {
+    const data = d.data();
+    return { ...(data as Omit<AuditEntry, "id" | "at">), id: d.id, at: data.at?.toDate?.() ?? new Date(0) } as AuditEntry;
+  });
+  if (opts.action) entries = entries.filter((e) => e.action === opts.action);
+  if (opts.actorUid) entries = entries.filter((e) => e.actor?.uid === opts.actorUid);
+  if (opts.team) entries = entries.filter((e) => e.applicantTeam === opts.team);
+  entries.sort((a, b) => b.at.getTime() - a.at.getTime());
+  return entries.slice(0, limit);
+}

--- a/lib/models/Audit.ts
+++ b/lib/models/Audit.ts
@@ -9,6 +9,7 @@ export type AuditAction =
   | "application.bulk"
   | "application.interview_offer"
   | "application.edit"
+  | "application.note_deleted"
   | "application.export"
   | "application.seed"
   | "application.backfill_ratings"
@@ -24,6 +25,7 @@ export const AUDIT_ACTION_LABELS: Record<AuditAction, string> = {
   "application.bulk": "Bulk action",
   "application.interview_offer": "Interview offer updated",
   "application.edit": "Application edited",
+  "application.note_deleted": "Note deleted",
   "application.export": "CSV export",
   "application.seed": "Seed data",
   "application.backfill_ratings": "Ratings backfill",

--- a/lib/models/Audit.ts
+++ b/lib/models/Audit.ts
@@ -1,0 +1,66 @@
+/**
+ * Staff action audit log types (#119). Client-safe: no Firebase imports.
+ * The writer and reader live in lib/firebase/audit.ts.
+ */
+
+export type AuditAction =
+  | "application.status"
+  | "application.reject"
+  | "application.bulk"
+  | "application.interview_offer"
+  | "application.edit"
+  | "application.export"
+  | "application.seed"
+  | "application.backfill_ratings"
+  | "emails.trigger"
+  | "config.recruiting_step"
+  | "config.update"
+  | "scorecard_config.update"
+  | "user.update";
+
+export const AUDIT_ACTION_LABELS: Record<AuditAction, string> = {
+  "application.status": "Status change",
+  "application.reject": "Rejected",
+  "application.bulk": "Bulk action",
+  "application.interview_offer": "Interview offer updated",
+  "application.edit": "Application edited",
+  "application.export": "CSV export",
+  "application.seed": "Seed data",
+  "application.backfill_ratings": "Ratings backfill",
+  "emails.trigger": "Emails sent",
+  "config.recruiting_step": "Recruiting step",
+  "config.update": "Config updated",
+  "scorecard_config.update": "Scorecard config",
+  "user.update": "User updated",
+};
+
+export interface AuditActor {
+  uid: string;
+  email?: string;
+  name?: string;
+  role?: string;
+  team?: string;
+  system?: string;
+}
+
+export interface AuditEntry {
+  id?: string;
+  at: Date;
+  actor: AuditActor;
+  action: AuditAction;
+  outcome: "ok" | "refused";
+  /** Application acted on. Never the applicant's name or email. */
+  applicationId?: string;
+  applicantTeam?: string;
+  /** For user.update: the user changed. */
+  targetUid?: string;
+  systems?: string[];
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+  /** One line a human can read without the before/after. */
+  detail?: string;
+  userAgent?: string;
+}
+
+/** Wire shape returned by the audit read routes (dates as ISO strings). */
+export type AuditEntryDto = Omit<AuditEntry, "at"> & { at: string };

--- a/lib/models/Audit.ts
+++ b/lib/models/Audit.ts
@@ -50,7 +50,8 @@ export interface AuditEntry {
   at: Date;
   actor: AuditActor;
   action: AuditAction;
-  outcome: "ok" | "refused";
+  /** `refused` = a rule stopped the actor; `error` = the request failed for another reason (not found, exception). */
+  outcome: "ok" | "refused" | "error";
   /** Application acted on. Never the applicant's name or email. */
   applicationId?: string;
   applicantTeam?: string;

--- a/lib/utils/downloadFile.ts
+++ b/lib/utils/downloadFile.ts
@@ -1,0 +1,30 @@
+/**
+ * Trigger a browser download for a Blob. The anchor is appended to the
+ * document before the click (a click on a detached anchor starts nothing in
+ * Firefox) and the object URL is revoked only after the click has been
+ * dispatched — revoking synchronously is the classic cancelled-download bug.
+ */
+export function downloadBlob(filename: string, blob: Blob): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/** RFC 4180-ish: quote a cell when it holds a comma, quote or newline. */
+export function csvFromRows(rows: (string | number)[][]): string {
+  const esc = (v: string | number) => {
+    const s = String(v);
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  return rows.map((r) => r.map(esc).join(",")).join("\n");
+}
+
+export function downloadCsv(filename: string, rows: (string | number)[][]): void {
+  downloadBlob(filename, new Blob([csvFromRows(rows)], { type: "text/csv" }));
+}

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -1,0 +1,119 @@
+// Staff audit log (#119): every mutating route writes an entry with the actor,
+// refusals are recorded, reads are scoped (staff see an application's history
+// they can access; admins see everything; captains see their team; leads and
+// applicants are refused), and no applicant PII ever appears. Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/audit-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie, "user-agent": "audit-harness/1.0" }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; let t = ""; try { t = await r.text(); j = JSON.parse(t); } catch {}
+  return { status: r.status, json: j, text: t };
+}
+const now = () => new Date();
+const APPLICANT_NAME = "Secretname Applicantperson", APPLICANT_EMAIL = "secret.applicant@utexas.edu";
+const entriesFor = async (id) => (await db.collection("audit_log").where("applicationId", "==", id).get()).docs.map((d) => d.data());
+const allEntries = async () => (await db.collection("audit_log").get()).docs.map((d) => d.data());
+
+await db.collection("audit_log").get().then((s) => Promise.all(s.docs.map((d) => d.ref.delete())));
+await ensureUser({ uid: "u-cap", email: "cap.e@utexas.edu", name: "Electric Captain", role: "team_captain_ob", memberProfile: { team: "Electric", system: "Electronics" } });
+await ensureUser({ uid: "u-caps", email: "cap.s@utexas.edu", name: "Solar Captain", role: "team_captain_ob", memberProfile: { team: "Solar", system: "Powertrain" } });
+await ensureUser({ uid: "u-body", email: "lead.body@utexas.edu", name: "Body Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+await ensureUser({ uid: "u-au", email: APPLICANT_EMAIL, name: APPLICANT_NAME, role: "applicant" });
+await ensureUser({ uid: "u-target", email: "target@utexas.edu", name: "Target Person", role: "applicant" });
+const adminC = await session("admin@utexas.edu"), capC = await session("cap.e@utexas.edu"), capSC = await session("cap.s@utexas.edu"), bodyC = await session("lead.body@utexas.edu"), appC = await session(APPLICANT_EMAIL);
+const mk = async (id, team = "Electric", extra = {}) => db.doc(`applications/${id}`).set({ userId: "u-au", userEmail: APPLICANT_EMAIL, userName: APPLICANT_NAME, team, preferredSystems: team === "Electric" ? ["Body", "Dynamics"] : ["Powertrain", "Dynamics"], status: "submitted", formData: { whyJoin: "x" }, createdAt: now(), updatedAt: now(), submittedAt: now(), ...extra });
+await mk("au-1"); await mk("au-2"); await mk("au-3"); await mk("au-solar", "Solar");
+let r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open", confirm: "open" });
+
+// ---- writes ----
+r = await api(bodyC, "POST", "/api/admin/applications/au-1/reject", { systems: ["Body"] });
+let e = await entriesFor("au-1");
+check("per-system reject writes an entry with the lead as actor", r.status === 200 && e.some((x) => x.action === "application.reject" && x.outcome === "ok" && x.actor.uid === "u-body" && x.actor.email === "lead.body@utexas.edu" && x.actor.system === "Body" && x.systems?.join() === "Body"), JSON.stringify(e.map((x) => [x.action, x.outcome, x.actor?.uid])));
+check("reject entry has before/after snapshots and team, no applicant PII", e.some((x) => x.action === "application.reject" && x.applicantTeam === "Electric" && x.before?.status === "submitted" && Array.isArray(x.after?.rejectedBySystems)) && !JSON.stringify(e).includes(APPLICANT_EMAIL) && !JSON.stringify(e).includes("Secretname"));
+check("entry carries the request user agent", e.some((x) => x.userAgent === "audit-harness/1.0"));
+
+r = await api(bodyC, "POST", "/api/admin/applications/au-1/status", { status: "rejected" });
+e = await entriesFor("au-1");
+check("a refused action is recorded as refused, with the reason", r.status === 403 && e.some((x) => x.action === "application.status" && x.outcome === "refused" && /per system/i.test(x.detail || "")), JSON.stringify(e.filter((x) => x.outcome === "refused").map((x) => x.detail)));
+
+r = await api(adminC, "POST", "/api/admin/applications/au-2/status", { status: "interview", systems: ["Body"] });
+e = await entriesFor("au-2");
+check("status change by admin: before submitted → after interview", r.status === 200 && e.some((x) => x.action === "application.status" && x.before?.status === "submitted" && x.after?.status === "interview" && x.detail === "submitted → interview" && x.actor.role === "admin"), JSON.stringify(e.map((x) => [x.detail, x.before?.status, x.after?.status])));
+
+r = await api(capC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["au-3", "au-solar"], action: "reject" });
+const e3 = await entriesFor("au-3"), eS = await entriesFor("au-solar");
+check("bulk writes one entry per application, ok for own team", e3.some((x) => x.action === "application.bulk" && x.outcome === "ok" && x.actor.uid === "u-cap" && x.applicantTeam === "Electric"), JSON.stringify(e3.map((x) => [x.action, x.outcome])));
+check("bulk refusal (other team) recorded as refused", eS.some((x) => x.action === "application.bulk" && x.outcome === "refused" && /access/i.test(x.detail || "")), JSON.stringify(eS.map((x) => [x.outcome, x.detail])));
+
+r = await api(adminC, "PATCH", "/api/admin/applications/au-2", { formData: { major: "ME" } });
+e = await entriesFor("au-2");
+check("admin edit recorded with the fields touched", r.status === 200 && e.some((x) => x.action === "application.edit" && /formData/.test(x.detail || "") && /major/.test(x.detail || "")), JSON.stringify(e.filter((x) => x.action === "application.edit").map((x) => x.detail)));
+
+r = await api(adminC, "PATCH", "/api/admin/applications/au-2/interview/Body", { status: "completed" });
+e = await entriesFor("au-2");
+check("interview offer status change recorded", r.status === 200 && e.some((x) => x.action === "application.interview_offer" && /Body interview → completed/.test(x.detail || "")), `${r.status} ${JSON.stringify(e.filter((x) => x.action === "application.interview_offer").map((x) => x.detail))}`);
+
+r = await api(adminC, "PATCH", "/api/admin/users/u-target", { role: "system_lead", team: "Electric", system: "Dynamics", isMember: true });
+let all = await allEntries();
+check("user role change recorded with target, before and after", r.status === 200 && all.some((x) => x.action === "user.update" && x.targetUid === "u-target" && x.before?.role === "applicant" && x.after?.role === "system_lead" && x.after?.system === "Dynamics"), JSON.stringify(all.filter((x) => x.action === "user.update").map((x) => [x.targetUid, x.before, x.after])));
+
+r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing" });
+all = await allEntries();
+check("recruiting step change recorded", r.status === 200 && all.some((x) => x.action === "config.recruiting_step" && x.before?.step === "open" && x.after?.step === "reviewing"), JSON.stringify(all.filter((x) => x.action === "config.recruiting_step").map((x) => x.detail)));
+
+r = await api(adminC, "POST", "/api/admin/applications/export-csv", { team: "Electric" });
+all = await allEntries();
+check("CSV export recorded", all.some((x) => x.action === "application.export" && x.actor.uid === "seed-admin"), `${r.status} ${JSON.stringify(all.filter((x) => x.action === "application.export").map((x) => x.detail))}`);
+
+check("no entry anywhere contains the applicant's name or email", !JSON.stringify(all).includes(APPLICANT_EMAIL) && !JSON.stringify(all).includes("Secretname"));
+
+// ---- reads ----
+r = await api(bodyC, "GET", "/api/admin/applications/au-1/audit");
+check("lead can read history of an application they can access", r.status === 200 && (r.json?.entries || []).some((x) => x.action === "application.reject") && (r.json?.entries || []).some((x) => x.outcome === "refused"), `${r.status} ${(r.json?.entries || []).length}`);
+r = await api(bodyC, "GET", "/api/admin/applications/au-solar/audit");
+check("lead cannot read history of an application outside their scope", r.status === 403, `${r.status}`);
+r = await api(appC, "GET", "/api/admin/applications/au-1/audit");
+check("applicant cannot read history", r.status === 401 || r.status === 403, `${r.status}`);
+r = await api(adminC, "GET", "/api/admin/audit?limit=100");
+check("admin activity feed includes config and user entries", r.status === 200 && r.json.entries.some((x) => x.action === "config.recruiting_step") && r.json.entries.some((x) => x.action === "user.update") && r.json.entries.some((x) => x.action === "application.reject"), `${r.status} ${r.json?.entries?.length}`);
+check("activity feed is newest first", r.json.entries.every((x, i, a) => i === 0 || new Date(a[i - 1].at) >= new Date(x.at)));
+r = await api(capC, "GET", "/api/admin/audit?limit=100");
+check("Electric captain sees only Electric application entries — no config/user/other-team entries", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.applicantTeam === "Electric"), `${r.status} ${JSON.stringify([...new Set((r.json?.entries || []).map((x) => x.applicantTeam ?? x.action))])}`);
+r = await api(capSC, "GET", "/api/admin/audit?limit=100");
+check("Solar captain sees the refused bulk attempt on the Solar app", r.status === 200 && r.json.entries.some((x) => x.applicationId === "au-solar" && x.outcome === "refused") && r.json.entries.every((x) => x.applicantTeam === "Solar"), `${r.status} ${r.json?.entries?.length}`);
+r = await api(bodyC, "GET", "/api/admin/audit");
+check("lead cannot read the activity feed", r.status === 403, `${r.status}`);
+r = await api(adminC, "GET", "/api/admin/audit?action=application.status");
+check("action filter works", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.action === "application.status"), `${r.json?.entries?.length}`);
+r = await api(adminC, "GET", "/api/admin/audit?actor=u-body");
+check("actor filter works", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.actor.uid === "u-body"), `${r.json?.entries?.length}`);
+check("feed payload has no applicant PII", !r.text.includes(APPLICANT_EMAIL) && !r.text.includes("Secretname"));
+
+await api(adminC, "POST", "/api/admin/config/recruiting", { step: "open", confirm: "open" });
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -87,7 +87,16 @@ check("recruiting step change recorded", r.status === 200 && all.some((x) => x.a
 
 r = await api(adminC, "POST", "/api/admin/applications/export-csv", { team: "Electric" });
 all = await allEntries();
-check("CSV export recorded", all.some((x) => x.action === "application.export" && x.actor.uid === "seed-admin"), `${r.status} ${JSON.stringify(all.filter((x) => x.action === "application.export").map((x) => x.detail))}`);
+check("CSV export recorded with count and teams", all.some((x) => x.action === "application.export" && x.actor.uid === "seed-admin" && Array.isArray(x.after?.teams) && typeof x.after?.count === "number"), `${r.status} ${JSON.stringify(all.filter((x) => x.action === "application.export").map((x) => [x.detail, x.after]))}`);
+r = await api(adminC, "DELETE", "/api/admin/applications/au-2/notes/nonexistent-note");
+all = await allEntries();
+check("note deletion recorded", r.status === 200 && all.some((x) => x.action === "application.note_deleted" && x.applicationId === "au-2" && x.applicantTeam === "Electric"), `${r.status}`);
+r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "release_trial" });
+all = await allEntries();
+check("refused out-of-order step change recorded as refused", r.status === 400 && all.some((x) => x.action === "config.recruiting_step" && x.outcome === "refused"), `${r.status}`);
+r = await api(adminC, "POST", "/api/admin/config/recruiting", { renegEnabled: true });
+all = await allEntries();
+check("reneg toggle recorded", r.status === 200 && all.some((x) => x.action === "config.update" && /renegEnabled/.test(x.detail || "")), `${r.status}`);
 
 check("no entry anywhere contains the applicant's name or email", !JSON.stringify(all).includes(APPLICANT_EMAIL) && !JSON.stringify(all).includes("Secretname"));
 
@@ -102,9 +111,11 @@ r = await api(adminC, "GET", "/api/admin/audit?limit=100");
 check("admin activity feed includes config and user entries", r.status === 200 && r.json.entries.some((x) => x.action === "config.recruiting_step") && r.json.entries.some((x) => x.action === "user.update") && r.json.entries.some((x) => x.action === "application.reject"), `${r.status} ${r.json?.entries?.length}`);
 check("activity feed is newest first", r.json.entries.every((x, i, a) => i === 0 || new Date(a[i - 1].at) >= new Date(x.at)));
 r = await api(capC, "GET", "/api/admin/audit?limit=100");
-check("Electric captain sees only Electric application entries — no config/user/other-team entries", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.applicantTeam === "Electric"), `${r.status} ${JSON.stringify([...new Set((r.json?.entries || []).map((x) => x.applicantTeam ?? x.action))])}`);
+check("Electric captain sees only Electric application entries — no config/user/other-team entries (exports that included Electric allowed)", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.applicantTeam === "Electric" || (x.action === "application.export" && x.after?.teams?.includes("Electric"))), `${r.status} ${JSON.stringify([...new Set((r.json?.entries || []).map((x) => x.applicantTeam ?? x.action))])}`);
+check("Electric captain CAN see the CSV export that included Electric applicants", r.json.entries.some((x) => x.action === "application.export"));
+check("feed reports whether its window was truncated", typeof r.json.truncated === "boolean");
 r = await api(capSC, "GET", "/api/admin/audit?limit=100");
-check("Solar captain sees the refused bulk attempt on the Solar app", r.status === 200 && r.json.entries.some((x) => x.applicationId === "au-solar" && x.outcome === "refused") && r.json.entries.every((x) => x.applicantTeam === "Solar"), `${r.status} ${r.json?.entries?.length}`);
+check("Solar captain sees the refused bulk attempt on the Solar app (and the export that included Solar), nothing else", r.status === 200 && r.json.entries.some((x) => x.applicationId === "au-solar" && x.outcome === "refused") && r.json.entries.every((x) => x.applicantTeam === "Solar" || (x.action === "application.export" && x.after?.teams?.includes("Solar"))), `${r.status} ${JSON.stringify(r.json?.entries?.map((x) => x.applicantTeam ?? x.action))}`);
 r = await api(bodyC, "GET", "/api/admin/audit");
 check("lead cannot read the activity feed", r.status === 403, `${r.status}`);
 r = await api(adminC, "GET", "/api/admin/audit?action=application.status");

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -71,6 +71,10 @@ check("bulk refusal (other team) recorded as refused", eS.some((x) => x.action =
 
 r = await api(adminC, "PATCH", "/api/admin/applications/au-2", { formData: { major: "ME" } });
 e = await entriesFor("au-2");
+{
+  const edit = e.find((x) => x.action === "application.edit");
+  check("admin edit: before/after describe the record, not the request (no false diff on a formData-only edit)", !!edit && edit.before?.team === "Electric" && edit.after?.team === "Electric" && JSON.stringify(edit.after?.preferredSystems) === JSON.stringify(edit.before?.preferredSystems), JSON.stringify([edit?.before, edit?.after]));
+}
 check("admin edit recorded with the fields touched", r.status === 200 && e.some((x) => x.action === "application.edit" && /formData/.test(x.detail || "") && /major/.test(x.detail || "")), JSON.stringify(e.filter((x) => x.action === "application.edit").map((x) => x.detail)));
 
 r = await api(adminC, "PATCH", "/api/admin/applications/au-2/interview/Body", { status: "completed" });
@@ -80,6 +84,16 @@ check("interview offer status change recorded", r.status === 200 && e.some((x) =
 r = await api(adminC, "PATCH", "/api/admin/users/u-target", { role: "system_lead", team: "Electric", system: "Dynamics", isMember: true });
 let all = await allEntries();
 check("user role change recorded with target, before and after", r.status === 200 && all.some((x) => x.action === "user.update" && x.targetUid === "u-target" && x.before?.role === "applicant" && x.after?.role === "system_lead" && x.after?.system === "Dynamics"), JSON.stringify(all.filter((x) => x.action === "user.update").map((x) => [x.targetUid, x.before, x.after])));
+
+// a system lead's role-fence refusal is recorded like a transition refusal
+r = await api(bodyC, "POST", "/api/admin/applications/au-2/status", { status: "interview", systems: ["Dynamics"] });
+e = await entriesFor("au-2");
+check("lead offering for another system -> 403 AND a refused entry naming the fence", r.status === 403 && e.some((x) => x.action === "application.status" && x.outcome === "refused" && x.actor?.uid === "u-body" && /own system/i.test(x.detail || "")), `${r.status} ${JSON.stringify(e.filter((x) => x.outcome === "refused").map((x) => x.detail))}`);
+
+// bulk: an unknown id is an error, not a refusal
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["au-does-not-exist"], action: "reject" });
+all = await allEntries();
+check("bulk on an unknown id records outcome=error (not refused)", all.some((x) => x.action === "application.bulk" && x.applicationId === "au-does-not-exist" && x.outcome === "error"), JSON.stringify(all.filter((x) => x.applicationId === "au-does-not-exist").map((x) => [x.outcome, x.detail])));
 
 // #124: a captain's roster edit (the form sends the role unchanged) is a real
 // write now — one entry, captain as actor, role absent from the field list.
@@ -127,6 +141,10 @@ r = await api(capC, "GET", "/api/admin/audit?limit=100");
 check("Electric captain sees only Electric application entries — no config/user/other-team entries (exports that included Electric allowed)", r.status === 200 && r.json.entries.length > 0 && r.json.entries.every((x) => x.applicantTeam === "Electric" || (x.action === "application.export" && x.after?.teams?.includes("Electric"))), `${r.status} ${JSON.stringify([...new Set((r.json?.entries || []).map((x) => x.applicantTeam ?? x.action))])}`);
 check("Electric captain CAN see the CSV export that included Electric applicants", r.json.entries.some((x) => x.action === "application.export"));
 check("feed reports whether its window was truncated", typeof r.json.truncated === "boolean");
+r = await api(adminC, "GET", "/api/admin/audit?limit=5");
+check("truncated is true when more matched than the requested limit", r.status === 200 && r.json.entries.length === 5 && r.json.truncated === true, `${r.json?.entries?.length} truncated=${r.json?.truncated}`);
+r = await api(adminC, "GET", "/api/admin/audit?limit=500");
+check("truncated is false when everything fit", r.status === 200 && r.json.entries.length > 5 && r.json.truncated === false, `${r.json?.entries?.length} truncated=${r.json?.truncated}`);
 r = await api(capSC, "GET", "/api/admin/audit?limit=100");
 check("Solar captain sees the refused bulk attempt on the Solar app (and the export that included Solar), nothing else", r.status === 200 && r.json.entries.some((x) => x.applicationId === "au-solar" && x.outcome === "refused") && r.json.entries.every((x) => x.applicantTeam === "Solar" || (x.action === "application.export" && x.after?.teams?.includes("Solar"))), `${r.status} ${JSON.stringify(r.json?.entries?.map((x) => x.applicantTeam ?? x.action))}`);
 r = await api(bodyC, "GET", "/api/admin/audit");

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -81,6 +81,19 @@ r = await api(adminC, "PATCH", "/api/admin/users/u-target", { role: "system_lead
 let all = await allEntries();
 check("user role change recorded with target, before and after", r.status === 200 && all.some((x) => x.action === "user.update" && x.targetUid === "u-target" && x.before?.role === "applicant" && x.after?.role === "system_lead" && x.after?.system === "Dynamics"), JSON.stringify(all.filter((x) => x.action === "user.update").map((x) => [x.targetUid, x.before, x.after])));
 
+// #124: a captain's roster edit (the form sends the role unchanged) is a real
+// write now — one entry, captain as actor, role absent from the field list.
+await ensureUser({ uid: "u-target2", email: "target2@utexas.edu", name: "Target Two", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+r = await api(capC, "PATCH", "/api/admin/users/u-target2", { role: "system_lead", team: "Electric", system: "Dynamics" });
+all = await allEntries();
+{
+  const e2 = all.filter((x) => x.action === "user.update" && x.targetUid === "u-target2");
+  check("captain roster edit recorded once, actor captain, role not among updated fields", r.status === 200 && e2.length === 1 && e2[0].actor?.uid === "u-cap" && e2[0].outcome === "ok" && !/role/.test(e2[0].detail || "") && e2[0].before?.system === "Body" && e2[0].after?.system === "Dynamics" && e2[0].after?.role === "system_lead", `${r.status} ${JSON.stringify(e2.map((x) => [x.actor?.uid, x.detail, x.before, x.after]))}`);
+}
+r = await api(capC, "PATCH", "/api/admin/users/u-target2", { role: "reviewer", team: "Electric", system: "Dynamics" });
+all = await allEntries();
+check("captain role change is refused (403) and writes no entry", r.status === 403 && all.filter((x) => x.action === "user.update" && x.targetUid === "u-target2").length === 1, `${r.status} ${r.json?.error || ""}`);
+
 r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing" });
 all = await allEntries();
 check("recruiting step change recorded", r.status === 200 && all.some((x) => x.action === "config.recruiting_step" && x.before?.step === "open" && x.after?.step === "reviewing"), JSON.stringify(all.filter((x) => x.action === "config.recruiting_step").map((x) => x.detail)));


### PR DESCRIPTION
Closes #119. Originally stacked on #120; now based on `main` with #120 and #121 (incl. #124, #126) merged in, so it records the final action shapes from the transition table and the reconciled users route.

## What you get

**Every mutating staff route writes an `audit_log` entry**, after the write succeeds: who (uid, email, name, role, team/system), what (action + `ok`/`refused`), on which application (id + team — **never an applicant's name or email**, so the log is safe for any staff member to read), a compact before/after of the pipeline-gating fields, the systems involved, a one-line human-readable detail, and the user agent. Refusals from the transition table are recorded too: "who tried what" is half of accountability.

Instrumented: single status route (including the #121 revert-to-submitted path), per-system reject, bulk (one entry per application), interview-offer status, admin application edit (including #121's team-change revalidation — a 400 there is a validation refusal, not a transition refusal, so it writes nothing), note deletion, CSV export (count + which teams + requested systems), seed / delete-seed, ratings backfill, email triggers and test sends, recruiting step changes (including refused out-of-order attempts and the reneg toggle), every config writer (about, announcement, contact, dashboard, email templates, FAQ, questions, teams), scorecard-config create/update/delete, user role/team changes (target uid + before/after — since #124 a captain's roster edit is a real write and is recorded as one; the entry's `after.role` is the effective role and `detail` lists only the fields actually changed).

Deliberately not instrumented: note/task/scorecard *creation* (the author is already on the document), cache refreshes, stats recompute, applicant-side actions.

**Two ways to read it:**
- **History panel** on every application's detail view — who did what to this applicant, newest first, refreshing after your own actions. Scoped like everything else on that page (`requireStaffForApplication`), so a system lead or reviewer sees the history of applications they can already open — which includes *who* on another system offered or rejected. Scorecard submissions are not in the log, so nothing another system's scorecard API withholds leaks through here.
- **`/admin/activity`** (admins + team captains; nav link restricted to match) — the feed with action / staff / application filters, a refused-only toggle, expandable before/after, and CSV export. Admins see everything. Captains see their own team's application entries plus any CSV export that included their team; config and user changes stay admin-only.

**Writes never fail a request** — `recordAudit` swallows its own errors (they still reach error monitoring). **No Firestore index deploy needed** — every query is single-field; the feed reads the newest 1,000 entries and filters in memory, and tells you when that window was full.

## Robustness: what the bot can and can't hide

Entries are written server-side inside the route, so any client — the admin UI, an ad-blocked browser, a scripted request, or a bot driving a real Chrome — is recorded identically under the account it used. What the log cannot do is distinguish a bot from the human whose session it borrowed; that's a property of shared credentials, not of the log.

## Independent review

Opus review pass found 7 items, all addressed: CSV exports were the least-visible entry despite being the one action that moves PII off-platform (now carry count/teams/systems and are visible to the captains whose applicants were in them); the action filter silently truncated (window raised to 1,000 with an explicit `truncated` flag and a notice in the UI); test-email sends and note deletions were uninstrumented (now are); free-text `cancelReason` in a detail was uncapped (200 chars); bulk not-found items lose their team (accepted — there is no team to know); one light-mode-unsafe class in the expanded JSON panel (fixed); user agent dropped on six routes that had the request in hand (fixed where a request exists). Verified by the reviewer: no applicant PII in any payload, captain scoping holds under every filter combination, `clean()` never feeds a `FieldValue` into `.add()`, all four write branches of the status route converge on one audit call.

Celina's review (at `7c393d3`) found seven, all addressed: false before/after diffs on admin edits (now describe the record, not the request), `truncated` ignoring the `limit` slice, unbounded actor/application lookups (capped, no composite index), errors recorded as refusals (third outcome `error`, own badge, "Refused only" stays refusals-only), N parallel audit writes on bulk (one `WriteBatch`), system-lead role fences not audited (all eight now are, via one `refuse()` helper), and a CSV download that failed in Firefox (one shared `downloadFile.ts` replaces three copies). Her two "noted" items: config entries for teams/questions now carry the scope; captains not seeing their own `user.update` entries stays as designed.

## Merge with main (after #121)

Three files overlapped. The admin application edit route had only an import conflict. The users route auto-merged but fetched the target twice (#124 loads it up front for every caller); reconciled to one read, with the audit entry's `before` taken from that same read. `ApplicationDetail.tsx` merged cleanly — History panel alongside #126's per-system status header — and was re-verified in the browser.

## Verification

- `scripts/qa/audit-regress.mjs` (committed) — **36 checks**: entries for reject / refused status / a lead's role-fence refusal (actor + fence named) / status change with before→after / bulk ok + refused + `error` on an unknown id / edit with a truthful before/after on a formData-only change / interview offer / user update by admin / captain roster edit (one entry, captain actor, no `role` in the field list) / captain role change refused with no entry / step change / export / note deletion / refused step / reneg; PII absence asserted over every entry and every feed payload; read scoping for lead (own application yes, other team no), applicant (no), admin (all), Electric captain (own team + relevant exports only), Solar captain, lead on the feed (403); action and actor filters; `truncated` true when more matched than `limit`, false when everything fit.
- Every other harness green on this exact tree: transitions 57/57, gates 33/33, users 19/19, staff-status 28/28, rejection 27/27, drafts 20/20, bulk 12/12, sweeps 20/20, stats 28/28.
- Browser-verified in the emulator: Activity page (dark + light), and the History panel on an application with entries next to the #126 status header.
- `npx tsc --noEmit` and `npm run build` clean.

## Migration / data

None. The `audit_log` collection is created on first write. Retention is a separate decision — entries hold staff identity and application ids only, so cycle-end deletion of applications does not leave applicant PII behind here.
