### PR TITLE
fix: staff cannot submit drafts; required answers enforced server-side (#127)

### DIFF
--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -124,6 +124,14 @@ export async function POST(
         systemsToOffer = preferred;
       }
 
+      // Once the applicant has chosen their interview system, the others were
+      // cancelled by that choice and cannot be re-offered — there is no way
+      // to book them (#127). Only the chosen system may be offered again.
+      const chosen = application.selectedInterviewSystem;
+      if (chosen && systemsToOffer.some((sys: string) => sys !== chosen)) {
+        return refuse(400, `The applicant already chose ${chosen} for their interview; other systems can't be offered now.`);
+      }
+
       // System leads can ONLY extend interview offers for their own system
       if (currentUser.role === UserRole.SYSTEM_LEAD) {
         const userSystem = currentUser.memberProfile?.system;
@@ -209,8 +217,8 @@ export async function POST(
       // Also set interviewDecision since we're advancing from interview to trial
       updatedApp = await addMultipleTrialOffers(id, systemsToOffer, 'advanced');
     } else if (status === ApplicationStatus.SUBMITTED) {
-      // Revert to a fresh review (or force-submit a draft). Full reset, and
-      // the original submission time is kept.
+      // Revert to a fresh review: full reset, original submission time kept.
+      // Never a draft — the transition table refuses those (#127).
       updatedApp = await revertToSubmitted(id);
     } else {
       // For other status changes (reject, accept), update status and stage decision

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -203,6 +203,11 @@ export async function POST(request: NextRequest) {
             case "interview": {
               const target = resolveBulkSystems(application, effectiveSystems, "interview");
               if (target.error) return { id: appId, success: false, error: target.error, refused: true };
+              // See the single-application route: nothing but the chosen
+              // system can be offered once the applicant has chosen (#127).
+              if (application.selectedInterviewSystem && target.systems.some((sys: string) => sys !== application.selectedInterviewSystem)) {
+                return { id: appId, success: false, error: `Applicant already chose ${application.selectedInterviewSystem} for their interview; other systems can't be offered now`, refused: true };
+              }
               await addMultipleInterviewOffers(appId, target.systems, 'advanced');
               return { id: appId, success: true };
             }

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -181,8 +181,9 @@ export async function POST(request: NextRequest) {
             return { id: appId, success: false, error: accessError, refused: true };
           }
 
-          // Drafts are not reviewable; see the single-application status route.
-          if (application.status === ApplicationStatus.IN_PROGRESS && action !== "submitted") {
+          // Drafts are not reviewable — and not submittable by staff (#127);
+          // see the single-application status route.
+          if (application.status === ApplicationStatus.IN_PROGRESS) {
             return { id: appId, success: false, error: DRAFT_ACTION_ERROR, refused: true };
           }
 

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -14,6 +14,27 @@ import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { logger } from "@/lib/logger";
 
 
+/**
+ * `baseEditAt` as the form sends it — an ISO string — or, defensively, an
+ * epoch number or a serialized Firestore Timestamp. `null`/absent means the
+ * client had no base (a fresh application). Anything else is a client bug and
+ * must be refused rather than read as "base 0", which would look like a
+ * conflict and throw the applicant's typing away.
+ */
+function baseEditMillis(v: unknown): number | null | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === "string" || typeof v === "number") {
+    const t = new Date(v).getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  if (typeof v === "object") {
+    const o = v as { _seconds?: unknown; seconds?: unknown };
+    const secs = typeof o._seconds === "number" ? o._seconds : typeof o.seconds === "number" ? o.seconds : undefined;
+    if (secs !== undefined) return secs * 1000;
+  }
+  return null;
+}
+
 function countWords(text: string): number {
   return text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
 }
@@ -174,9 +195,12 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // and a client that sends no session (an older cached form) is accepted
     // as before.
     const session = typeof editSession === "string" && editSession.length > 0 && editSession.length <= 64 ? editSession : undefined;
+    const baseMs = baseEditMillis(baseEditAt);
+    if (baseMs === null) {
+      return NextResponse.json({ error: "Invalid baseEditAt" }, { status: 400 });
+    }
     if (session && existingApplication.lastEditSession && existingApplication.lastEditSession !== session) {
-      const parsedBase = typeof baseEditAt === "string" ? new Date(baseEditAt).getTime() : 0;
-      const base = Number.isNaN(parsedBase) ? 0 : parsedBase;
+      const base = baseMs ?? 0;
       const last = existingApplication.lastEditAt?.getTime() ?? 0;
       if (last > base) {
         return NextResponse.json(
@@ -230,6 +254,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     // submitted application without a resume. The client shows this message
     // verbatim. (getApplicationQuestions() falls back to the code defaults on
     // a read failure, as the word-count check below already relies on.)
+    //
+    // Deliberately *only* on submit. Later edits to a submitted application
+    // are the applicant's own, including ones that leave it incomplete
+    // (removing the resume, emptying the ranking) — as before this change.
+    // Applying the rule to every autosave wedged the form on exactly those
+    // edits (review on #128); the form warns instead, and reviewers see the
+    // gap.
     if (status === ApplicationStatus.SUBMITTED) {
       const questionsConfig = await getApplicationQuestions();
       const mergedFormData = formData

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -155,7 +155,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     }
 
     const body = await request.json();
-    const { preferredSystems, status } = body;
+    const { preferredSystems, status, editSession, baseEditAt } = body;
 
     // An applicant may only move their own application between the two statuses
     // they own. This value reaches Firestore unmodified, and nothing downstream
@@ -164,6 +164,28 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (status !== undefined && !APPLICANT_STATUSES.includes(status)) {
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
     }
+
+    // Two tabs, one application (#127). Each tab identifies itself and says
+    // which version it last saw. A save from a tab that is not the last
+    // editor, made after another tab saved, is refused with 409 and the form
+    // reloads — an older copy must never overwrite a newer one (that is how
+    // a submitted application lost its resume on Aug 28). The same tab is
+    // never refused, so an in-flight save racing its own follow-up is fine,
+    // and a client that sends no session (an older cached form) is accepted
+    // as before.
+    const session = typeof editSession === "string" && editSession.length > 0 && editSession.length <= 64 ? editSession : undefined;
+    if (session && existingApplication.lastEditSession && existingApplication.lastEditSession !== session) {
+      const parsedBase = typeof baseEditAt === "string" ? new Date(baseEditAt).getTime() : 0;
+      const base = Number.isNaN(parsedBase) ? 0 : parsedBase;
+      const last = existingApplication.lastEditAt?.getTime() ?? 0;
+      if (last > base) {
+        return NextResponse.json(
+          { error: "This application was edited in another tab or on another device. Reload to continue from the latest version." },
+          { status: 409 }
+        );
+      }
+    }
+    const editStamp = session ? { lastEditSession: session, lastEditAt: new Date() } : {};
 
     // Whitelist formData keys server-side — applicants own this document but
     // must not be able to write arbitrary fields into it.
@@ -202,43 +224,24 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Required answers are enforced here too (#127), not only by the form: on
-    // submit, everything the form would demand; and on any later save to an
-    // application that is no longer a draft, nothing already answered may be
-    // blanked and the ranking may not be emptied — a second tab holding an
-    // older copy of the form used to autosave over a submitted application
-    // and erase its resume.
-    if (status === ApplicationStatus.SUBMITTED || existingApplication.status !== ApplicationStatus.IN_PROGRESS) {
-      try {
-        const questionsConfig = await getApplicationQuestions();
-        const mergedFormData = formData
-          ? { ...existingApplication.formData, ...formData }
-          : existingApplication.formData;
-        const mergedSystems: string[] = preferredSystems ?? existingApplication.preferredSystems ?? [];
-        const missingNow = missingRequiredAnswers(mergedFormData, mergedSystems, existingApplication.team, questionsConfig);
-        if (status === ApplicationStatus.SUBMITTED && missingNow.length > 0) {
-          return NextResponse.json(
-            { error: `Please fill in the following required fields: ${missingNow.join(", ")}` },
-            { status: 400 }
-          );
-        }
-        if (existingApplication.status !== ApplicationStatus.IN_PROGRESS) {
-          const missingBefore = missingRequiredAnswers(
-            existingApplication.formData,
-            existingApplication.preferredSystems ?? [],
-            existingApplication.team,
-            questionsConfig
-          );
-          const blanked = missingNow.filter((label) => !missingBefore.includes(label));
-          if (blanked.length > 0) {
-            return NextResponse.json(
-              { error: `Required answers can't be blanked on a submitted application: ${blanked.join(", ")}` },
-              { status: 400 }
-            );
-          }
-        }
-      } catch (err) {
-        logger.warn({ err }, "Could not validate required answers, proceeding without validation");
+    // Required answers are enforced on submit here too (#127), not only by
+    // the form: a stale question cache, a form that never rendered a newly
+    // required question, or a hand-rolled request must not produce a
+    // submitted application without a resume. The client shows this message
+    // verbatim. (getApplicationQuestions() falls back to the code defaults on
+    // a read failure, as the word-count check below already relies on.)
+    if (status === ApplicationStatus.SUBMITTED) {
+      const questionsConfig = await getApplicationQuestions();
+      const mergedFormData = formData
+        ? { ...existingApplication.formData, ...formData }
+        : existingApplication.formData;
+      const mergedSystems: string[] = preferredSystems ?? existingApplication.preferredSystems ?? [];
+      const missing = missingRequiredAnswers(mergedFormData, mergedSystems, existingApplication.team, questionsConfig);
+      if (missing.length > 0) {
+        return NextResponse.json(
+          { error: `Please fill in the following required fields: ${missing.join(", ")}` },
+          { status: 400 }
+        );
       }
     }
 
@@ -299,10 +302,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     // If only formData is being updated on a draft, use the merge function
     if (formData && !preferredSystems && !status && !alreadySubmitted) {
-      application = await updateApplicationFormData(id, formData);
+      application = await updateApplicationFormData(id, formData, editStamp);
     } else {
       // Update all provided fields
-      const updates: Record<string, unknown> = {};
+      const updates: Record<string, unknown> = { ...editStamp };
       if (formData) updates.formData = { ...existingApplication.formData, ...formData };
       if (preferredSystems !== undefined) updates.preferredSystems = preferredSystems;
       const nextStatus = isRejected

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -9,7 +9,7 @@ import { ApplicationStatus } from "@/lib/models/Application";
 import { getRecruitingConfig, getApplicationQuestions } from "@/lib/firebase/config";
 import { RecruitingStep } from "@/lib/models/Config";
 import { getUserVisibleStatus, sanitizeApplicationForApplicant } from "@/lib/utils/statusUtils";
-import { sanitizeIncomingFormData } from "@/lib/utils/formAnswers";
+import { sanitizeIncomingFormData, missingRequiredAnswers } from "@/lib/utils/formAnswers";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
 import { logger } from "@/lib/logger";
 
@@ -199,6 +199,46 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
           { error: "Rank at least one system before submitting" },
           { status: 400 }
         );
+      }
+    }
+
+    // Required answers are enforced here too (#127), not only by the form: on
+    // submit, everything the form would demand; and on any later save to an
+    // application that is no longer a draft, nothing already answered may be
+    // blanked and the ranking may not be emptied — a second tab holding an
+    // older copy of the form used to autosave over a submitted application
+    // and erase its resume.
+    if (status === ApplicationStatus.SUBMITTED || existingApplication.status !== ApplicationStatus.IN_PROGRESS) {
+      try {
+        const questionsConfig = await getApplicationQuestions();
+        const mergedFormData = formData
+          ? { ...existingApplication.formData, ...formData }
+          : existingApplication.formData;
+        const mergedSystems: string[] = preferredSystems ?? existingApplication.preferredSystems ?? [];
+        const missingNow = missingRequiredAnswers(mergedFormData, mergedSystems, existingApplication.team, questionsConfig);
+        if (status === ApplicationStatus.SUBMITTED && missingNow.length > 0) {
+          return NextResponse.json(
+            { error: `Please fill in the following required fields: ${missingNow.join(", ")}` },
+            { status: 400 }
+          );
+        }
+        if (existingApplication.status !== ApplicationStatus.IN_PROGRESS) {
+          const missingBefore = missingRequiredAnswers(
+            existingApplication.formData,
+            existingApplication.preferredSystems ?? [],
+            existingApplication.team,
+            questionsConfig
+          );
+          const blanked = missingNow.filter((label) => !missingBefore.includes(label));
+          if (blanked.length > 0) {
+            return NextResponse.json(
+              { error: `Required answers can't be blanked on a submitted application: ${blanked.join(", ")}` },
+              { status: 400 }
+            );
+          }
+        }
+      } catch (err) {
+        logger.warn({ err }, "Could not validate required answers, proceeding without validation");
       }
     }
 

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -42,6 +42,24 @@ const QUESTIONS_CACHE_KEY = "lhr_app_questions_cache";
 const QUESTIONS_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 // Debounce helper
+// The form's editable state for an application payload (used on load and
+// when the server's copy replaces this tab's).
+function formStateFrom(app: Application): FormData {
+  const f = app.formData || {};
+  return {
+    whyJoin: f.whyJoin || "",
+    relevantExperience: f.relevantExperience || "",
+    availability: f.availability || "",
+    resumeUrl: f.resumeUrl || "",
+    portfolioUrl: f.portfolioUrl || "",
+    preferredSystems: app.preferredSystems || [],
+    graduationYear: f.graduationYear || "",
+    major: f.major || "",
+    teamQuestions: f.teamQuestions || {},
+    customAnswers: f.customAnswers || {},
+  };
+}
+
 function debounce<T extends (...args: Parameters<T>) => void>(
   func: T,
   wait: number
@@ -124,10 +142,19 @@ export default function TeamApplicationPage() {
 
   // State
   const [application, setApplication] = useState<Application | null>(null);
+  // Identifies this tab to the server (#127): a save from another tab that
+  // loaded an older copy is refused, and this tab reloads instead of
+  // overwriting. Fixed for the life of the page.
+  const editSession = useRef<string>(
+    typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2)
+  );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Inline, above the form: validation on submit, or "another tab saved
+  // first". `error` is for failures that replace the page (load, closed).
+  const [formNotice, setFormNotice] = useState<string | null>(null);
   const [saveStatus, setSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
@@ -230,18 +257,7 @@ export default function TeamApplicationPage() {
 
         // Populate form with existing data
         if (app.formData) {
-          setFormData({
-            whyJoin: app.formData.whyJoin || "",
-            relevantExperience: app.formData.relevantExperience || "",
-            availability: app.formData.availability || "",
-            resumeUrl: app.formData.resumeUrl || "",
-            portfolioUrl: app.formData.portfolioUrl || "",
-            preferredSystems: app.preferredSystems || [],
-            graduationYear: app.formData.graduationYear || "",
-            major: app.formData.major || "",
-            teamQuestions: app.formData.teamQuestions || {},
-            customAnswers: app.formData.customAnswers || {},
-          });
+          setFormData(formStateFrom(app));
         }
       } catch (err) {
         console.error(err);
@@ -256,6 +272,18 @@ export default function TeamApplicationPage() {
 
   // Helper to clean trailing commas and spaces when saving
   const cleanString = (str: string) => (str || "").replace(/[\s,]+$/, "");
+
+  // Another tab or device saved this application after this one loaded it.
+  // Its copy is older, so it must not win: show the latest version instead.
+  const reloadFromServer = useCallback(async () => {
+    if (!application) return;
+    const res = await fetch(`/api/applications/${application.id}`);
+    if (!res.ok) return;
+    const { application: latest } = await res.json();
+    setApplication(latest);
+    if (latest?.formData) setFormData(formStateFrom(latest));
+    setFormNotice("This application was edited in another tab or on another device. Showing the latest version — unsaved changes in this tab were not kept.");
+  }, [application]);
 
   // Save form data to API
   const saveFormData = useCallback(
@@ -291,6 +319,8 @@ export default function TeamApplicationPage() {
               customAnswers: cleanedCustomAnswers,
             },
             preferredSystems: data.preferredSystems,
+            editSession: editSession.current,
+            baseEditAt: application.lastEditAt ?? null,
           }),
         });
 
@@ -312,9 +342,18 @@ export default function TeamApplicationPage() {
             setSaveStatus("idle");
             return;
           }
+          if (res.status === 409) {
+            await reloadFromServer();
+            setSaveStatus("idle");
+            return;
+          }
           throw new Error("Failed to save");
         }
 
+        // Keep lastEditAt (and editable) current so the next save carries
+        // the version it is based on.
+        const saved = await res.json().catch(() => null);
+        if (saved?.application) setApplication(saved.application);
         setSaveStatus("saved");
         setTimeout(() => setSaveStatus("idle"), 2000);
       } catch (err) {
@@ -322,7 +361,7 @@ export default function TeamApplicationPage() {
         setSaveStatus("error");
       }
     },
-    [application, refreshStep]
+    [application, refreshStep, reloadFromServer]
   );
 
   // Debounced save
@@ -601,7 +640,7 @@ export default function TeamApplicationPage() {
     }
 
     if (missingFields.length > 0) {
-      setError(`Please fill in the following required fields: ${missingFields.join(", ")}`);
+      setFormNotice(`Please fill in the following required fields: ${missingFields.join(", ")}`);
       return;
     }
 
@@ -634,12 +673,12 @@ export default function TeamApplicationPage() {
       });
     });
     if (overLimitFields.length > 0) {
-      setError(`The following fields exceed the word limit: ${overLimitFields.join(", ")}`);
+      setFormNotice(`The following fields exceed the word limit: ${overLimitFields.join(", ")}`);
       return;
     }
 
     setSubmitting(true);
-    setError(null);
+    setFormNotice(null);
 
     try {
       // Save form data first
@@ -651,11 +690,21 @@ export default function TeamApplicationPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           status: ApplicationStatus.SUBMITTED,
+          editSession: editSession.current,
+          baseEditAt: application.lastEditAt ?? null,
         }),
       });
 
       if (!res.ok) {
-        throw new Error("Failed to submit application");
+        // The server's reason is the useful part: which required answers are
+        // missing (a question the cached form never rendered, say), or that
+        // another tab saved a newer copy.
+        const body = await res.json().catch(() => ({}));
+        if (res.status === 409) {
+          await reloadFromServer();
+          return;
+        }
+        throw new Error(body?.error || "Failed to submit application");
       }
 
       posthog.capture("application_submitted", {
@@ -666,7 +715,7 @@ export default function TeamApplicationPage() {
       router.push("/dashboard?submitted=true");
     } catch (err) {
       console.error(err);
-      setError("Failed to submit application. Please try again.");
+      setFormNotice(err instanceof Error && err.message ? err.message : "Failed to submit application. Please try again.");
     } finally {
       setSubmitting(false);
     }
@@ -868,12 +917,12 @@ export default function TeamApplicationPage() {
         </div>
 
         {/* Error Message */}
-        {error && (
+        {formNotice && (
           <div
             className="mb-6 p-4 rounded-xl font-urbanist text-[13px]"
             style={{ backgroundColor: "var(--status-error-bg)", border: "1px solid var(--status-error-border)", color: "var(--status-error-ink)" }}
           >
-            {error}
+            {formNotice}
           </div>
         )}
 

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -42,6 +42,9 @@ const QUESTIONS_CACHE_KEY = "lhr_app_questions_cache";
 const QUESTIONS_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 // Debounce helper
+const CONFLICT_NOTICE =
+  "This application was edited in another tab or on another device. Showing the latest version — unsaved changes in this tab were not kept.";
+
 // The form's editable state for an application payload (used on load and
 // when the server's copy replaces this tab's).
 function formStateFrom(app: Application): FormData {
@@ -282,13 +285,13 @@ export default function TeamApplicationPage() {
     const { application: latest } = await res.json();
     setApplication(latest);
     if (latest?.formData) setFormData(formStateFrom(latest));
-    setFormNotice("This application was edited in another tab or on another device. Showing the latest version — unsaved changes in this tab were not kept.");
+    setFormNotice(CONFLICT_NOTICE);
   }, [application]);
 
   // Save form data to API
   const saveFormData = useCallback(
-    async (data: FormData) => {
-      if (!application) return;
+    async (data: FormData): Promise<"saved" | "conflict" | "failed"> => {
+      if (!application) return "failed";
 
       setSaveStatus("saving");
       
@@ -332,7 +335,7 @@ export default function TeamApplicationPage() {
           if (res.status === 400 && /no longer be edited/i.test(body?.error || "")) {
             setApplication((prev) => (prev ? { ...prev, editable: false } : prev));
             setSaveStatus("idle");
-            return;
+            return "failed";
           }
           if (res.status === 403 && /closed/i.test(body?.error || "")) {
             // The step moved past `open` while this tab was up: refetch it so
@@ -340,12 +343,12 @@ export default function TeamApplicationPage() {
             // failure on the applicant's side, so no "Failed to save" flash.
             refreshStep();
             setSaveStatus("idle");
-            return;
+            return "failed";
           }
           if (res.status === 409) {
             await reloadFromServer();
             setSaveStatus("idle");
-            return;
+            return "conflict";
           }
           throw new Error("Failed to save");
         }
@@ -354,11 +357,15 @@ export default function TeamApplicationPage() {
         // the version it is based on.
         const saved = await res.json().catch(() => null);
         if (saved?.application) setApplication(saved.application);
+        // A successful save supersedes an earlier "another tab saved first".
+        setFormNotice((n) => (n === CONFLICT_NOTICE ? null : n));
         setSaveStatus("saved");
         setTimeout(() => setSaveStatus("idle"), 2000);
+        return "saved";
       } catch (err) {
         console.error(err);
         setSaveStatus("error");
+        return "failed";
       }
     },
     [application, refreshStep, reloadFromServer]
@@ -593,51 +600,58 @@ export default function TeamApplicationPage() {
   };
 
   // Handle submit
+  // Required answers the form refuses to submit without. Also shown as a
+  // warning on a submitted application the applicant has since made
+  // incomplete — post-submit edits are theirs to make, and reviewers see the gap.
+  const missingRequiredFields = (): string[] => {
+        const missingFields: string[] = [];
+
+      // Resume is always required
+      if (!formData.resumeUrl) {
+        missingFields.push("Resume");
+      }
+
+      commonQuestions.forEach((q) => {
+        if (q.required) {
+          const val = commonAnswer(q.id);
+          if (!val || !val.trim()) {
+            missingFields.push(q.label);
+          }
+        }
+      });
+
+      teamQuestions.forEach((q) => {
+        if (q.required) {
+          const val = formData.teamQuestions[q.id];
+          if (!val || !val.trim()) {
+            missingFields.push(q.label);
+          }
+        }
+      });
+
+      // Only questions for systems they actually picked are required.
+      activeSystemQuestions.forEach(({ system, questions }) => {
+        questions.forEach((q) => {
+          if (q.required) {
+            const val = formData.customAnswers[q.id];
+            if (!val || !val.trim()) {
+              missingFields.push(`${q.label} (${system})`);
+            }
+          }
+        });
+      });
+
+      if (formData.preferredSystems.length === 0) {
+        missingFields.push("Preferred Systems (at least one)");
+      }
+    return missingFields;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!application) return;
 
-    // Validate required fields
-    const missingFields: string[] = [];
-
-    // Resume is always required
-    if (!formData.resumeUrl) {
-      missingFields.push("Resume");
-    }
-
-    commonQuestions.forEach((q) => {
-      if (q.required) {
-        const val = commonAnswer(q.id);
-        if (!val || !val.trim()) {
-          missingFields.push(q.label);
-        }
-      }
-    });
-
-    teamQuestions.forEach((q) => {
-      if (q.required) {
-        const val = formData.teamQuestions[q.id];
-        if (!val || !val.trim()) {
-          missingFields.push(q.label);
-        }
-      }
-    });
-
-    // Only questions for systems they actually picked are required.
-    activeSystemQuestions.forEach(({ system, questions }) => {
-      questions.forEach((q) => {
-        if (q.required) {
-          const val = formData.customAnswers[q.id];
-          if (!val || !val.trim()) {
-            missingFields.push(`${q.label} (${system})`);
-          }
-        }
-      });
-    });
-
-    if (formData.preferredSystems.length === 0) {
-      missingFields.push("Preferred Systems (at least one)");
-    }
+    const missingFields = missingRequiredFields();
 
     if (missingFields.length > 0) {
       setFormNotice(`Please fill in the following required fields: ${missingFields.join(", ")}`);
@@ -681,8 +695,14 @@ export default function TeamApplicationPage() {
     setFormNotice(null);
 
     try {
-      // Save form data first
-      await saveFormData(formData);
+      // Save form data first. A save that did not land must not be followed
+      // by a submit of the stored copy: the applicant's last edits would be
+      // silently dropped and they would be told the application went in.
+      const saved = await saveFormData(formData);
+      if (saved !== "saved") {
+        if (saved === "failed") setFormNotice("Your latest changes couldn't be saved, so the application wasn't submitted. Check your connection and try again.");
+        return;
+      }
 
       // Then submit
       const res = await fetch(`/api/applications/${application.id}`, {
@@ -925,6 +945,17 @@ export default function TeamApplicationPage() {
             {formNotice}
           </div>
         )}
+        {isEditingSubmitted && (() => {
+          const missing = missingRequiredFields();
+          return missing.length > 0 ? (
+            <div
+              className="rounded-xl px-4 py-3 mb-5 font-urbanist text-[13px]"
+              style={{ backgroundColor: "rgba(245,158,11,0.10)", border: "1px solid rgba(245,158,11,0.30)", color: "rgba(217,119,6,0.95)" }}
+            >
+              Your submitted application is missing: {missing.join(", ")}. Reviewers will see it as incomplete until you add {missing.length > 1 ? "them" : "it"}.
+            </div>
+          ) : null;
+        })()}
 
         {/* Editing an application that has already been submitted. Allowed
             until applications close; re-submitting updates submittedAt. */}

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -114,6 +114,7 @@ export async function createApplication(
         createdAt: existingData.createdAt?.toDate() || new Date(),
         updatedAt: existingData.updatedAt?.toDate() || new Date(),
         submittedAt: existingData.submittedAt?.toDate(),
+        lastEditAt: safeToDate(existingData.lastEditAt),
         interviewOffers: normalizeInterviewOffers(existingData.interviewOffers),
       } as Application;
     }
@@ -429,10 +430,17 @@ export async function addMultipleInterviewOffers(
     const data = doc.data()!;
     const existingOffers = normalizeInterviewOffers(data.interviewOffers) || [];
     const existingOfferSystems = new Set(existingOffers.map((o) => o.system));
+    // Once the applicant has chosen their interview system, the other offers
+    // were cancelled by that choice; only the chosen one may be offered again
+    // (the routes refuse the rest with a message). Everything below — new
+    // offers, refresh, ranking join, un-reject — works on `offerable` only,
+    // so a bypass cannot rank or un-reject a system it did not offer.
+    const chosen = data.selectedInterviewSystem as string | undefined;
+    const offerable = chosen ? systems.filter((s) => s === chosen) : systems;
     
     // Create new offers only for systems that don't already have one
     const newOffers: InterviewOffer[] = [];
-    for (const system of systems) {
+    for (const system of offerable) {
       if (!existingOfferSystems.has(system)) {
         newOffers.push({
           system,
@@ -446,13 +454,11 @@ export async function addMultipleInterviewOffers(
     // cancelled entry used to block the re-offer silently — the lead saw a
     // 200, nothing changed, and the application sat at `interview` with no
     // live offer (#127). Pending, completed and no-show offers are kept.
-    // Once the applicant has chosen their interview system, the other offers
-    // were cancelled by that choice; refreshing one would produce a pending
-    // offer the applicant can never book. The routes refuse that case with a
-    // message — this is the belt and braces.
-    const chosen = data.selectedInterviewSystem as string | undefined;
+    // A cancelled or no-show offer that is offered again becomes a fresh
+    // pending one; a completed offer is left alone.
+    const REOFFERABLE = new Set<InterviewEventStatus>([InterviewEventStatus.CANCELLED, InterviewEventStatus.NO_SHOW]);
     const refreshedOffers: InterviewOffer[] = existingOffers.map((o) =>
-      systems.includes(o.system) && o.status === InterviewEventStatus.CANCELLED && (!chosen || chosen === o.system)
+      offerable.includes(o.system) && REOFFERABLE.has(o.status)
         ? { system: o.system, status: InterviewEventStatus.PENDING, createdAt: new Date() }
         : o
     );
@@ -461,7 +467,7 @@ export async function addMultipleInterviewOffers(
     // Un-reject systems that are getting offers
     const currentRejections = (data.rejectedBySystems || []) as string[];
     const updatedRejections = currentRejections.filter(
-      (sys) => !systems.includes(sys)
+      (sys) => !offerable.includes(sys)
     );
 
     // Prepare update data
@@ -476,7 +482,7 @@ export async function addMultipleInterviewOffers(
     // see an application keys off preferredSystems — so the offered system
     // joins the ranking, with the applicant's own order kept in
     // originalPreferredSystems (#104).
-    Object.assign(updateData, joinRanking(data, systems));
+    Object.assign(updateData, joinRanking(data, offerable));
 
     // Update status to INTERVIEW if not already
     if (data.status !== ApplicationStatus.INTERVIEW) {
@@ -1126,6 +1132,7 @@ export async function sweepOnDecisionAdvance(
     // committed to, and the stale snapshot would reject it.
     const isCrossTeamRejectable = (d: FirebaseFirestore.DocumentData): boolean =>
       !TERMINAL.includes(d.status) &&
+      d.status !== ApplicationStatus.IN_PROGRESS && // a draft is never acted on (#127)
       d.status !== ApplicationStatus.WAITLISTED && // reneg pathway stays alive
       // ...and so does its second half: an acceptance stamped for the day being
       // entered (or later) is a promotion off the waitlist that this very
@@ -1494,7 +1501,8 @@ function joinRanking(data: FirebaseFirestore.DocumentData, systems: string[]): R
 }
 
 /**
- * Revert an application to a fresh Submitted state, or force-submit a draft.
+ * Revert an application to a fresh Submitted state. Never a draft — that is
+ * the applicant's to submit (#127).
  * Clears every offer and decision so the applicant sees a clean "Submitted"
  * and staff review from scratch. Keeps the original submittedAt (stamped only
  * if this is the first submission) and restores the applicant's own system

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -1486,6 +1486,11 @@ export async function revertToSubmitted(applicationId: string): Promise<Applicat
     const doc = await transaction.get(ref);
     if (!doc.exists) return false;
     const data = doc.data()!;
+    // Belt and braces for the transition table: a draft is the applicant's to
+    // submit. Never turn one into a submitted application from here (#127).
+    if (data.status === ApplicationStatus.IN_PROGRESS) {
+      throw new Error("A draft cannot be submitted on the applicant's behalf");
+    }
     const updateData: Record<string, unknown> = {
     status: ApplicationStatus.SUBMITTED,
     reviewDecision: "pending",

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -438,7 +438,16 @@ export async function addMultipleInterviewOffers(
       }
     }
 
-    const updatedOffers = [...existingOffers, ...newOffers];
+    // A system re-offering after cancelling gets a fresh pending offer. A
+    // cancelled entry used to block the re-offer silently — the lead saw a
+    // 200, nothing changed, and the application sat at `interview` with no
+    // live offer (#127). Pending, completed and no-show offers are kept.
+    const refreshedOffers: InterviewOffer[] = existingOffers.map((o) =>
+      systems.includes(o.system) && o.status === InterviewEventStatus.CANCELLED
+        ? { system: o.system, status: InterviewEventStatus.PENDING, createdAt: new Date() }
+        : o
+    );
+    const updatedOffers = [...refreshedOffers, ...newOffers];
 
     // Un-reject systems that are getting offers
     const currentRejections = (data.rejectedBySystems || []) as string[];

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -171,6 +171,7 @@ export async function getApplication(
     id: doc.id,
     createdAt: data.createdAt?.toDate() || new Date(),
     updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
     submittedAt: data.submittedAt?.toDate(),
     interviewOffers: normalizeInterviewOffers(data.interviewOffers),
   } as Application;
@@ -194,6 +195,7 @@ export async function getUserApplications(
       id: doc.id,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
       submittedAt: data.submittedAt?.toDate(),
       interviewOffers: normalizeInterviewOffers(data.interviewOffers),
     } as Application;
@@ -272,6 +274,7 @@ export async function getUserApplicationForTeam(
     id: doc.id,
     createdAt: data.createdAt?.toDate() || new Date(),
     updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
     submittedAt: data.submittedAt?.toDate(),
     interviewOffers: normalizeInterviewOffers(data.interviewOffers),
   } as Application;
@@ -282,7 +285,7 @@ export async function getUserApplicationForTeam(
  */
 export async function updateApplication(
   applicationId: string,
-  updates: Partial<Pick<Application, "formData" | "preferredSystems" | "originalPreferredSystems" | "status" | "interviewOffers" | "selectedInterviewSystem" | "rejectedBySystems" | "trialOffers" | "reviewDecision" | "interviewDecision" | "trialDecision" | "trialDecisionDay" | "offer" | "waitlistSystem" | "emailsSent">>
+  updates: Partial<Pick<Application, "formData" | "preferredSystems" | "originalPreferredSystems" | "status" | "interviewOffers" | "selectedInterviewSystem" | "rejectedBySystems" | "trialOffers" | "reviewDecision" | "interviewDecision" | "trialDecision" | "trialDecisionDay" | "offer" | "waitlistSystem" | "emailsSent" | "lastEditSession" | "lastEditAt">>
 ): Promise<Application | null> {
   const applicationRef = adminDb
     .collection(APPLICATIONS_COLLECTION)
@@ -322,7 +325,8 @@ export async function updateApplication(
  */
 export async function updateApplicationFormData(
   applicationId: string,
-  formData: Partial<ApplicationFormData>
+  formData: Partial<ApplicationFormData>,
+  extra: Partial<Pick<Application, "lastEditSession" | "lastEditAt">> = {}
 ): Promise<Application | null> {
   const application = await getApplication(applicationId);
   if (!application) {
@@ -334,7 +338,7 @@ export async function updateApplicationFormData(
     ...formData,
   };
 
-  return updateApplication(applicationId, { formData: mergedFormData });
+  return updateApplication(applicationId, { formData: mergedFormData, ...extra });
 }
 
 /**
@@ -442,8 +446,13 @@ export async function addMultipleInterviewOffers(
     // cancelled entry used to block the re-offer silently — the lead saw a
     // 200, nothing changed, and the application sat at `interview` with no
     // live offer (#127). Pending, completed and no-show offers are kept.
+    // Once the applicant has chosen their interview system, the other offers
+    // were cancelled by that choice; refreshing one would produce a pending
+    // offer the applicant can never book. The routes refuse that case with a
+    // message — this is the belt and braces.
+    const chosen = data.selectedInterviewSystem as string | undefined;
     const refreshedOffers: InterviewOffer[] = existingOffers.map((o) =>
-      systems.includes(o.system) && o.status === InterviewEventStatus.CANCELLED
+      systems.includes(o.system) && o.status === InterviewEventStatus.CANCELLED && (!chosen || chosen === o.system)
         ? { system: o.system, status: InterviewEventStatus.PENDING, createdAt: new Date() }
         : o
     );
@@ -1275,6 +1284,7 @@ export async function getAllApplications(): Promise<Application[]> {
       id: doc.id,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
       submittedAt: data.submittedAt?.toDate(),
       interviewOffers: normalizeInterviewOffers(data.interviewOffers),
     } as Application;
@@ -1297,6 +1307,7 @@ export async function getTeamApplications(team: Team): Promise<Application[]> {
       id: doc.id,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
       submittedAt: data.submittedAt?.toDate(),
       interviewOffers: normalizeInterviewOffers(data.interviewOffers),
     } as Application;
@@ -1320,6 +1331,7 @@ export async function getSystemApplications(
       id: doc.id,
       createdAt: data.createdAt?.toDate() || new Date(),
       updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
       submittedAt: data.submittedAt?.toDate(),
       interviewOffers: normalizeInterviewOffers(data.interviewOffers),
     } as Application;
@@ -1345,6 +1357,7 @@ function docToApplication(doc: FirebaseFirestore.DocumentSnapshot): Application 
     id: doc.id,
     createdAt: data.createdAt?.toDate() || new Date(),
     updatedAt: data.updatedAt?.toDate() || new Date(),
+    lastEditAt: safeToDate(data.lastEditAt),
     submittedAt: data.submittedAt?.toDate(),
     interviewOffers: normalizeInterviewOffers(data.interviewOffers),
     trialOffers: normalizeTrialOffers(data.trialOffers),

--- a/lib/models/Application.ts
+++ b/lib/models/Application.ts
@@ -115,6 +115,13 @@ export interface Application {
   updatedAt: Date;
   submittedAt?: Date;
 
+  // Two-tab conflict detection for the apply form (#127): the tab that last
+  // saved, and when. A save from a different tab whose copy predates
+  // lastEditAt is refused so an older form never overwrites a newer one.
+  // lastEditSession never reaches the applicant payload.
+  lastEditSession?: string;
+  lastEditAt?: Date;
+
   formData: ApplicationFormData;
 
   // Interview-related fields 

--- a/lib/utils/formAnswers.ts
+++ b/lib/utils/formAnswers.ts
@@ -1,3 +1,5 @@
+import { ApplicationQuestion } from "@/lib/models/Config";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { ApplicationFormData } from "@/lib/models/Application";
 
 /**
@@ -38,6 +40,43 @@ export function isNamedCommonField(questionId: string): questionId is NamedCommo
  * Read a common question's answer without caring where it is stored.
  * Returns "" when unanswered.
  */
+/**
+ * Required answers the applicant has not given, by label, judged against the
+ * live question config: the resume (always), every required common and team
+ * question, required system questions for the systems actually ranked, and
+ * at least one ranked system. Mirrors the form's own Submit check — this is
+ * the server-side backstop (#127).
+ */
+export function missingRequiredAnswers(
+  formData: Partial<ApplicationFormData> | undefined,
+  preferredSystems: string[],
+  team: string,
+  questions: {
+    commonQuestions: ApplicationQuestion[];
+    teamQuestions: Record<string, ApplicationQuestion[]>;
+    systemQuestions?: Record<string, ApplicationQuestion[]>;
+  }
+): string[] {
+  const missing: string[] = [];
+  const blank = (v: unknown) => typeof v !== "string" || v.trim() === "";
+  if (blank(formData?.resumeUrl)) missing.push("Resume");
+  for (const q of questions.commonQuestions) {
+    if (q.required && blank(getCommonAnswer(formData, q.id))) missing.push(q.label);
+  }
+  for (const q of questions.teamQuestions[team] ?? []) {
+    if (q.required && blank(formData?.teamQuestions?.[q.id])) missing.push(q.label);
+  }
+  for (const system of preferredSystems) {
+    const key = generateTeamSystemKey(team, system);
+    const qs = questions.systemQuestions?.[key] ?? questions.systemQuestions?.[system] ?? [];
+    for (const q of qs) {
+      if (q.required && blank(formData?.customAnswers?.[q.id])) missing.push(`${q.label} (${system})`);
+    }
+  }
+  if (preferredSystems.length === 0) missing.push("Preferred Systems (at least one)");
+  return missing;
+}
+
 export function getCommonAnswer(
   formData: Partial<ApplicationFormData> | undefined,
   questionId: string

--- a/lib/utils/formAnswers.ts
+++ b/lib/utils/formAnswers.ts
@@ -37,10 +37,6 @@ export function isNamedCommonField(questionId: string): questionId is NamedCommo
 }
 
 /**
- * Read a common question's answer without caring where it is stored.
- * Returns "" when unanswered.
- */
-/**
  * Required answers the applicant has not given, by label, judged against the
  * live question config: the resume (always), every required common and team
  * question, required system questions for the systems actually ranked, and
@@ -77,6 +73,10 @@ export function missingRequiredAnswers(
   return missing;
 }
 
+/**
+ * Read a common question's answer without caring where it is stored.
+ * Returns "" when unanswered.
+ */
 export function getCommonAnswer(
   formData: Partial<ApplicationFormData> | undefined,
   questionId: string

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -246,6 +246,7 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     autoRejected,
     renegedFrom,
     waitlistSystem,
+    lastEditSession,
     status: rawStatus,
     ...safeData
   } = app;

--- a/lib/utils/transitions.ts
+++ b/lib/utils/transitions.ts
@@ -45,11 +45,13 @@ interface TransitionRule {
 }
 
 export const STAFF_TRANSITIONS: Partial<Record<ApplicationStatus, TransitionRule>> = {
-  // "Revert to Submitted" — a fresh review. Also force-submits a draft, and
-  // clears a partial per-system rejection (status still submitted), which is
-  // why SUBMITTED is its own valid source.
+  // "Revert to Submitted" — a fresh review. Clears a partial per-system
+  // rejection (status still submitted), which is why SUBMITTED is its own
+  // valid source. Never from a draft: submitting is the applicant's act, and
+  // "submitting" someone's unfinished form put blank applications in front
+  // of reviewers (#127).
   [S.SUBMITTED]: {
-    from: [S.IN_PROGRESS, S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED, S.ACCEPTED],
+    from: [S.SUBMITTED, S.INTERVIEW, S.TRIAL, S.REJECTED, S.WAITLISTED, S.ACCEPTED],
     minStep: RecruitingStep.OPEN,
     stepError: "Applications can't be changed before the cycle opens.",
     roles: [UserRole.ADMIN, UserRole.TEAM_CAPTAIN_OB],
@@ -117,7 +119,9 @@ export function validateStaffTransition(input: TransitionInput): TransitionRefus
     return { status: 403, error: "Reviewers are not authorized to advance or reject applicants" };
   }
 
-  if (from === S.IN_PROGRESS && to !== S.SUBMITTED) {
+  // A draft is the applicant's alone — no staff transition starts from one,
+  // submitting it included (#127).
+  if (from === S.IN_PROGRESS) {
     return { status: 400, error: DRAFT_ACTION_ERROR };
   }
 
@@ -143,10 +147,7 @@ export function validateStaffTransition(input: TransitionInput): TransitionRefus
   }
 
   if (rule.roles && !rule.roles.includes(role)) {
-    const what = from === S.IN_PROGRESS
-      ? "submit an application on the applicant's behalf"
-      : `move an application back to ${label(to)}`;
-    return { status: 403, error: `Only admins and team captains can ${what}.` };
+    return { status: 403, error: `Only admins and team captains can move an application back to ${label(to)}.` };
   }
 
   if (to === S.REJECTED && role === UserRole.SYSTEM_LEAD && !perSystemReject) {

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -44,6 +44,8 @@ await ensureUser({ uid: "u-ag", email: "ag@utexas.edu", name: "Gated Applicant",
 const adminC = await session("admin@utexas.edu"), appC = await session("ag@utexas.edu");
 const mk = async (id, st, extra = {}) => { await db.doc(`applications/${id}`).set({ userId: "u-ag", userEmail: "ag@utexas.edu", team: "Electric", preferredSystems: ["Body", "Dynamics"], status: st, formData: { whyJoin: "x" }, createdAt: now(), updatedAt: now(), ...(st !== "in_progress" ? { submittedAt: now() } : {}), ...extra }); };
 const off = (system, st = "pending") => ({ system, status: st, createdAt: now() });
+// Complete against the emulator's default question set (5 required common answers, electric_skills, resume).
+const COMPLETE = { whyJoin: "why", relevantExperience: "exp", availability: "5551234567", graduationYear: "2029", major: "ME", resumeUrl: "https://example.test/resume.pdf", portfolioUrl: "", teamQuestions: { electric_skills: "skills" }, customAnswers: {} };
 let r = await setStep(adminC, "open"); check("step -> open", r.status === 200);
 
 // ---- #111: editable flag on the applicant payload ----
@@ -59,7 +61,7 @@ r = await api(appC, "GET", "/api/applications/ag-int");
 check("#111 single-application GET carries editable=false too", r.status === 200 && r.json?.application?.editable === false, `${r.status} ${JSON.stringify(r.json?.application?.editable)}`);
 
 // ---- a rejection made while open is masked, so it must NOT freeze the form (#121 review, finding 3) ----
-await mk("ag-rej-open", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Body", "Dynamics"] });
+await mk("ag-rej-open", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Body", "Dynamics"], formData: COMPLETE });
 await db.doc("users/u-ag").set({ applications: ["ag-draft", "ag-sub", "ag-int", "ag-rej-open"] }, { merge: true });
 r = await api(appC, "GET", "/api/applications/ag-rej-open");
 check("rejected while open: masked as submitted AND editable — indistinguishable from a peer", r.status === 200 && r.json?.application?.status === "submitted" && r.json?.application?.editable === true && !("reviewDecision" in (r.json?.application || {})) && !("rejectedBySystems" in (r.json?.application || {})), `${r.status} ${r.json?.application?.status} editable=${r.json?.application?.editable}`);
@@ -72,6 +74,24 @@ dr = await get("ag-rej-open");
 check("rejected while open: Submit from the form is accepted but never rewrites status", r.status === 200 && dr.status === "rejected" && dr.reviewDecision === "rejected" && dr.formData.whyJoin === "resubmit" && dr.preferredSystems.join("+") === "Dynamics+Body", `${err(r)} status=${dr.status}`);
 r = await api(appC, "PATCH", "/api/applications/ag-rej-open", { status: "interview" });
 check("rejected while open: still cannot set a status it doesn't own", r.status === 400 && (await get("ag-rej-open")).status === "rejected", err(r));
+
+// ---- #127: required answers are enforced server-side ----
+await mk("ag-req", "in_progress", { formData: { ...COMPLETE, resumeUrl: "" } });
+r = await api(appC, "PATCH", "/api/applications/ag-req", { status: "submitted" });
+check("#127 submit without a resume -> 400 naming Resume; still a draft", r.status === 400 && /Resume/.test(r.json?.error || "") && (await get("ag-req")).status === "in_progress", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { status: "submitted", formData: { resumeUrl: "https://example.test/resume.pdf", relevantExperience: "" } });
+check("#127 submit with a required answer blank -> 400 naming it", r.status === 400 && /experience/i.test(r.json?.error || "") && (await get("ag-req")).status === "in_progress", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { status: "submitted", formData: { resumeUrl: "https://example.test/resume.pdf" } });
+check("#127 complete submit -> 200", r.status === 200 && (await get("ag-req")).status === "submitted", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { resumeUrl: "", relevantExperience: "" } });
+dr = await get("ag-req");
+check("#127 a later save that blanks answered fields (stale tab) -> 400, answers intact", r.status === 400 && /blank/i.test(r.json?.error || "") && !!dr.formData.resumeUrl && dr.formData.relevantExperience === "exp", `${err(r)} resume=${!!dr.formData.resumeUrl}`);
+r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { whyJoin: "why (edited)" } });
+check("#127 a normal post-submit edit still saves", r.status === 200 && (await get("ag-req")).formData.whyJoin === "why (edited)", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { preferredSystems: [] });
+check("#127 emptying the ranking on a submitted application -> 400", r.status === 400 && (await get("ag-req")).preferredSystems.length === 2, err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { preferredSystems: ["Dynamics"] });
+check("#127 narrowing the ranking is still the applicant's call", r.status === 200 && (await get("ag-req")).preferredSystems.join("+") === "Dynamics", err(r));
 
 // ---- ranking stays the applicant's to change while open, even after a (masked) rejection ----
 await mk("ag-lock", "submitted", { rejectedBySystems: ["Body"] });

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -83,15 +83,34 @@ r = await api(appC, "PATCH", "/api/applications/ag-req", { status: "submitted", 
 check("#127 submit with a required answer blank -> 400 naming it", r.status === 400 && /experience/i.test(r.json?.error || "") && (await get("ag-req")).status === "in_progress", err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { status: "submitted", formData: { resumeUrl: "https://example.test/resume.pdf" } });
 check("#127 complete submit -> 200", r.status === 200 && (await get("ag-req")).status === "submitted", err(r));
-r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { resumeUrl: "", relevantExperience: "" } });
-dr = await get("ag-req");
-check("#127 a later save that blanks answered fields (stale tab) -> 400, answers intact", r.status === 400 && /blank/i.test(r.json?.error || "") && !!dr.formData.resumeUrl && dr.formData.relevantExperience === "exp", `${err(r)} resume=${!!dr.formData.resumeUrl}`);
 r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { whyJoin: "why (edited)" } });
 check("#127 a normal post-submit edit still saves", r.status === 200 && (await get("ag-req")).formData.whyJoin === "why (edited)", err(r));
-r = await api(appC, "PATCH", "/api/applications/ag-req", { preferredSystems: [] });
-check("#127 emptying the ranking on a submitted application -> 400", r.status === 400 && (await get("ag-req")).preferredSystems.length === 2, err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { preferredSystems: ["Dynamics"] });
 check("#127 narrowing the ranking is still the applicant's call", r.status === 200 && (await get("ag-req")).preferredSystems.join("+") === "Dynamics", err(r));
+
+// ---- #127: two tabs, one application — the older copy never wins ----
+const TAB_A = "tab-a-" + Date.now(), TAB_B = "tab-b-" + Date.now();
+r = await api(appC, "GET", "/api/applications/ag-req");
+let baseA = r.json?.application?.lastEditAt ?? null;
+check("#127 lastEditSession never reaches the applicant payload", r.status === 200 && !("lastEditSession" in (r.json?.application || {})));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_B, baseEditAt: baseA, formData: { whyJoin: "from tab B" } });
+check("#127 tab B saves -> 200 and the payload carries lastEditAt", r.status === 200 && !!r.json?.application?.lastEditAt, err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: baseA, formData: { whyJoin: "stale tab A", resumeUrl: "", relevantExperience: "" } });
+dr = await get("ag-req");
+check("#127 stale tab A -> 409, tab B's data intact (the Aug 28 resume wipe)", r.status === 409 && dr.formData.whyJoin === "from tab B" && !!dr.formData.resumeUrl && dr.formData.relevantExperience === "exp", `${err(r)} whyJoin=${dr.formData.whyJoin} resume=${!!dr.formData.resumeUrl}`);
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: baseA, status: "submitted" });
+check("#127 a stale tab cannot submit over the newer copy either -> 409", r.status === 409, err(r));
+r = await api(appC, "GET", "/api/applications/ag-req"); baseA = r.json.application.lastEditAt;
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: baseA, formData: { whyJoin: "tab A after reload" } });
+check("#127 tab A after reloading -> 200", r.status === 200 && (await get("ag-req")).formData.whyJoin === "tab A after reload", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, formData: { whyJoin: "tab A, stale base" } });
+check("#127 the same tab is never refused (in-flight save racing its follow-up)", r.status === 200 && (await get("ag-req")).formData.whyJoin === "tab A, stale base", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { whyJoin: "legacy client" } });
+check("#127 a client sending no session (older cached form) is accepted", r.status === 200 && (await get("ag-req")).formData.whyJoin === "legacy client", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, formData: { resumeUrl: "" } });
+check("#127 the applicant's own Remove-resume on a submitted application saves (no wedge)", r.status === 200 && (await get("ag-req")).formData.resumeUrl === "", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, preferredSystems: ["Dynamics", "Body"] });
+check("#127 adding a system to a submitted application saves before its questions are answered", r.status === 200 && (await get("ag-req")).preferredSystems.join("+") === "Dynamics+Body", err(r));
 
 // ---- ranking stays the applicant's to change while open, even after a (masked) rejection ----
 await mk("ag-lock", "submitted", { rejectedBySystems: ["Body"] });
@@ -156,6 +175,12 @@ r = await api(appC, "GET", "/api/applications/ag-pick/interview");
 check("#114 GET offers the picker during interviewing", r.status === 200 && r.json?.needsSystemSelection === true, `${r.status} ${JSON.stringify(r.json?.needsSystemSelection)}`);
 r = await api(appC, "POST", "/api/applications/ag-pick/interview", { system: "Body" });
 check("#114 selecting during interviewing works", r.status === 200 && (await get("ag-pick")).selectedInterviewSystem === "Body", err(r));
+r = await api(adminC, "POST", "/api/admin/applications/ag-pick/status", { status: "interview", systems: ["Dynamics"] });
+check("#127 re-offering a system the applicant declined by choosing another -> 400, offer stays cancelled", r.status === 400 && (await get("ag-pick")).interviewOffers.find((o) => o.system === "Dynamics")?.status === "cancelled", err(r));
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["ag-pick"], action: "interview", systems: ["Dynamics"] });
+check("#127 bulk re-offer of a declined system is refused per item", r.status === 200 && r.json?.results?.[0]?.success === false && /already chose|did not rank/i.test(r.json?.results?.[0]?.error || ""), `${r.status} ${JSON.stringify(r.json?.results)}`);
+r = await api(adminC, "POST", "/api/admin/applications/ag-pick/status", { status: "interview", systems: ["Body"] });
+check("#127 re-offering the chosen system is still fine", r.status === 200, err(r));
 await mk("ag-pick2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });
 await db.doc("users/u-ag").set({ applications: ["ag-pick2"] }, { merge: true });
 await setStep(adminC, "close_interviews");

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -105,6 +105,12 @@ r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, b
 check("#127 tab A after reloading -> 200", r.status === 200 && (await get("ag-req")).formData.whyJoin === "tab A after reload", err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, formData: { whyJoin: "tab A, stale base" } });
 check("#127 the same tab is never refused (in-flight save racing its follow-up)", r.status === 200 && (await get("ag-req")).formData.whyJoin === "tab A, stale base", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_B, baseEditAt: "garbage", formData: { whyJoin: "never" } });
+check("#127 an unparseable baseEditAt is a 400, never a false conflict; nothing written", r.status === 400 && (await get("ag-req")).formData.whyJoin === "tab A, stale base", err(r));
+r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: { _seconds: Math.floor(Date.now() / 1000) + 60, _nanoseconds: 0 }, formData: { whyJoin: "timestamp-shaped base" } });
+check("#127 a serialized-Timestamp base is understood (same tab here -> 200)", r.status === 200 && (await get("ag-req")).formData.whyJoin === "timestamp-shaped base", err(r));
+r = await api(appC, "POST", "/api/applications", { team: "Electric" });
+check("#127 the form's load path (POST create-or-return) serialises lastEditAt as a string", r.status === 201 || r.status === 200 ? (r.json?.application?.lastEditAt === undefined || typeof r.json?.application?.lastEditAt === "string") : false, `${r.status} ${typeof r.json?.application?.lastEditAt}`);
 r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { whyJoin: "legacy client" } });
 check("#127 a client sending no session (older cached form) is accepted", r.status === 200 && (await get("ag-req")).formData.whyJoin === "legacy client", err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, formData: { resumeUrl: "" } });
@@ -177,8 +183,9 @@ r = await api(appC, "POST", "/api/applications/ag-pick/interview", { system: "Bo
 check("#114 selecting during interviewing works", r.status === 200 && (await get("ag-pick")).selectedInterviewSystem === "Body", err(r));
 r = await api(adminC, "POST", "/api/admin/applications/ag-pick/status", { status: "interview", systems: ["Dynamics"] });
 check("#127 re-offering a system the applicant declined by choosing another -> 400, offer stays cancelled", r.status === 400 && (await get("ag-pick")).interviewOffers.find((o) => o.system === "Dynamics")?.status === "cancelled", err(r));
+r = await api(adminC, "PATCH", "/api/admin/applications/ag-pick", { preferredSystems: ["Body", "Dynamics"] });
 r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["ag-pick"], action: "interview", systems: ["Dynamics"] });
-check("#127 bulk re-offer of a declined system is refused per item", r.status === 200 && r.json?.results?.[0]?.success === false && /already chose|did not rank/i.test(r.json?.results?.[0]?.error || ""), `${r.status} ${JSON.stringify(r.json?.results)}`);
+check("#127 bulk re-offer of a declined system (ranking widened by an admin) is refused per item with the reason", r.status === 200 && r.json?.results?.[0]?.success === false && /already chose/i.test(r.json?.results?.[0]?.error || "") && (await get("ag-pick")).interviewOffers.find((o) => o.system === "Dynamics")?.status === "cancelled", `${r.status} ${JSON.stringify(r.json?.results)}`);
 r = await api(adminC, "POST", "/api/admin/applications/ag-pick/status", { status: "interview", systems: ["Body"] });
 check("#127 re-offering the chosen system is still fine", r.status === 200, err(r));
 await mk("ag-pick2", "interview", { reviewDecision: "advanced", interviewOffers: [off("Body"), off("Dynamics")] });

--- a/scripts/qa/applicant-gates-regress.mjs
+++ b/scripts/qa/applicant-gates-regress.mjs
@@ -109,8 +109,20 @@ r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_B, b
 check("#127 an unparseable baseEditAt is a 400, never a false conflict; nothing written", r.status === 400 && (await get("ag-req")).formData.whyJoin === "tab A, stale base", err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: { _seconds: Math.floor(Date.now() / 1000) + 60, _nanoseconds: 0 }, formData: { whyJoin: "timestamp-shaped base" } });
 check("#127 a serialized-Timestamp base is understood (same tab here -> 200)", r.status === 200 && (await get("ag-req")).formData.whyJoin === "timestamp-shaped base", err(r));
-r = await api(appC, "POST", "/api/applications", { team: "Electric" });
-check("#127 the form's load path (POST create-or-return) serialises lastEditAt as a string", r.status === 201 || r.status === 200 ? (r.json?.application?.lastEditAt === undefined || typeof r.json?.application?.lastEditAt === "string") : false, `${r.status} ${typeof r.json?.application?.lastEditAt}`);
+{
+  // A dedicated user with exactly one Electric application, stamped by a
+  // session save: the form's load path must hand back lastEditAt as a
+  // string, or the next save carries a garbage base and 409s.
+  await ensureUser({ uid: "u-ag2", email: "ag2@utexas.edu", name: "Second Applicant", role: "applicant" });
+  await db.doc("applications/ag-post").set({ userId: "u-ag2", userEmail: "ag2@utexas.edu", team: "Electric", preferredSystems: ["Body"], status: "submitted", formData: COMPLETE, createdAt: now(), updatedAt: now(), submittedAt: now() });
+  await db.doc("users/u-ag2").set({ applications: ["ag-post"] }, { merge: true });
+  const app2C = await session("ag2@utexas.edu");
+  r = await api(app2C, "PATCH", "/api/applications/ag-post", { editSession: "tab-x", baseEditAt: null, formData: { whyJoin: "stamped" } });
+  r = await api(app2C, "POST", "/api/applications", { team: "Electric" });
+  check("#127 the form's load path (POST create-or-return) serialises lastEditAt as a string", (r.status === 200 || r.status === 201) && r.json?.application?.id === "ag-post" && typeof r.json?.application?.lastEditAt === "string", `${r.status} id=${r.json?.application?.id} lastEditAt=${JSON.stringify(r.json?.application?.lastEditAt)}`);
+  r = await api(app2C, "PATCH", "/api/applications/ag-post", { editSession: "tab-y", baseEditAt: r.json?.application?.lastEditAt ?? null, formData: { whyJoin: "fresh tab after reload" } });
+  check("#127 a fresh tab that loaded through that path saves without a false conflict", r.status === 200 && (await get("ag-post")).formData.whyJoin === "fresh tab after reload", err(r));
+}
 r = await api(appC, "PATCH", "/api/applications/ag-req", { formData: { whyJoin: "legacy client" } });
 check("#127 a client sending no session (older cached form) is accepted", r.status === 200 && (await get("ag-req")).formData.whyJoin === "legacy client", err(r));
 r = await api(appC, "PATCH", "/api/applications/ag-req", { editSession: TAB_A, baseEditAt: null, formData: { resumeUrl: "" } });

--- a/scripts/qa/drafts-regress.mjs
+++ b/scripts/qa/drafts-regress.mjs
@@ -55,10 +55,12 @@ for (const [who, c, body] of [["admin", adminC, { status: "interview" }], ["lead
   r = await api(c, "POST", "/api/admin/applications/dr-1/status", body);
   check(`${who} advancing a draft to interview -> 400 draft error`, isDraftErr(r), `${r.status} ${r.json?.error}`);
 }
-for (const status of ["trial", "rejected", "waitlisted", "accepted"]) {
+for (const status of ["submitted", "trial", "rejected", "waitlisted", "accepted"]) {
   r = await api(adminC, "POST", "/api/admin/applications/dr-1/status", { status, ...(status === "accepted" ? { offer: { system: "Body", role: "Member" } } : {}) });
   check(`admin setting draft -> ${status} -> 400 draft error`, isDraftErr(r), `${r.status} ${r.json?.error}`);
 }
+r = await api(capC, "POST", "/api/admin/applications/dr-1/status", { status: "submitted" });
+check("#127 captain 'submitting' a draft -> 400 draft error", isDraftErr(r), `${r.status} ${r.json?.error}`);
 check("draft untouched after all status attempts", untouched(await get("dr-1")), S(await get("dr-1")));
 
 // ---- reject route ----
@@ -78,6 +80,8 @@ check("bulk reject by lead: draft refused", item("dr-2")?.success === false && /
 await api(adminC, "POST", "/api/admin/config/recruiting", { step: "interviewing", confirm: "interviewing" });
 r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2"], action: "trial" });
 check("bulk trial: draft refused", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || ""), `${r.status} ${JSON.stringify(item("dr-2") ?? r.json)}`);
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["dr-2", "dr-sub2"], action: "submitted" });
+check("#127 bulk 'submitted': draft refused with draft error, submitted sibling still processed", item("dr-2")?.success === false && /hasn't submitted/i.test(item("dr-2")?.error || "") && item("dr-sub2")?.success === true && (await get("dr-2")).status === "in_progress" && !(await get("dr-2")).submittedAt, `${r.status} ${JSON.stringify(r.json?.results)}`);
 check("drafts untouched after bulk attempts", untouched(await get("dr-1")) && untouched(await get("dr-2")), `${S(await get("dr-1"))} | ${S(await get("dr-2"))}`);
 
 // ---- submitted applications are unaffected ----

--- a/scripts/qa/sweeps-regress.mjs
+++ b/scripts/qa/sweeps-regress.mjs
@@ -1,0 +1,94 @@
+// Regression for #57 (close_interviews predicate + signup link), #56 (promotion
+// sweep) and #127 (drafts untouched by the cross-team sweep). Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/sweeps-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: false }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const getApp = async (id) => (await db.doc(`applications/${id}`).get()).data();
+const setStep = (c, step) => api(c, "POST", "/api/admin/config/recruiting", { step, confirm: step });
+const offer = (system, status) => ({ system, status, createdAt: now() });
+
+await ensureUser({ uid: "u-ci", email: "ci@utexas.edu", name: "Close Interviews", role: "applicant" });
+await ensureUser({ uid: "u-pr", email: "pr@utexas.edu", name: "Promoted", role: "applicant" });
+const adminC = await session("admin@utexas.edu"), ciC = await session("ci@utexas.edu");
+const base = (team, systems, extra) => ({ userId: "u-ci", userEmail: "ci@utexas.edu", team, preferredSystems: systems, status: "interview", reviewDecision: "advanced", formData: {}, createdAt: now(), updatedAt: now(), submittedAt: now(), ...extra });
+
+// ---- #57 close_interviews predicate ----
+await db.doc("interviewConfigs/electric-electronics").set({ team: "Electric", system: "Electronics", signupLink: "https://example.com/book" });
+await db.doc("applications/ci-completed-2offers").set(base("Electric", ["Electronics", "Body"], { interviewOffers: [offer("Electronics", "completed"), offer("Body", "pending")] }));
+await db.doc("applications/ci-multi-nopick").set(base("Electric", ["Electronics", "Body"], { interviewOffers: [offer("Electronics", "pending"), offer("Body", "pending")] }));
+await db.doc("applications/ci-single-pending").set(base("Electric", ["Electronics"], { interviewOffers: [offer("Electronics", "pending")] }));
+await db.doc("applications/ci-noshow").set(base("Electric", ["Electronics"], { interviewOffers: [offer("Electronics", "no_show")] }));
+await db.doc("applications/ci-solar-noshow").set(base("Solar", ["Powertrain"], { interviewOffers: [offer("Powertrain", "no_show")] }));
+await db.doc("applications/ci-solar-pending-multi").set(base("Solar", ["Powertrain", "Aerodynamics"], { interviewOffers: [offer("Powertrain", "pending"), offer("Aerodynamics", "pending")] }));
+await db.doc("applications/ci-cancelled-all").set(base("Electric", ["Electronics", "Body"], { interviewOffers: [offer("Electronics", "cancelled"), offer("Body", "cancelled")] }));
+
+let r = await setStep(adminC, "interviewing"); check("step -> interviewing", r.status === 200);
+r = await api(ciC, "GET", "/api/applications/ci-single-pending/interview");
+const linkBefore = (r.json?.offers || r.json?.interviewOffers || []).find?.((o) => o.system === "Electronics")?.signupLink;
+check("#57 signup link served while interviewing", r.status === 200 && !!linkBefore, `${r.status} keys=${Object.keys(r.json || {}).join(",")}`);
+
+r = await setStep(adminC, "close_interviews"); check("step -> close_interviews (sweep)", r.status === 200 && !r.json?.sweepError, JSON.stringify(r.json));
+const status = async (id) => (await getApp(id)).status;
+check("#57 completed interview + later 2nd offer is SPARED", (await status("ci-completed-2offers")) === "interview", await status("ci-completed-2offers"));
+check("#57 multi-offer never picked is rejected", (await status("ci-multi-nopick")) === "rejected", await status("ci-multi-nopick"));
+check("#57 single pending (ambiguous) is spared", (await status("ci-single-pending")) === "interview", await status("ci-single-pending"));
+check("#57 explicit no-show is rejected", (await status("ci-noshow")) === "rejected", await status("ci-noshow"));
+check("#57 Solar no-show is rejected too", (await status("ci-solar-noshow")) === "rejected", await status("ci-solar-noshow"));
+check("#57 Solar multi pending spared (no selection required)", (await status("ci-solar-pending-multi")) === "interview", await status("ci-solar-pending-multi"));
+check("#57 all offers cancelled is rejected", (await status("ci-cancelled-all")) === "rejected", await status("ci-cancelled-all"));
+const rej = await getApp("ci-noshow"); check("#57 rejection is the interview-stage decision (masked until release_trial)", rej.interviewDecision === "rejected", `${rej.interviewDecision}`);
+r = await api(ciC, "GET", "/api/applications/ci-single-pending/interview");
+const linkAfter = (r.json?.offers || r.json?.interviewOffers || []).find?.((o) => o.system === "Electronics")?.signupLink;
+check("#57 signup link withheld after close_interviews", r.status === 200 && !linkAfter, `${r.status} link=${linkAfter}`);
+r = await setStep(adminC, "close_interviews"); check("#57 re-run is idempotent", r.status === 200 && (await status("ci-completed-2offers")) === "interview");
+
+// ---- #56 promotion survives the day-2 sweep ----
+const pb = { userId: "u-pr", userEmail: "pr@utexas.edu", formData: {}, createdAt: now(), updatedAt: now(), submittedAt: now() };
+await db.doc("applications/pr-a").set({ ...pb, team: "Electric", preferredSystems: ["Body"], status: "committed", trialDecision: "advanced", trialDecisionDay: 1, commitment: { accepted: true, committedAt: now() } });
+await db.doc("applications/pr-b").set({ ...pb, team: "Solar", preferredSystems: ["Powertrain"], status: "accepted", trialDecision: "advanced", trialDecisionDay: 2, offer: { system: "Powertrain", role: "Member", issuedAt: now() } });
+await db.doc("applications/pr-c").set({ ...pb, team: "Combustion", preferredSystems: ["Body"], status: "trial" });
+// #127: an unfinished draft on another team is not an application to reject
+const { submittedAt: _drafted, ...pbDraft } = pb;
+await db.doc("applications/pr-d").set({ ...pbDraft, team: "Combustion", preferredSystems: [], status: "in_progress" });
+r = await setStep(adminC, "release_decisions_day1"); check("step -> day1", r.status === 200);
+r = await setStep(adminC, "release_decisions_day2"); check("step -> day2 (sweep)", r.status === 200 && !r.json?.sweepError, JSON.stringify(r.json));
+check("#56 day-2 promotion survives pass 2", (await status("pr-b")) === "accepted", await status("pr-b"));
+check("#56 other live application still cross-team rejected", (await status("pr-c")) === "rejected" && (await getApp("pr-c")).autoRejected?.reason === "committed_elsewhere", await status("pr-c"));
+check("#56 committed application untouched", (await status("pr-a")) === "committed");
+check("#127 the cross-team sweep leaves a draft alone", (await status("pr-d")) === "in_progress" && !(await getApp("pr-d")).autoRejected, `${await status("pr-d")} ${JSON.stringify((await getApp("pr-d")).autoRejected)}`);
+r = await setStep(adminC, "release_decisions_day3"); check("step -> day3 (sweep)", r.status === 200);
+check("#56 unanswered day-2 promotion expires on day 3 as before", (await status("pr-b")) === "rejected" && (await getApp("pr-b")).autoRejected?.reason === "offer_expired", `${await status("pr-b")} ${(await getApp("pr-b")).autoRejected?.reason}`);
+
+await setStep(adminC, "open");
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);

--- a/scripts/qa/transitions-regress.mjs
+++ b/scripts/qa/transitions-regress.mjs
@@ -53,6 +53,18 @@ const off = (system, st = "pending") => ({ system, status: st, createdAt: now() 
 
 // ================= step order (#116) =================
 let r = await setStep(adminC, "open", "open"); check("reset -> open (typed)", r.status === 200);
+
+// ---- #127: a cancelled interview offer must not block a re-offer for that system ----
+await mk("tr-cancel", "submitted");
+r = await status(capC, "tr-cancel", { status: "interview", systems: ["Body"] });
+check("offer Body -> pending Body offer", r.status === 200 && (await get("tr-cancel")).interviewOffers?.[0]?.status === "pending", err(r));
+r = await api(capC, "PATCH", "/api/admin/applications/tr-cancel/interview/Body", { status: "cancelled", cancelReason: "changed our mind" });
+check("cancel the Body offer", r.status === 200 && (await get("tr-cancel")).interviewOffers?.[0]?.status === "cancelled", err(r));
+r = await status(capC, "tr-cancel", { status: "interview", systems: ["Body"] });
+{
+  const tc = await get("tr-cancel");
+  check("#127 re-offering Body after a cancel resets it to pending (was a silent no-op)", r.status === 200 && tc.interviewOffers?.length === 1 && tc.interviewOffers[0].status === "pending" && !tc.interviewOffers[0].cancelReason && tc.status === "interview", `${err(r)} ${JSON.stringify(tc.interviewOffers)}`);
+}
 r = await setStep(adminC, "reviewing"); check("#116 forward one step without confirm -> 200", r.status === 200, err(r));
 r = await setStep(adminC, "reviewing"); check("#116 re-saving current step without confirm -> 200", r.status === 200, err(r));
 r = await setStep(adminC, "release_trial"); check("#116 skipping ahead without confirm -> 400 requiresConfirmation", r.status === 400 && r.json?.requiresConfirmation === true, err(r));

--- a/scripts/qa/transitions-regress.mjs
+++ b/scripts/qa/transitions-regress.mjs
@@ -65,6 +65,12 @@ r = await status(capC, "tr-cancel", { status: "interview", systems: ["Body"] });
   const tc = await get("tr-cancel");
   check("#127 re-offering Body after a cancel resets it to pending (was a silent no-op)", r.status === 200 && tc.interviewOffers?.length === 1 && tc.interviewOffers[0].status === "pending" && !tc.interviewOffers[0].cancelReason && tc.status === "interview", `${err(r)} ${JSON.stringify(tc.interviewOffers)}`);
 }
+r = await api(capC, "PATCH", "/api/admin/applications/tr-cancel/interview/Body", { status: "no_show" });
+r = await status(capC, "tr-cancel", { status: "interview", systems: ["Body"] });
+{
+  const tc = await get("tr-cancel");
+  check("#127 re-offering after a no-show resets it to pending too", r.status === 200 && tc.interviewOffers?.length === 1 && tc.interviewOffers[0].status === "pending", `${err(r)} ${JSON.stringify(tc.interviewOffers)}`);
+}
 r = await setStep(adminC, "reviewing"); check("#116 forward one step without confirm -> 200", r.status === 200, err(r));
 r = await setStep(adminC, "reviewing"); check("#116 re-saving current step without confirm -> 200", r.status === 200, err(r));
 r = await setStep(adminC, "release_trial"); check("#116 skipping ahead without confirm -> 400 requiresConfirmation", r.status === 400 && r.json?.requiresConfirmation === true, err(r));


### PR DESCRIPTION
Closes #127. Hotfix for two holes found while investigating five resume-less submissions from the night of Aug 28.

## What was wrong

**Staff could submit an applicant's draft.** #120's transition table listed `in_progress` as a valid source for "Revert to Submitted" (my call, and a wrong one — the comment even said "also force-submits a draft"), and the draft guard exempted that target. Admins and captains could do it from the status route or in bulk, and `revertToSubmitted` stamps `submittedAt` when absent. Two completely blank applications with zero ranked systems reached the review queue this way — the applicant route has refused a zero-ranking submit since Aug 25, so nothing else produces them. Still reachable during `reviewing` until this lands.

**Required answers were only enforced in the browser.** The server checked word limits and ≥1 ranked system on submit, nothing else, and accepted any save to an already-submitted application. Autosave sends the whole form, so a second tab holding an older copy could overwrite a submitted application's resume and answers with blanks. One applicant's Electric application lost its resume and "relevant experience" this way and was then rejected.

**A cancelled interview offer could never be re-issued.** `addMultipleInterviewOffers` skipped any system that already had an offer entry, cancelled ones included, so a lead who cancelled their own offer and then re-advanced got a 200 and no change — the application sat at `interview` with no live offer. Caught tonight on a real application by the audit log (advance → cancel → advance, 16 seconds, nothing to show for it) and reported by the lead.

## What changes

- **Re-advancing a system whose offer was cancelled resets it to `pending`** (fresh `createdAt`, cancel reason dropped). Pending, completed and no-show offers are left alone.
- **Drafts are never a valid source for any staff transition**, `submitted` included: the table entry, the guard in `validateStaffTransition` (now unconditional), the bulk route's per-item check, and a belt-and-braces throw inside `revertToSubmitted`. Reverting a *submitted-or-later* application still works exactly as before.
- **`missingRequiredAnswers()`** in `lib/utils/formAnswers.ts` — the form's Submit check, server-side: resume (always), required common/team questions, required system questions for the systems actually ranked, ≥1 ranked system.
- The applicant route applies it **on submit**: everything must be present, and the 400 lists what's missing in the form's own wording. The form now shows that message (and any other server reason) inline instead of a fixed "Failed to submit" — the same inline notice also carries the client-side required/word-limit messages, which the early-return added in #121 had been sending to the full-page error screen.
- **Two-tab conflict detection** replaces the first draft's "don't blank answered fields" guard (which, as review showed, could not tell a stale tab from the applicant removing a resume or adding a system, and then wedged every later autosave). The form identifies its tab (`editSession`) and the version it last saw (`baseEditAt`); the route stamps `lastEditSession` / `lastEditAt` on every applicant save and refuses with **409** only a save from a *different* tab made after another tab saved. The same tab is never refused; a client sending no session (older cached form) is accepted as before. On 409 the form reloads the server's copy and says so — nothing is overwritten. Submit carries the session too. `lastEditSession` never reaches the applicant payload.
- Re-advancing a system the applicant declined by choosing another is refused with a message (status route, audited; bulk per item) instead of producing an unbookable pending offer.

## Verification

- `scripts/qa/drafts-regress.mjs` — **23 checks** (+3): admin and captain "submitted" on a draft → draft error; bulk "submitted" with a draft and a submitted sibling → draft refused, sibling processed, draft still `in_progress` with no `submittedAt`.
- Second review round (Opus, standing in): the create-or-return load path now converts `lastEditAt` like every other mapper (it was handing the form a raw Timestamp, which would have 409'd a returning applicant's first save); a malformed `baseEditAt` is a 400, never a conflict; submit aborts if the pre-submit save didn't land; a submitted application the applicant has since made incomplete shows an inline warning listing what's missing (post-submit edits stay theirs — the backstop is for submission only, stated in the route); `no_show` offers are re-offerable like `cancelled`; every side effect of an interview offer runs on the offerable systems only; the cross-team decision sweep leaves drafts alone; the conflict notice clears on the next successful save.
- `scripts/qa/sweeps-regress.mjs` — **21 checks**, now committed (+1: the sweep leaves a draft alone).
- `scripts/qa/applicant-gates-regress.mjs` — **54 checks** (+21): submit without a resume → 400 naming Resume; submit with a required answer blank → 400 naming it; complete submit → 200; normal post-submit edit and narrowing the ranking → 200; two tabs: B saves, stale A → 409 with B's resume and answers intact (the Aug 28 shape), stale A submit → 409, A after reload → 200, same tab with a stale base → 200, no-session client → 200, Remove-resume → 200, adding a system → 200; `lastEditSession` absent from the payload; re-offering a declined system → 400 (status) and refused per item (bulk), re-offering the chosen system → 200.
- `scripts/qa/transitions-regress.mjs` — **61 checks** (+4): offer → cancel → re-offer leaves one pending offer for that system with the cancel reason gone and the application at `interview`; the same after a no-show.
- All three new groups fail against `main` (the drafts run there is instructive: the first "submitted" on a draft returns 200, after which the "draft" is a real submitted application staff can reject), pass on this branch.
- Everything else unchanged: rejection, users, staff-status, audit, bulk, sweeps, stats.
- `npx tsc --noEmit` and `npm run build` clean.

## Migration / data

None in this PR. The five affected applications are being handled with team management (two blank drafts to revert, three that need a resume attached).
