### PR TITLE
feat: activity feed shows an exact total and pages older entries

### DIFF
--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -25,24 +25,55 @@ export function ActivityView() {
   const [appQuery, setAppQuery] = useState("");
   const [refusedOnly, setRefusedOnly] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
-  const [truncated, setTruncated] = useState(false);
+  // Paged: the newest PAGE first, "Load older" appends. `total` is the exact
+  // count for the scope (null when the server can't count it cheaply).
+  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<{ at: string; id: string } | null>(null);
+  const [total, setTotal] = useState<number | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const PAGE = 300;
+
+  const fetchPage = useCallback(async (cursor: { at: string; id: string } | null) => {
+    const q = new URLSearchParams({ limit: String(PAGE) });
+    if (action) q.set("action", action);
+    if (cursor) { q.set("before", cursor.at); q.set("beforeId", cursor.id); }
+    const res = await fetch(`/api/admin/audit?${q}`);
+    if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || `HTTP ${res.status}`);
+    return res.json() as Promise<{ entries: AuditEntryDto[]; hasMore: boolean; nextCursor: { at: string; id: string } | null; total?: number | null }>;
+  }, [action]);
 
   const load = useCallback(async () => {
     setLoading(true); setError(null);
     try {
-      const q = new URLSearchParams({ limit: "300" });
-      if (action) q.set("action", action);
-      const res = await fetch(`/api/admin/audit?${q}`);
-      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || `HTTP ${res.status}`);
-      const data = await res.json();
-      setEntries((data.entries || []) as AuditEntryDto[]);
-      setTruncated(Boolean(data.truncated));
+      const data = await fetchPage(null);
+      setEntries(data.entries || []);
+      setHasMore(Boolean(data.hasMore));
+      setNextCursor(data.nextCursor ?? null);
+      setTotal(typeof data.total === "number" ? data.total : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
-  }, [action]);
+  }, [fetchPage]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true); setError(null);
+    try {
+      const data = await fetchPage(nextCursor);
+      setEntries((prev) => {
+        const seen = new Set(prev.map((e) => e.id));
+        return [...prev, ...(data.entries || []).filter((e) => !seen.has(e.id))];
+      });
+      setHasMore(Boolean(data.hasMore));
+      setNextCursor(data.nextCursor ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [fetchPage, nextCursor, loadingMore]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -88,11 +119,20 @@ export function ActivityView() {
           <input value={actorQuery} onChange={(e) => setActorQuery(e.target.value)} placeholder="Filter by staff name / email" className="h-8 px-2.5 rounded-md text-[12px] bg-white/5 border border-white/10 text-white/80 placeholder:text-white/30 w-56" />
           <input value={appQuery} onChange={(e) => setAppQuery(e.target.value)} placeholder="Application or user id" className="h-8 px-2.5 rounded-md text-[12px] bg-white/5 border border-white/10 text-white/80 placeholder:text-white/30 w-48" />
           <label className="inline-flex items-center gap-1.5 text-[12px] text-white/60 select-none"><input type="checkbox" checked={refusedOnly} onChange={(e) => setRefusedOnly(e.target.checked)} /> Refused only</label>
-          <span className="text-[12px] text-white/30 ml-auto">{rows.length} of {entries.length} loaded</span>
+          <span className="text-[12px] text-white/30 ml-auto">
+            {rows.length} shown · {entries.length} loaded{total !== null ? ` of ${total.toLocaleString()} total` : ""}
+          </span>
         </div>
 
         {error && <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-300">{error}</div>}
-        {truncated && <div className="mb-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-[12px] text-white/60">Not every event is loaded — this list holds the newest {entries.length}, and the staff / application filters only search those. Narrow with the action filter, or open a specific application for its full History.</div>}
+        {hasMore && (
+          <div className="mb-4 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-[12px] text-white/60 flex items-center gap-3 flex-wrap">
+            <span>Loaded the newest {entries.length}{total !== null ? ` of ${total.toLocaleString()}` : ""} — the staff / application filters and the CSV cover only what's loaded.</span>
+            <button type="button" onClick={loadMore} disabled={loadingMore} className="px-2.5 py-1 rounded-md text-[12px] font-semibold bg-white/10 hover:bg-white/15 border border-white/15 disabled:opacity-50">
+              {loadingMore ? "Loading…" : `Load older${total !== null ? ` (${(total - entries.length).toLocaleString()} more)` : ""}`}
+            </button>
+          </div>
+        )}
 
         <div className="rounded-xl border border-white/10 bg-white/[0.04] overflow-x-auto">
           <table className="w-full text-[13px]">

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,16 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireRoles } from "@/lib/auth/guard";
 import { UserRole } from "@/lib/models/User";
-import { listAudit, isVisibleToTeam } from "@/lib/firebase/audit";
+import { listAudit, countAudit, isVisibleToTeam } from "@/lib/firebase/audit";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/admin/audit?action=&actor=&applicationId=&limit=
+ * GET /api/admin/audit?action=&actor=&applicationId=&limit=&before=&beforeId=
  * Recent staff activity, newest first. Admins see everything; team captains
  * see entries about their own team's applications (config and user changes
  * carry no application, so those stay admin-only).
+ *
+ * Paged: the response carries `hasMore` and `nextCursor` ({at, id}); pass
+ * them back as `before` / `beforeId` for the next page. The first page also
+ * carries `total`, an exact count for the scope (null when it would need a
+ * composite index: a captain with an action filter).
  */
 export async function GET(request: NextRequest) {
   try {
@@ -23,17 +28,30 @@ export async function GET(request: NextRequest) {
       if (!team) return NextResponse.json({ error: "Team profile missing" }, { status: 403 });
       scope.team = team;
     }
-    const { entries, truncated } = await listAudit({
-      ...scope,
-      action: p.get("action") || undefined,
-      actorUid: p.get("actor") || undefined,
-      applicationId: p.get("applicationId") || undefined,
-      limit,
-    });
+    const action = p.get("action") || undefined;
+    const beforeAt = p.get("before"), beforeId = p.get("beforeId");
+    const before = beforeAt && beforeId && !Number.isNaN(new Date(beforeAt).getTime()) ? { at: new Date(beforeAt), id: beforeId } : undefined;
+    const [{ entries, truncated, hasMore, nextCursor }, total] = await Promise.all([
+      listAudit({
+        ...scope,
+        action,
+        actorUid: p.get("actor") || undefined,
+        applicationId: p.get("applicationId") || undefined,
+        limit,
+        before,
+      }),
+      before ? Promise.resolve(undefined) : countAudit({ ...scope, action }),
+    ]);
     // A captain asking for a specific application still only gets their team.
     const visible = scope.team ? entries.filter((e) => isVisibleToTeam(e, scope.team!)) : entries;
     return NextResponse.json(
-      { entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })), truncated },
+      {
+        entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })),
+        truncated,
+        hasMore,
+        nextCursor: nextCursor ? { at: nextCursor.at.toISOString(), id: nextCursor.id } : null,
+        ...(before ? {} : { total }),
+      },
       { headers: { "Cache-Control": "private, no-store" } }
     );
   } catch (error) {

--- a/lib/firebase/audit.ts
+++ b/lib/firebase/audit.ts
@@ -1,4 +1,4 @@
-import { FieldValue } from "firebase-admin/firestore";
+import { FieldValue, FieldPath } from "firebase-admin/firestore";
 import { adminDb } from "./admin";
 import { getUser } from "./users";
 import { logger } from "@/lib/logger";
@@ -160,6 +160,38 @@ export interface ListAuditOptions {
   /** Restrict to entries about this team's applications (captains). Entries with no application are excluded. */
   team?: string;
   limit?: number;
+  /** Feed paging: continue after this entry (its `at` and id), newest first. */
+  before?: { at: Date; id: string };
+}
+
+export interface AuditPage {
+  entries: AuditEntry[];
+  /** More matched than returned — kept for older callers; same as `hasMore`. */
+  truncated: boolean;
+  hasMore: boolean;
+  /** Pass back as `before` to get the next page. */
+  nextCursor?: { at: Date; id: string };
+}
+
+/**
+ * Exact total for the feed's scope, from a count aggregation — no documents
+ * read. Admins: everything, or one action. Captains: their team's application
+ * entries plus CSV exports that included the team (two single-field counts).
+ * A captain *and* an action filter would need a composite index, so that
+ * combination returns null and the UI says so.
+ */
+export async function countAudit(opts: { action?: string; team?: string } = {}): Promise<number | null> {
+  const col = adminDb.collection(AUDIT_COLLECTION);
+  if (opts.team) {
+    if (opts.action) return null;
+    const [own, exports] = await Promise.all([
+      col.where("applicantTeam", "==", opts.team).count().get(),
+      col.where("after.teams", "array-contains", opts.team).count().get(),
+    ]);
+    return own.data().count + exports.data().count;
+  }
+  const q = opts.action ? col.where("action", "==", opts.action) : col;
+  return (await q.count().get()).data().count;
 }
 
 /**
@@ -170,18 +202,22 @@ export interface ListAuditOptions {
  * matched than `limit` — the UI filters client-side over what it received,
  * and a filter over a silently truncated set looks like "nothing happened".
  */
-export async function listAudit(opts: ListAuditOptions = {}): Promise<{ entries: AuditEntry[]; truncated: boolean }> {
+export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditPage> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
   let docs;
-  let truncated = false;
   if (opts.applicationId) {
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).limit(AUDIT_FEED_WINDOW).get()).docs;
   } else if (opts.actorUid) {
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).limit(AUDIT_FEED_WINDOW).get()).docs;
   } else {
-    docs = (await adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").limit(AUDIT_FEED_WINDOW).get()).docs;
+    // Ordered by (at, id) so a cursor is exact even where a bulk write gave
+    // many entries the same timestamp; the document-id tiebreak needs no
+    // composite index.
+    let q = adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").orderBy(FieldPath.documentId(), "desc");
+    if (opts.before) q = q.startAfter(opts.before.at, opts.before.id);
+    docs = (await q.limit(AUDIT_FEED_WINDOW).get()).docs;
   }
-  truncated = docs.length >= AUDIT_FEED_WINDOW;
+  const windowFull = docs.length >= AUDIT_FEED_WINDOW;
   let entries: AuditEntry[] = docs.map((d) => {
     const data = d.data();
     return { ...(data as Omit<AuditEntry, "id" | "at">), id: d.id, at: data.at?.toDate?.() ?? new Date(0) } as AuditEntry;
@@ -189,7 +225,20 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<{ entries:
   if (opts.action) entries = entries.filter((e) => e.action === opts.action);
   if (opts.actorUid) entries = entries.filter((e) => e.actor?.uid === opts.actorUid);
   if (opts.team) entries = entries.filter((e) => isVisibleToTeam(e, opts.team!));
-  entries.sort((a, b) => b.at.getTime() - a.at.getTime());
-  if (entries.length > limit) truncated = true;
-  return { entries: entries.slice(0, limit), truncated };
+  if (!opts.before) entries.sort((a, b) => b.at.getTime() - a.at.getTime());
+  const page = entries.slice(0, limit);
+  // More to load when the window held more matches than returned, or the
+  // window itself was full (older entries exist beyond it). The cursor is the
+  // last entry returned, or — when the page ran out before the window did —
+  // the last raw document examined, so nothing is skipped or repeated.
+  const hasMore = entries.length > limit || windowFull;
+  let nextCursor: AuditPage["nextCursor"];
+  if (entries.length > limit) {
+    const last = page[page.length - 1];
+    nextCursor = { at: last.at, id: last.id! };
+  } else if (windowFull) {
+    const lastDoc = docs[docs.length - 1];
+    nextCursor = { at: lastDoc.data().at?.toDate?.() ?? new Date(0), id: lastDoc.id };
+  }
+  return { entries: page, truncated: hasMore, hasMore, nextCursor };
 }

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -145,6 +145,30 @@ r = await api(adminC, "GET", "/api/admin/audit?limit=5");
 check("truncated is true when more matched than the requested limit", r.status === 200 && r.json.entries.length === 5 && r.json.truncated === true, `${r.json?.entries?.length} truncated=${r.json?.truncated}`);
 r = await api(adminC, "GET", "/api/admin/audit?limit=500");
 check("truncated is false when everything fit", r.status === 200 && r.json.entries.length > 5 && r.json.truncated === false, `${r.json?.entries?.length} truncated=${r.json?.truncated}`);
+
+// ---- paging + exact total ----
+{
+  const first = await api(adminC, "GET", "/api/admin/audit?limit=5");
+  const total = first.json?.total;
+  check("feed: first page carries an exact total >= what it returned", typeof total === "number" && total >= first.json.entries.length && total > 5, `total=${total} entries=${first.json?.entries?.length}`);
+  check("feed: hasMore + cursor when more exist", first.json.hasMore === true && !!first.json.nextCursor?.at && !!first.json.nextCursor?.id, JSON.stringify(first.json?.nextCursor));
+  const seen = new Set(first.json.entries.map((x) => x.id));
+  let cursor = first.json.nextCursor, pages = 1, overlap = 0, outOfOrder = 0, lastAt = first.json.entries[first.json.entries.length - 1]?.at;
+  while (cursor && pages < 200) {
+    const page = await api(adminC, "GET", `/api/admin/audit?limit=5&before=${encodeURIComponent(cursor.at)}&beforeId=${encodeURIComponent(cursor.id)}`);
+    if (page.status !== 200) { check("feed: paging request ok", false, `${page.status} ${page.json?.error}`); break; }
+    check(`feed: page ${pages + 1} carries no total (only the first page counts)`, !("total" in page.json), Object.keys(page.json).join(","));
+    for (const x of page.json.entries) { if (seen.has(x.id)) overlap++; if (lastAt && x.at > lastAt) outOfOrder++; seen.add(x.id); lastAt = x.at; }
+    cursor = page.json.hasMore ? page.json.nextCursor : null; pages++;
+  }
+  check("feed: walking every page yields exactly `total` distinct entries, no repeats, never newer than the page before", seen.size === total && overlap === 0 && outOfOrder === 0, `distinct=${seen.size} total=${total} overlap=${overlap} outOfOrder=${outOfOrder} pages=${pages}`);
+  const capAll = await api(capC, "GET", "/api/admin/audit?limit=500");
+  check("captain: total equals their visible entries (no action filter)", capAll.status === 200 && capAll.json.total === capAll.json.entries.length && capAll.json.hasMore === false, `total=${capAll.json?.total} entries=${capAll.json?.entries?.length}`);
+  const capAct = await api(capC, "GET", "/api/admin/audit?limit=500&action=application.bulk");
+  check("captain + action filter: total is null (composite index), entries still scoped and filtered", capAct.status === 200 && capAct.json.total === null && capAct.json.entries.length > 0 && capAct.json.entries.every((x) => x.action === "application.bulk" && x.applicantTeam === "Electric"), `total=${capAct.json?.total} n=${capAct.json?.entries?.length}`);
+  const adminAct = await api(adminC, "GET", "/api/admin/audit?limit=500&action=application.status");
+  check("admin + action filter: total counts only that action", adminAct.json.total === adminAct.json.entries.length && adminAct.json.entries.length > 0, `total=${adminAct.json?.total} n=${adminAct.json?.entries?.length}`);
+}
 r = await api(capSC, "GET", "/api/admin/audit?limit=100");
 check("Solar captain sees the refused bulk attempt on the Solar app (and the export that included Solar), nothing else", r.status === 200 && r.json.entries.some((x) => x.applicationId === "au-solar" && x.outcome === "refused") && r.json.entries.every((x) => x.applicantTeam === "Solar" || (x.action === "application.export" && x.after?.teams?.includes("Solar"))), `${r.status} ${JSON.stringify(r.json?.entries?.map((x) => x.applicantTeam ?? x.action))}`);
 r = await api(bodyC, "GET", "/api/admin/audit");


### PR DESCRIPTION
Follow-up to #122, from an admin: the Activity page said "300 of 300 loaded" with well over 300 entries in the table.

## What was wrong

That figure was *shown-of-loaded*, not a total: the page asked for the newest 300 and had no way to know how many exist. The only hint that more existed was a notice keyed on `truncated`, which is easy to miss and gave no number. There was no way to see anything older than the newest 300.

## What changes

- **Exact total.** The first page carries `total` from a Firestore `count()` aggregation — no documents read. Admins: everything, or one action. Captains: their team's application entries plus CSV exports that included the team (two single-field counts). A captain *with* an action filter would need a composite index, so that one case returns `null` and the UI just omits the total.
- **Cursor paging.** `GET /api/admin/audit` orders by `(at, document id)` and accepts `before` / `beforeId`; it returns `hasMore` and `nextCursor`. The id tiebreak matters: a bulk action writes its entries in one batch with one timestamp, and a timestamp-only cursor would skip or repeat the tail of that batch. Ordering on document id adds no index. Cursors are exact whether the page was cut by `limit` or by the 1,000-document window.
- **UI.** Header now reads "N shown · M loaded of T total". When more exists, a notice says how many are loaded of the total, that the staff/application filters and the CSV cover only what's loaded, and offers **Load older (K more)** which appends the next page (de-duplicated by id). Changing the action filter restarts from the newest.

`truncated` is still returned (same value as `hasMore`) for any older caller.

## Verification

- `scripts/qa/audit-regress.mjs` — **45 checks** (+9): first page carries an exact total > page size with `hasMore` and a cursor; later pages carry no total; walking every page at `limit=5` yields exactly `total` distinct entries with no repeats and never newer than the page before (bulk batches with shared timestamps included); captain's total equals their visible entries; captain + action filter → `total: null`, entries still scoped and filtered; admin + action filter → total counts only that action.
- Browser-checked in the emulator on the Activity page: total in the header, "Load older" appending, count decreasing as pages load.
- `npx tsc --noEmit` and `npm run build` clean.

## Migration / data

None. No new Firestore indexes (verified: every query is single-field or `at` + document id).
