### PR TITLE
fix: dashboard pending counts are per-system for leads (#131)

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -264,6 +264,9 @@ export default function AdminDashboardPage() {
 
               {counts && Object.keys(counts.pendingReviews.byGroup).length > 0 && (
                 <div className="space-y-2 pt-4" style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}>
+                  <p className="font-urbanist text-[10px] font-semibold tracking-widest uppercase text-white/20">
+                    By group — an application can count under more than one
+                  </p>
                   {Object.entries(counts.pendingReviews.byGroup)
                     .sort((a, b) => b[1] - a[1])
                     .map(([group, count]) => (
@@ -313,6 +316,9 @@ export default function AdminDashboardPage() {
 
               {counts && Object.keys(counts.pendingDecisions.byGroup).length > 0 && (
                 <div className="space-y-2 pt-4" style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}>
+                  <p className="font-urbanist text-[10px] font-semibold tracking-widest uppercase text-white/20">
+                    By group — an application can count under more than one
+                  </p>
                   {Object.entries(counts.pendingDecisions.byGroup)
                     .sort((a, b) => b[1] - a[1])
                     .map(([group, count]) => (

--- a/app/api/admin/dashboard/pending-count/route.ts
+++ b/app/api/admin/dashboard/pending-count/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { requireStaff } from "@/lib/auth/guard";
 import { adminDb } from "@/lib/firebase/admin";
 import { UserRole, Team } from "@/lib/models/User";
-import { ApplicationStatus } from "@/lib/models/Application";
+import { ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
 import { logger } from "@/lib/logger";
 
 
@@ -25,22 +25,28 @@ interface PendingCounts {
  * `submitted` until every ranked system has rejected, and another system's
  * offer moves it to `interview` — so for a lead or reviewer the count has to
  * be per-system, the same lens as the applicants list (#126):
- *  - review pending: still at review or interview stage, and this system has
- *    neither rejected nor extended an offer;
- *  - decision pending: this system extended an interview offer (not
- *    cancelled) and has since neither rejected nor extended a trial offer.
+ *  - review pending: the application is still in play (submitted, interview
+ *    or trial stage) and this system has neither rejected it nor extended an
+ *    offer — another system's advance does not review it for us;
+ *  - decision pending: this system's interview offer is out with no
+ *    rejection or trial offer after it, or this system's trial offer is out
+ *    and the final decision has not been made.
+ * A cancelled offer is no offer; completed and no-show offers still stand.
  */
 function systemPending(app: FirebaseFirestore.DocumentData, system: string): { review: boolean; decision: boolean } {
-  const live = (o: { system?: string; status?: string }) => o.system === system && o.status !== "cancelled";
+  const live = (o: { system?: string; status?: string }) => o.system === system && o.status !== InterviewEventStatus.CANCELLED;
   const rejected = ((app.rejectedBySystems as string[] | undefined) || []).includes(system);
   const interviewOffer = ((app.interviewOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
   const trialOffer = ((app.trialOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
-  const reviewStage = app.status === ApplicationStatus.SUBMITTED || app.status === ApplicationStatus.INTERVIEW;
-  const decisionStage = app.status === ApplicationStatus.INTERVIEW || app.status === ApplicationStatus.TRIAL;
-  return {
-    review: reviewStage && !rejected && !interviewOffer && !trialOffer,
-    decision: decisionStage && interviewOffer && !rejected && !trialOffer,
-  };
+  const S = ApplicationStatus;
+  const inPlay = app.status === S.SUBMITTED || app.status === S.INTERVIEW || app.status === S.TRIAL;
+  const review = inPlay && !rejected && !interviewOffer && !trialOffer;
+  const decision =
+    !rejected &&
+    ((app.status === S.INTERVIEW && interviewOffer && !trialOffer) ||
+      (app.status === S.TRIAL && trialOffer && !app.trialDecision) ||
+      (app.status === S.TRIAL && interviewOffer && !trialOffer));
+  return { review, decision };
 }
 
 export async function GET() {
@@ -110,6 +116,9 @@ export async function GET() {
             if (pending.review) { anyReview = true; counts.pendingReviews.byGroup[system] = (counts.pendingReviews.byGroup[system] || 0) + 1; }
             if (pending.decision) { anyDecision = true; counts.pendingDecisions.byGroup[system] = (counts.pendingDecisions.byGroup[system] || 0) + 1; }
           }
+          // A submitted application with no ranking is invisible to every lead
+          // (array-contains); the captain's total is the one place it surfaces.
+          if (systems.length === 0 && app.status === ApplicationStatus.SUBMITTED && !app.reviewDecision) anyReview = true;
           if (anyReview) counts.pendingReviews.total++;
           if (anyDecision) counts.pendingDecisions.total++;
         }

--- a/app/api/admin/dashboard/pending-count/route.ts
+++ b/app/api/admin/dashboard/pending-count/route.ts
@@ -19,6 +19,30 @@ interface PendingCounts {
   };
 }
 
+/**
+ * What one system still has to decide on an application (#131). The global
+ * status is the applicant's pipeline stage — a per-system rejection leaves it
+ * `submitted` until every ranked system has rejected, and another system's
+ * offer moves it to `interview` — so for a lead or reviewer the count has to
+ * be per-system, the same lens as the applicants list (#126):
+ *  - review pending: still at review or interview stage, and this system has
+ *    neither rejected nor extended an offer;
+ *  - decision pending: this system extended an interview offer (not
+ *    cancelled) and has since neither rejected nor extended a trial offer.
+ */
+function systemPending(app: FirebaseFirestore.DocumentData, system: string): { review: boolean; decision: boolean } {
+  const live = (o: { system?: string; status?: string }) => o.system === system && o.status !== "cancelled";
+  const rejected = ((app.rejectedBySystems as string[] | undefined) || []).includes(system);
+  const interviewOffer = ((app.interviewOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
+  const trialOffer = ((app.trialOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
+  const reviewStage = app.status === ApplicationStatus.SUBMITTED || app.status === ApplicationStatus.INTERVIEW;
+  const decisionStage = app.status === ApplicationStatus.INTERVIEW || app.status === ApplicationStatus.TRIAL;
+  return {
+    review: reviewStage && !rejected && !interviewOffer && !trialOffer,
+    decision: decisionStage && interviewOffer && !rejected && !trialOffer,
+  };
+}
+
 export async function GET() {
   try {
     const { user } = await requireStaff();
@@ -78,27 +102,16 @@ export async function GET() {
         for (const doc of teamDocs.docs) {
           const app = doc.data();
           const systems = (app.preferredSystems as string[]) || [];
-          
-          // Count pending reviews
-          if (app.status === ApplicationStatus.SUBMITTED && !app.reviewDecision) {
-            counts.pendingReviews.total++;
-            // Add to each preferred system's count
-            for (const system of systems) {
-              counts.pendingReviews.byGroup[system] = (counts.pendingReviews.byGroup[system] || 0) + 1;
-            }
+          // Per system: what each system still has to decide. The total is
+          // applications with at least one system yet to decide.
+          let anyReview = false, anyDecision = false;
+          for (const system of systems) {
+            const pending = systemPending(app, system);
+            if (pending.review) { anyReview = true; counts.pendingReviews.byGroup[system] = (counts.pendingReviews.byGroup[system] || 0) + 1; }
+            if (pending.decision) { anyDecision = true; counts.pendingDecisions.byGroup[system] = (counts.pendingDecisions.byGroup[system] || 0) + 1; }
           }
-          
-          // Count pending decisions
-          if (
-            (app.status === ApplicationStatus.INTERVIEW || app.status === ApplicationStatus.TRIAL) &&
-            app.status !== ApplicationStatus.ACCEPTED &&
-            app.status !== ApplicationStatus.REJECTED
-          ) {
-            counts.pendingDecisions.total++;
-            for (const system of systems) {
-              counts.pendingDecisions.byGroup[system] = (counts.pendingDecisions.byGroup[system] || 0) + 1;
-            }
-          }
+          if (anyReview) counts.pendingReviews.total++;
+          if (anyDecision) counts.pendingDecisions.total++;
         }
         break;
 
@@ -115,21 +128,12 @@ export async function GET() {
           .get();
         
         for (const doc of systemDocs.docs) {
-          const app = doc.data();
-          
-          // Count pending reviews
-          if (app.status === ApplicationStatus.SUBMITTED && !app.reviewDecision) {
-            counts.pendingReviews.total++;
-          }
-          
-          // Count pending decisions
-          if (
-            (app.status === ApplicationStatus.INTERVIEW || app.status === ApplicationStatus.TRIAL) &&
-            app.status !== ApplicationStatus.ACCEPTED &&
-            app.status !== ApplicationStatus.REJECTED
-          ) {
-            counts.pendingDecisions.total++;
-          }
+          // Only what THIS system still has to decide (#131): an application
+          // this system already rejected, or already offered, is not pending
+          // here even while other systems are still working on it.
+          const pending = systemPending(doc.data(), userSystem);
+          if (pending.review) counts.pendingReviews.total++;
+          if (pending.decision) counts.pendingDecisions.total++;
         }
         // For system lead/reviewer, byGroup is just their system
         counts.pendingReviews.byGroup[userSystem] = counts.pendingReviews.total;

--- a/scripts/qa/dashboard-regress.mjs
+++ b/scripts/qa/dashboard-regress.mjs
@@ -47,31 +47,39 @@ await ensureUser({ uid: "u-db-pt", email: "db.pt@utexas.edu", name: "Solar Power
 await ensureUser({ uid: "u-db-cap", email: "db.cap@utexas.edu", name: "Solar Captain", role: "team_captain_ob", memberProfile: { team: TEAM, system: "Aerodynamics" } });
 const dynC = await session("db.dyn@utexas.edu"), ptC = await session("db.pt@utexas.edu"), capC = await session("db.cap@utexas.edu"), adminC = await session("admin@utexas.edu");
 
-// Seven applications ranking Dynamics + Powertrain, in every relevant state:
-await mk("db-untouched", "submitted");                                                                   // nobody acted: pending review for both
+// Applications ranking Dynamics + Powertrain in every relevant state:
+await mk("db-untouched", "submitted");                                                                   // nobody acted: review pending for both
 await mk("db-dyn-rejected", "submitted", { rejectedBySystems: ["Dynamics"] });                            // Dynamics done, Powertrain not
-await mk("db-dyn-rejected-2", "submitted", { rejectedBySystems: ["Dynamics"] });                          // another one — makes the Dynamics count differ from the global one
-await mk("db-pt-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Powertrain")] }); // Powertrain offered; Dynamics still to review; Powertrain has a decision pending
-await mk("db-dyn-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")] }); // Dynamics interviewed, decision pending; Powertrain still to review
-await mk("db-dyn-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")], trialOffers: [off("Dynamics")] }); // Dynamics decided (trial); Powertrain: nothing to review at trial stage
+await mk("db-dyn-rejected-2", "submitted", { rejectedBySystems: ["Dynamics"] });                          // another — makes the Dynamics count differ from the global one
+await mk("db-pt-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Powertrain")] }); // Powertrain offered (decision pending); Dynamics still to review
+await mk("db-dyn-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")] }); // Dynamics interviewed (decision pending); Powertrain still to review
+await mk("db-dyn-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")], trialOffers: [off("Dynamics")] }); // Dynamics' trial offer out: Dynamics owes the final decision; Powertrain never acted, still to review
+await mk("db-dyn-cancelled", "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "cancelled"), off("Powertrain")] }); // Dynamics' offer cancelled = back to review pending for Dynamics; Powertrain decision pending
+await mk("db-dyn-noshow", "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "no_show")] }); // no-show still Dynamics' offer: decision pending; Powertrain still to review
+await mk("db-draft", "in_progress");                                                                     // drafts never count
+await mk("db-accepted", "accepted", { reviewDecision: "advanced", interviewDecision: "advanced", trialDecision: "advanced", trialDecisionDay: 1, interviewOffers: [off("Dynamics", "completed")], trialOffers: [{ ...off("Dynamics"), accepted: true }], offer: { system: "Dynamics", role: "Member", issuedAt: now() } }); // decided
 await mk("db-all-rejected", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Dynamics", "Powertrain"] }); // nothing pending anywhere
+await mk("db-noranking", "submitted", { preferredSystems: [] });                                          // invisible to leads; surfaces only in the captain total
 
 const counts = async (c) => (await api(c, "GET", "/api/admin/dashboard/pending-count")).json?.counts;
 const dyn = await counts(dynC), pt = await counts(ptC), cap = await counts(capC), adm = await counts(adminC);
 console.log("dyn", JSON.stringify(dyn), "\npt ", JSON.stringify(pt), "\ncap", JSON.stringify(cap));
 
-// Dynamics: review pending = untouched + pt-advanced (Dynamics hasn't acted) = 2 (globally-submitted-undecided would be 3); decision pending = dyn-advanced = 1
-check("#131 Dynamics lead: pending reviews count only what Dynamics has not decided (2)", dyn?.pendingReviews?.total === 2, JSON.stringify(dyn?.pendingReviews));
-check("#131 Dynamics lead: own rejections are NOT pending (they were: same applications are still globally submitted)", dyn?.pendingReviews?.total === 2 && adm?.pendingReviews?.byGroup?.[TEAM] === 3, `dyn=${dyn?.pendingReviews?.total} globalSolar=${adm?.pendingReviews?.byGroup?.[TEAM]}`);
-check("#131 Dynamics lead: pending decisions = its own live interview offers awaiting a trial/reject decision (1)", dyn?.pendingDecisions?.total === 1, JSON.stringify(dyn?.pendingDecisions));
-// Powertrain: review pending = untouched + dyn-rejected ×2 + dyn-advanced = 4; decision pending = pt-advanced = 1
-check("#131 Powertrain lead: 4 pending reviews (untouched, both Dynamics-rejected, Dynamics-advanced)", pt?.pendingReviews?.total === 4, JSON.stringify(pt?.pendingReviews));
-check("#131 Powertrain lead: 1 pending decision", pt?.pendingDecisions?.total === 1, JSON.stringify(pt?.pendingDecisions));
-// Captain: byGroup mirrors the leads; total counts applications with any system still to decide
-check("#131 captain breakdown matches each lead", cap?.pendingReviews?.byGroup?.Dynamics === 2 && cap?.pendingReviews?.byGroup?.Powertrain === 4 && cap?.pendingDecisions?.byGroup?.Dynamics === 1 && cap?.pendingDecisions?.byGroup?.Powertrain === 1, JSON.stringify(cap));
-check("#131 captain totals = applications with at least one system still to decide (5 review, 2 decision)", cap?.pendingReviews?.total === 5 && cap?.pendingDecisions?.total === 2, JSON.stringify(cap));
-// Admin keeps the global meaning: submitted with no reviewDecision (untouched + both dyn-rejected) = 3 for Solar
-check("admin by-team view unchanged: globally-submitted-undecided (3 for Solar)", adm?.pendingReviews?.byGroup?.[TEAM] === 3, JSON.stringify(adm?.pendingReviews?.byGroup));
+// Dynamics: review = untouched, pt-advanced, dyn-cancelled = 3 (globally-submitted-undecided would be 4); decision = dyn-advanced, dyn-trial, dyn-noshow = 3
+check("#131 Dynamics lead: pending reviews = only what Dynamics has not decided (3)", dyn?.pendingReviews?.total === 3, JSON.stringify(dyn?.pendingReviews));
+check("#131 Dynamics lead: own rejections are NOT pending (globally-submitted-undecided for the team is 4)", dyn?.pendingReviews?.total === 3 && adm?.pendingReviews?.byGroup?.[TEAM] === 4, `dyn=${dyn?.pendingReviews?.total} globalSolar=${adm?.pendingReviews?.byGroup?.[TEAM]}`);
+check("#131 Dynamics lead: pending decisions = live interview offer awaiting reject/trial, no-show included, and its own trial offer awaiting the final decision (3)", dyn?.pendingDecisions?.total === 3, JSON.stringify(dyn?.pendingDecisions));
+// Powertrain: review = untouched, rej, rej2, dyn-advanced, dyn-trial, dyn-noshow = 6; decision = pt-advanced, dyn-cancelled = 2
+check("#131 Powertrain lead: 6 pending reviews (untouched, both Dynamics-rejected, Dynamics-advanced, Dynamics-trial, Dynamics-no-show)", pt?.pendingReviews?.total === 6, JSON.stringify(pt?.pendingReviews));
+check("#131 Powertrain lead: 2 pending decisions", pt?.pendingDecisions?.total === 2, JSON.stringify(pt?.pendingDecisions));
+// a cancelled offer is no offer: Dynamics is review-pending on db-dyn-cancelled, not decision-pending (drop the cancelled clause and both counts move)
+check("#131 cancelled offer counts as no offer (review 3 / decision 3 for Dynamics, not 2 / 4)", dyn?.pendingReviews?.total === 3 && dyn?.pendingDecisions?.total === 3);
+// Captain: byGroup mirrors the leads; totals count applications with any system still to decide (+ the unranked one for reviews)
+check("#131 captain breakdown matches each lead", cap?.pendingReviews?.byGroup?.Dynamics === 3 && cap?.pendingReviews?.byGroup?.Powertrain === 6 && cap?.pendingDecisions?.byGroup?.Dynamics === 3 && cap?.pendingDecisions?.byGroup?.Powertrain === 2, JSON.stringify(cap));
+check("#131 captain totals = applications with at least one system still to decide, unranked submitted included (9 review, 5 decision)", cap?.pendingReviews?.total === 9 && cap?.pendingDecisions?.total === 5, JSON.stringify(cap));
+check("#131 drafts and decided applications count nowhere", !Object.values(cap?.pendingReviews?.byGroup || {}).some((v) => v > 6) && cap?.pendingDecisions?.total === 5);
+// Admin keeps the global meaning: submitted with no reviewDecision (untouched, both dyn-rejected, unranked) = 4 for Solar
+check("admin by-team view unchanged: globally-submitted-undecided (4 for Solar)", adm?.pendingReviews?.byGroup?.[TEAM] === 4, JSON.stringify(adm?.pendingReviews?.byGroup));
 
 const fails = results.filter((x) => !x).length;
 console.log(`\n${results.length - fails}/${results.length} checks passed`);

--- a/scripts/qa/dashboard-regress.mjs
+++ b/scripts/qa/dashboard-regress.mjs
@@ -1,0 +1,78 @@
+// Dashboard pending counts are per-system for leads/reviewers and for a
+// captain's breakdown (#131): a system's own rejection or offer takes an
+// application out of THAT system's count even while the application is still
+// globally submitted for other systems. Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/dashboard-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function session(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2.headers.getSetCookie().map((c) => c.split(";")[0]).join("; ");
+}
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const off = (system, st = "pending") => ({ system, status: st, createdAt: now() });
+// A team of its own so other harnesses' leftovers can't change the counts.
+const TEAM = "Solar";
+const mk = (id, st, extra = {}) => db.doc(`applications/${id}`).set({ userId: `u-db-${id}`, userEmail: `${id}@utexas.edu`, userName: `Dash ${id}`, team: TEAM, preferredSystems: ["Dynamics", "Powertrain"], status: st, formData: { whyJoin: "x" }, createdAt: now(), updatedAt: now(), submittedAt: now(), ...extra });
+
+// wipe any earlier run's Solar fixtures
+for (const d of (await db.collection("applications").where("team", "==", TEAM).get()).docs) await d.ref.delete();
+
+await ensureUser({ uid: "u-db-dyn", email: "db.dyn@utexas.edu", name: "Solar Dynamics Lead", role: "system_lead", memberProfile: { team: TEAM, system: "Dynamics" } });
+await ensureUser({ uid: "u-db-pt", email: "db.pt@utexas.edu", name: "Solar Powertrain Lead", role: "system_lead", memberProfile: { team: TEAM, system: "Powertrain" } });
+await ensureUser({ uid: "u-db-cap", email: "db.cap@utexas.edu", name: "Solar Captain", role: "team_captain_ob", memberProfile: { team: TEAM, system: "Aerodynamics" } });
+const dynC = await session("db.dyn@utexas.edu"), ptC = await session("db.pt@utexas.edu"), capC = await session("db.cap@utexas.edu"), adminC = await session("admin@utexas.edu");
+
+// Seven applications ranking Dynamics + Powertrain, in every relevant state:
+await mk("db-untouched", "submitted");                                                                   // nobody acted: pending review for both
+await mk("db-dyn-rejected", "submitted", { rejectedBySystems: ["Dynamics"] });                            // Dynamics done, Powertrain not
+await mk("db-dyn-rejected-2", "submitted", { rejectedBySystems: ["Dynamics"] });                          // another one — makes the Dynamics count differ from the global one
+await mk("db-pt-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Powertrain")] }); // Powertrain offered; Dynamics still to review; Powertrain has a decision pending
+await mk("db-dyn-advanced", "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")] }); // Dynamics interviewed, decision pending; Powertrain still to review
+await mk("db-dyn-trial", "trial", { reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")], trialOffers: [off("Dynamics")] }); // Dynamics decided (trial); Powertrain: nothing to review at trial stage
+await mk("db-all-rejected", "rejected", { reviewDecision: "rejected", rejectedBySystems: ["Dynamics", "Powertrain"] }); // nothing pending anywhere
+
+const counts = async (c) => (await api(c, "GET", "/api/admin/dashboard/pending-count")).json?.counts;
+const dyn = await counts(dynC), pt = await counts(ptC), cap = await counts(capC), adm = await counts(adminC);
+console.log("dyn", JSON.stringify(dyn), "\npt ", JSON.stringify(pt), "\ncap", JSON.stringify(cap));
+
+// Dynamics: review pending = untouched + pt-advanced (Dynamics hasn't acted) = 2 (globally-submitted-undecided would be 3); decision pending = dyn-advanced = 1
+check("#131 Dynamics lead: pending reviews count only what Dynamics has not decided (2)", dyn?.pendingReviews?.total === 2, JSON.stringify(dyn?.pendingReviews));
+check("#131 Dynamics lead: own rejections are NOT pending (they were: same applications are still globally submitted)", dyn?.pendingReviews?.total === 2 && adm?.pendingReviews?.byGroup?.[TEAM] === 3, `dyn=${dyn?.pendingReviews?.total} globalSolar=${adm?.pendingReviews?.byGroup?.[TEAM]}`);
+check("#131 Dynamics lead: pending decisions = its own live interview offers awaiting a trial/reject decision (1)", dyn?.pendingDecisions?.total === 1, JSON.stringify(dyn?.pendingDecisions));
+// Powertrain: review pending = untouched + dyn-rejected ×2 + dyn-advanced = 4; decision pending = pt-advanced = 1
+check("#131 Powertrain lead: 4 pending reviews (untouched, both Dynamics-rejected, Dynamics-advanced)", pt?.pendingReviews?.total === 4, JSON.stringify(pt?.pendingReviews));
+check("#131 Powertrain lead: 1 pending decision", pt?.pendingDecisions?.total === 1, JSON.stringify(pt?.pendingDecisions));
+// Captain: byGroup mirrors the leads; total counts applications with any system still to decide
+check("#131 captain breakdown matches each lead", cap?.pendingReviews?.byGroup?.Dynamics === 2 && cap?.pendingReviews?.byGroup?.Powertrain === 4 && cap?.pendingDecisions?.byGroup?.Dynamics === 1 && cap?.pendingDecisions?.byGroup?.Powertrain === 1, JSON.stringify(cap));
+check("#131 captain totals = applications with at least one system still to decide (5 review, 2 decision)", cap?.pendingReviews?.total === 5 && cap?.pendingDecisions?.total === 2, JSON.stringify(cap));
+// Admin keeps the global meaning: submitted with no reviewDecision (untouched + both dyn-rejected) = 3 for Solar
+check("admin by-team view unchanged: globally-submitted-undecided (3 for Solar)", adm?.pendingReviews?.byGroup?.[TEAM] === 3, JSON.stringify(adm?.pendingReviews?.byGroup));
+
+const fails = results.filter((x) => !x).length;
+console.log(`\n${results.length - fails}/${results.length} checks passed`);
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Closes #131. Reported by an Electric Dynamics lead: ~85 "Pending Reviews" on the admin dashboard after Dynamics had finished accepting and rejecting.

## What was wrong

`GET /api/admin/dashboard/pending-count` counted, for a lead or reviewer, every application that ranks their system and is still globally `submitted` with no `reviewDecision`. Neither changes when one system rejects — the application stays `submitted` until *every* ranked system has rejected, or one advances — so a lead's own rejections stayed in their count, and an application another system advanced dropped out of it even though this lead had never looked at it. "Pending Decisions" (global `interview`/`trial`) had the same shape. Same family as #126: the global status is the applicant's stage, not one system's to-do list.

## What changes

Per-system semantics, the same lens the applicants list now uses:

- **Review pending** for system S: the application is still at review or interview stage and S has neither rejected it nor extended an offer.
- **Decision pending** for S: S's interview offer is out with no rejection or trial offer after it; or S's own trial offer is out and the final accept/waitlist/reject decision is unset; or, at trial stage, S interviewed but never trial-offered. A cancelled offer is no offer; completed and no-show offers still stand.
- Review pending covers the trial stage too — an application another system took to trial that S never opened is still S's to review, exactly as the applicants list badges it.
- A submitted application with an empty ranking (invisible to every lead) still counts in the captain's review total. Both dashboard cards label the breakdown "By group — an application can count under more than one".

Leads and reviewers get exactly their system's numbers. A captain's per-system breakdown uses the same rule, and their totals count applications with at least one system still to decide. Admins keep the by-team global meaning (submitted with no decision from anyone), which is the right question at their level.

## Verification

- `scripts/qa/dashboard-regress.mjs` (new, **10 checks**): twelve applications ranking Dynamics + Powertrain in every state (untouched; two Dynamics-rejected; Powertrain advanced; Dynamics interviewed; Dynamics at trial; Dynamics offer cancelled; Dynamics no-show; a draft; an accepted; fully rejected; submitted with no ranking). Dynamics sees 3 reviews / 3 decisions, Powertrain 6 / 2, the captain's breakdown matches both leads with totals 9 / 5, admin's by-team count (4, globally submitted and undecided) is unchanged. Deleting the cancelled-offer clause or the trial arm fails the suite. Against `main`, 4 of 10 pass: the Dynamics lead sees their own rejections counted — the report.
- Opus review pass (7 findings) addressed in the second commit: trial decisions were credited to the wrong system, review-pending stopped one stage short of the applicants-list lens, harness couldn't distinguish the fix, empty-ranking applications vanished from the captain's total, unlabelled breakdown, string literal for the offer status.
- `npx tsc --noEmit` and `npm run build` clean. No index changes (query shapes untouched).

## Migration / data

None.
