### PR TITLE
fix: bulk actions over 100 sent in batches; show the server reason

### DIFF
--- a/app/admin/applications/_components/ApplicationsContext.tsx
+++ b/app/admin/applications/_components/ApplicationsContext.tsx
@@ -26,7 +26,13 @@ interface BulkActionResult {
 interface BulkActionResponse {
   results: BulkActionResult[];
   summary: { total: number; success: number; failed: number };
+  /** Set when a batch was refused or died; `results` then covers only the batches that ran. */
+  error?: string;
 }
+
+// The bulk route caps one request at 100 applications (it has to finish
+// inside the function's time limit); larger selections go out in batches.
+const BULK_BATCH = 100;
 
 interface ApplicationsContextType {
   applications: ApplicationWithUser[]; // This will now be the FILTERED and SORTED list for the UI
@@ -206,12 +212,11 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
     setRefetching(false);
   }, [fetchAllApps]);
 
-  // The route caps one request at 100 applications (it has to finish inside
-  // the function's time limit), so a larger selection goes out as sequential
-  // batches and the summaries are merged. A batch that fails stops the run;
-  // the error says how many were already processed, and the list refreshes
-  // either way so it reflects what actually went through.
-  const BULK_BATCH = 100;
+  // Sends the selection as sequential batches of BULK_BATCH and merges the
+  // per-application results. A batch that is refused or dies stops the run
+  // and is reported in `error` rather than thrown, so the caller still gets
+  // every result that landed and can deselect exactly those. The list
+  // refreshes either way so it reflects what actually went through.
   const bulkUpdateStatus = useCallback(async (ids: string[], action: BulkAction, systems?: string[]): Promise<BulkActionResponse> => {
     const merged: BulkActionResponse = { results: [], summary: { total: ids.length, success: 0, failed: 0 } };
     try {
@@ -224,23 +229,22 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
         });
         if (!res.ok) {
           const errData = await res.json().catch(() => ({}));
-          const done = merged.summary.success + merged.summary.failed;
-          throw new Error(
-            `${errData.error || 'Bulk action failed'}${done > 0 ? ` — ${done} of ${ids.length} were processed before the error` : ''}`
-          );
+          merged.error = errData.error || `Bulk action failed (HTTP ${res.status})`;
+          break;
         }
         const data: BulkActionResponse = await res.json();
         merged.results.push(...(data.results || []));
         merged.summary.success += data.summary?.success ?? 0;
         merged.summary.failed += data.summary?.failed ?? 0;
       }
-      return merged;
     } catch (err) {
       console.error('Bulk action failed', err);
-      throw err;
+      merged.error = err instanceof Error && err.message ? err.message : 'Bulk action failed';
     } finally {
-      await refreshApplications();
+      // Never let a refresh failure hide the bulk outcome.
+      await refreshApplications().catch(() => {});
     }
+    return merged;
   }, [refreshApplications]);
 
   // Client-side search and sort

--- a/app/admin/applications/_components/ApplicationsContext.tsx
+++ b/app/admin/applications/_components/ApplicationsContext.tsx
@@ -206,24 +206,40 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
     setRefetching(false);
   }, [fetchAllApps]);
 
+  // The route caps one request at 100 applications (it has to finish inside
+  // the function's time limit), so a larger selection goes out as sequential
+  // batches and the summaries are merged. A batch that fails stops the run;
+  // the error says how many were already processed, and the list refreshes
+  // either way so it reflects what actually went through.
+  const BULK_BATCH = 100;
   const bulkUpdateStatus = useCallback(async (ids: string[], action: BulkAction, systems?: string[]): Promise<BulkActionResponse> => {
+    const merged: BulkActionResponse = { results: [], summary: { total: ids.length, success: 0, failed: 0 } };
     try {
-      const res = await fetch('/api/admin/applications/bulk-status', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ applicationIds: ids, action, systems }),
-      });
-      if (!res.ok) {
-        const errData = await res.json().catch(() => ({}));
-        throw new Error(errData.error || 'Bulk action failed');
+      for (let i = 0; i < ids.length; i += BULK_BATCH) {
+        const batch = ids.slice(i, i + BULK_BATCH);
+        const res = await fetch('/api/admin/applications/bulk-status', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ applicationIds: batch, action, systems }),
+        });
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          const done = merged.summary.success + merged.summary.failed;
+          throw new Error(
+            `${errData.error || 'Bulk action failed'}${done > 0 ? ` — ${done} of ${ids.length} were processed before the error` : ''}`
+          );
+        }
+        const data: BulkActionResponse = await res.json();
+        merged.results.push(...(data.results || []));
+        merged.summary.success += data.summary?.success ?? 0;
+        merged.summary.failed += data.summary?.failed ?? 0;
       }
-      const data: BulkActionResponse = await res.json();
-      // Refresh the list after bulk action
-      await refreshApplications();
-      return data;
+      return merged;
     } catch (err) {
       console.error('Bulk action failed', err);
       throw err;
+    } finally {
+      await refreshApplications();
     }
   }, [refreshApplications]);
 

--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo, Fragment } from "react";
+import React, { useState, useMemo, Fragment, useRef, useEffect } from "react";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { UserRole } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
@@ -102,7 +102,11 @@ export default function FullScreenListView(props: Props) {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkProcessing, setBulkProcessing] = useState(false);
-  const [bulkResult, setBulkResult] = useState<{ success: number; failed: number; error?: string } | null>(null);
+  const [bulkResult, setBulkResult] = useState<{ success: number; failed: number; notAttempted?: number; error?: string } | null>(null);
+  // One dismiss timer at a time: a second run must not have its banner
+  // cleared by the first run's timer, and nothing fires after unmount.
+  const bulkResultTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (bulkResultTimer.current) clearTimeout(bulkResultTimer.current); }, []);
   const [confirmAction, setConfirmAction] = useState<BulkAction | null>(null);
   const [groupByUser, setGroupByUser] = useState(false);
   const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
@@ -185,15 +189,24 @@ export default function FullScreenListView(props: Props) {
         currentUser?.role === UserRole.SYSTEM_LEAD && currentUser.memberProfile?.system
           ? [currentUser.memberProfile.system]
           : undefined;
-      const res = await bulkUpdateStatus(Array.from(selectedIds), action, systems);
-      setBulkResult(res.summary);
-      setSelectedIds(new Set());
+      const ids = Array.from(selectedIds);
+      const res = await bulkUpdateStatus(ids, action, systems);
+      if (res.error) {
+        // A batch was refused or died. Everything that ran is in `results`:
+        // deselect those so a retry covers only what was never attempted.
+        const attempted = new Set((res.results as { id: string }[]).map((r) => r.id));
+        setBulkResult({ success: res.summary.success, failed: res.summary.failed, notAttempted: ids.filter((id) => !attempted.has(id)).length, error: res.error });
+        setSelectedIds(new Set(ids.filter((id) => !attempted.has(id))));
+      } else {
+        setBulkResult(res.summary);
+        setSelectedIds(new Set());
+      }
     } catch (err) {
-      // The request itself was refused or died: say why, not just "failed".
-      setBulkResult({ success: 0, failed: selectedIds.size, error: err instanceof Error ? err.message : 'Bulk action failed' });
+      setBulkResult({ success: 0, failed: 0, notAttempted: selectedIds.size, error: err instanceof Error && err.message ? err.message : 'Bulk action failed' });
     } finally {
       setBulkProcessing(false);
-      setTimeout(() => setBulkResult(null), 8000);
+      if (bulkResultTimer.current) clearTimeout(bulkResultTimer.current);
+      bulkResultTimer.current = setTimeout(() => setBulkResult(null), 8000);
     }
   };
 
@@ -557,11 +570,11 @@ export default function FullScreenListView(props: Props) {
       {/* Result toast */}
       {bulkResult && (
         <div className="absolute bottom-20 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg font-urbanist text-[12px] font-semibold flex items-center gap-2"
-          style={{ backgroundColor: bulkResult.failed === 0 ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)', border: `1px solid ${bulkResult.failed === 0 ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.3)'}`, color: bulkResult.failed === 0 ? 'rgba(34,197,94,0.9)' : 'rgba(239,68,68,0.9)' }}>
-          {bulkResult.failed === 0
-            ? <><Check className="h-3.5 w-3.5" /> {bulkResult.success} updated successfully</>
-            : bulkResult.error
-              ? <><AlertCircle className="h-3.5 w-3.5" /> {bulkResult.error}</>
+          style={{ backgroundColor: !bulkResult.error && bulkResult.failed === 0 ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)', border: `1px solid ${!bulkResult.error && bulkResult.failed === 0 ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.3)'}`, color: !bulkResult.error && bulkResult.failed === 0 ? 'rgba(34,197,94,0.9)' : 'rgba(239,68,68,0.9)' }}>
+          {bulkResult.error
+            ? <><AlertCircle className="h-3.5 w-3.5" /> Stopped: {bulkResult.error} — {bulkResult.success} done, {bulkResult.failed} refused, {bulkResult.notAttempted ?? 0} not attempted (still selected)</>
+            : bulkResult.failed === 0
+              ? <><Check className="h-3.5 w-3.5" /> {bulkResult.success} updated successfully</>
               : <><AlertCircle className="h-3.5 w-3.5" /> {bulkResult.success} succeeded, {bulkResult.failed} failed</>}
         </div>
       )}

--- a/app/admin/applications/_components/FullScreenListView.tsx
+++ b/app/admin/applications/_components/FullScreenListView.tsx
@@ -102,7 +102,7 @@ export default function FullScreenListView(props: Props) {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkProcessing, setBulkProcessing] = useState(false);
-  const [bulkResult, setBulkResult] = useState<{ success: number; failed: number } | null>(null);
+  const [bulkResult, setBulkResult] = useState<{ success: number; failed: number; error?: string } | null>(null);
   const [confirmAction, setConfirmAction] = useState<BulkAction | null>(null);
   const [groupByUser, setGroupByUser] = useState(false);
   const [expandedUsers, setExpandedUsers] = useState<Set<string>>(new Set());
@@ -188,11 +188,12 @@ export default function FullScreenListView(props: Props) {
       const res = await bulkUpdateStatus(Array.from(selectedIds), action, systems);
       setBulkResult(res.summary);
       setSelectedIds(new Set());
-    } catch {
-      setBulkResult({ success: 0, failed: selectedIds.size });
+    } catch (err) {
+      // The request itself was refused or died: say why, not just "failed".
+      setBulkResult({ success: 0, failed: selectedIds.size, error: err instanceof Error ? err.message : 'Bulk action failed' });
     } finally {
       setBulkProcessing(false);
-      setTimeout(() => setBulkResult(null), 4000);
+      setTimeout(() => setBulkResult(null), 8000);
     }
   };
 
@@ -559,7 +560,9 @@ export default function FullScreenListView(props: Props) {
           style={{ backgroundColor: bulkResult.failed === 0 ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)', border: `1px solid ${bulkResult.failed === 0 ? 'rgba(34,197,94,0.3)' : 'rgba(239,68,68,0.3)'}`, color: bulkResult.failed === 0 ? 'rgba(34,197,94,0.9)' : 'rgba(239,68,68,0.9)' }}>
           {bulkResult.failed === 0
             ? <><Check className="h-3.5 w-3.5" /> {bulkResult.success} updated successfully</>
-            : <><AlertCircle className="h-3.5 w-3.5" /> {bulkResult.success} succeeded, {bulkResult.failed} failed</>}
+            : bulkResult.error
+              ? <><AlertCircle className="h-3.5 w-3.5" /> {bulkResult.error}</>
+              : <><AlertCircle className="h-3.5 w-3.5" /> {bulkResult.success} succeeded, {bulkResult.failed} failed</>}
         </div>
       )}
     </div>


### PR DESCRIPTION
Reported tonight by an admin: selecting ~200 applications and clicking Reject showed every one of them as failed.

## What was wrong

`POST /api/admin/applications/bulk-status` refuses more than **100 ids per request** (`Maximum batch size is 100 applications` — a deliberate cap since April so the function finishes inside its time limit). The full-screen list sent all 200 in one request, got the 400, and its `catch` rendered "0 succeeded, 200 failed" with the server's reason thrown away. Nothing was written — the audit log has no bulk entries from that attempt, while other staff's ≤100 batches tonight went through.

## What changes

Client only; the server cap stays.

- `bulkUpdateStatus` (ApplicationsContext) sends a large selection as **sequential batches of 100** and merges the per-application results. A batch that is refused or dies stops the run and is returned as `error` alongside everything that landed (not thrown), and the list refreshes either way so it reflects what actually went through.
- The full-screen list uses that to be exact about a partial run: the banner reads "Stopped: <server reason> — N done, M refused, K not attempted (still selected)", and **only the applications that were never attempted stay selected**, so a retry covers just the remainder instead of re-submitting everything. Full success reads "N updated successfully" and clears the selection. One dismiss timer at a time (ref-held, cleared on a new run and on unmount), 8 s.

## Verification

- Emulator, admin, 130 seeded submitted applications: select all → Reject → confirm → "130 updated successfully"; dev log shows two requests (100 + 30), both 200; every row reads Rejected.
- `npx tsc --noEmit` and `npm run build` clean. No route changes, so the existing bulk harness (`p1-bulk`, 12/12) is unaffected.

## Migration / data

None. The admin's 200 were never touched; she can simply redo the selection once this is live.
