### PR TITLE
fix: activity paging cursor keeps the raw timestamp; exact captain totals

### DIFF
--- a/app/admin/activity/ActivityView.tsx
+++ b/app/admin/activity/ActivityView.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { downloadCsv } from "@/lib/utils/downloadFile";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import clsx from "clsx";
 import { Download, Loader2, RefreshCw } from "lucide-react";
 import { AUDIT_ACTION_LABELS, type AuditAction, type AuditEntryDto } from "@/lib/models/Audit";
+
+const PAGE = 300;
+type Cursor = { seconds: number; nanos: number; id: string };
 
 const fmtWhen = (iso: string) =>
   new Date(iso).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
@@ -28,40 +31,47 @@ export function ActivityView() {
   // Paged: the newest PAGE first, "Load older" appends. `total` is the exact
   // count for the scope (null when the server can't count it cheaply).
   const [hasMore, setHasMore] = useState(false);
-  const [nextCursor, setNextCursor] = useState<{ at: string; id: string } | null>(null);
+  const [nextCursor, setNextCursor] = useState<Cursor | null>(null);
   const [total, setTotal] = useState<number | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
-  const PAGE = 300;
+  // Every (re)load bumps this; a "Load older" that started under an earlier
+  // filter must not append its rows, or its cursor, to the new list.
+  const generation = useRef(0);
 
-  const fetchPage = useCallback(async (cursor: { at: string; id: string } | null) => {
+  const fetchPage = useCallback(async (cursor: Cursor | null) => {
     const q = new URLSearchParams({ limit: String(PAGE) });
     if (action) q.set("action", action);
-    if (cursor) { q.set("before", cursor.at); q.set("beforeId", cursor.id); }
+    if (cursor) { q.set("beforeSeconds", String(cursor.seconds)); q.set("beforeNanos", String(cursor.nanos)); q.set("beforeId", cursor.id); }
     const res = await fetch(`/api/admin/audit?${q}`);
     if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || `HTTP ${res.status}`);
-    return res.json() as Promise<{ entries: AuditEntryDto[]; hasMore: boolean; nextCursor: { at: string; id: string } | null; total?: number | null }>;
+    return res.json() as Promise<{ entries: AuditEntryDto[]; hasMore: boolean; nextCursor: Cursor | null; total?: number | null }>;
   }, [action]);
 
   const load = useCallback(async () => {
+    const gen = ++generation.current;
     setLoading(true); setError(null);
+    setEntries([]); setHasMore(false); setNextCursor(null); setTotal(null);
     try {
       const data = await fetchPage(null);
+      if (gen !== generation.current) return;
       setEntries(data.entries || []);
       setHasMore(Boolean(data.hasMore));
       setNextCursor(data.nextCursor ?? null);
       setTotal(typeof data.total === "number" ? data.total : null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (gen === generation.current) setError(e instanceof Error ? e.message : String(e));
     } finally {
-      setLoading(false);
+      if (gen === generation.current) setLoading(false);
     }
   }, [fetchPage]);
 
   const loadMore = useCallback(async () => {
     if (!nextCursor || loadingMore) return;
+    const gen = generation.current;
     setLoadingMore(true); setError(null);
     try {
       const data = await fetchPage(nextCursor);
+      if (gen !== generation.current) return;
       setEntries((prev) => {
         const seen = new Set(prev.map((e) => e.id));
         return [...prev, ...(data.entries || []).filter((e) => !seen.has(e.id))];
@@ -69,7 +79,7 @@ export function ActivityView() {
       setHasMore(Boolean(data.hasMore));
       setNextCursor(data.nextCursor ?? null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      if (gen === generation.current) setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoadingMore(false);
     }

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -2,20 +2,24 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireRoles } from "@/lib/auth/guard";
 import { UserRole } from "@/lib/models/User";
 import { listAudit, countAudit, isVisibleToTeam } from "@/lib/firebase/audit";
+import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/admin/audit?action=&actor=&applicationId=&limit=&before=&beforeId=
+ * GET /api/admin/audit?action=&actor=&applicationId=&limit=&beforeSeconds=&beforeNanos=&beforeId=
  * Recent staff activity, newest first. Admins see everything; team captains
  * see entries about their own team's applications (config and user changes
  * carry no application, so those stay admin-only).
  *
- * Paged: the response carries `hasMore` and `nextCursor` ({at, id}); pass
- * them back as `before` / `beforeId` for the next page. The first page also
- * carries `total`, an exact count for the scope (null when it would need a
- * composite index: a captain with an action filter).
+ * Paged: the response carries `hasMore` and `nextCursor` ({seconds, nanos,
+ * id} — the raw timestamp, never an ISO string: milliseconds are not enough
+ * to place a cursor inside a bulk batch); pass it back as `beforeSeconds` /
+ * `beforeNanos` / `beforeId` for the next page. The first page also carries
+ * `total`, an exact count for the scope (null when it can't be counted
+ * cheaply — a captain with an action filter — or when the count failed; the
+ * feed itself never depends on it).
  */
 export async function GET(request: NextRequest) {
   try {
@@ -29,8 +33,17 @@ export async function GET(request: NextRequest) {
       scope.team = team;
     }
     const action = p.get("action") || undefined;
-    const beforeAt = p.get("before"), beforeId = p.get("beforeId");
-    const before = beforeAt && beforeId && !Number.isNaN(new Date(beforeAt).getTime()) ? { at: new Date(beforeAt), id: beforeId } : undefined;
+    const bs = p.get("beforeSeconds"), bn = p.get("beforeNanos"), beforeId = p.get("beforeId");
+    let before: { at: Timestamp; id: string } | undefined;
+    if (bs !== null || bn !== null || beforeId !== null) {
+      const seconds = Number(bs), nanos = Number(bn);
+      const valid =
+        Number.isInteger(seconds) && seconds >= 0 &&
+        Number.isInteger(nanos) && nanos >= 0 && nanos < 1_000_000_000 &&
+        !!beforeId && beforeId.length <= 128 && !beforeId.includes("/");
+      if (!valid) return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+      before = { at: new Timestamp(seconds, nanos), id: beforeId! };
+    }
     const [{ entries, truncated, hasMore, nextCursor }, total] = await Promise.all([
       listAudit({
         ...scope,
@@ -40,7 +53,12 @@ export async function GET(request: NextRequest) {
         limit,
         before,
       }),
-      before ? Promise.resolve(undefined) : countAudit({ ...scope, action }),
+      before
+        ? Promise.resolve(undefined)
+        : countAudit({ ...scope, action }).catch((err) => {
+            logger.error({ err }, "Failed to count audit entries");
+            return null;
+          }),
     ]);
     // A captain asking for a specific application still only gets their team.
     const visible = scope.team ? entries.filter((e) => isVisibleToTeam(e, scope.team!)) : entries;
@@ -49,7 +67,7 @@ export async function GET(request: NextRequest) {
         entries: visible.map((e) => ({ ...e, at: e.at.toISOString() })),
         truncated,
         hasMore,
-        nextCursor: nextCursor ? { at: nextCursor.at.toISOString(), id: nextCursor.id } : null,
+        nextCursor: nextCursor ? { seconds: nextCursor.at.seconds, nanos: nextCursor.at.nanoseconds, id: nextCursor.id } : null,
         ...(before ? {} : { total }),
       },
       { headers: { "Cache-Control": "private, no-store" } }

--- a/lib/firebase/audit.ts
+++ b/lib/firebase/audit.ts
@@ -1,4 +1,4 @@
-import { FieldValue, FieldPath } from "firebase-admin/firestore";
+import { FieldValue, FieldPath, Timestamp } from "firebase-admin/firestore";
 import { adminDb } from "./admin";
 import { getUser } from "./users";
 import { logger } from "@/lib/logger";
@@ -160,8 +160,13 @@ export interface ListAuditOptions {
   /** Restrict to entries about this team's applications (captains). Entries with no application are excluded. */
   team?: string;
   limit?: number;
-  /** Feed paging: continue after this entry (its `at` and id), newest first. */
-  before?: { at: Date; id: string };
+  /**
+   * Feed paging: continue after this entry, newest first. `at` is the raw
+   * Firestore Timestamp — never a Date: toDate() rounds to milliseconds, and
+   * every entry of a bulk batch shares one server timestamp, so a rounded
+   * cursor lands on the wrong side of that batch and skips or repeats it.
+   */
+  before?: { at: Timestamp; id: string };
 }
 
 export interface AuditPage {
@@ -169,8 +174,8 @@ export interface AuditPage {
   /** More matched than returned — kept for older callers; same as `hasMore`. */
   truncated: boolean;
   hasMore: boolean;
-  /** Pass back as `before` to get the next page. */
-  nextCursor?: { at: Date; id: string };
+  /** Pass back as `before` to get the next page. Only the feed (no applicationId/actor) pages. */
+  nextCursor?: { at: Timestamp; id: string };
 }
 
 /**
@@ -184,11 +189,19 @@ export async function countAudit(opts: { action?: string; team?: string } = {}):
   const col = adminDb.collection(AUDIT_COLLECTION);
   if (opts.team) {
     if (opts.action) return null;
-    const [own, exports] = await Promise.all([
+    // A single-team export carries applicantTeam too and is already in the
+    // first count; only multi-team exports need adding. Exports are rare, so
+    // reading them (rather than a second count) keeps this exact without a
+    // composite index.
+    const [own, exportDocs] = await Promise.all([
       col.where("applicantTeam", "==", opts.team).count().get(),
-      col.where("after.teams", "array-contains", opts.team).count().get(),
+      col.where("after.teams", "array-contains", opts.team).get(),
     ]);
-    return own.data().count + exports.data().count;
+    const multiTeamExports = exportDocs.docs.filter((d) => {
+      const e = d.data();
+      return e.action === "application.export" && e.applicantTeam !== opts.team;
+    }).length;
+    return own.data().count + multiTeamExports;
   }
   const q = opts.action ? col.where("action", "==", opts.action) : col;
   return (await q.count().get()).data().count;
@@ -204,6 +217,12 @@ export async function countAudit(opts: { action?: string; team?: string } = {}):
  */
 export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditPage> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  // Only the feed pages. The exact lookups have no ordering (a composite index
+  // would be needed) and are bounded by the window instead.
+  const paged = !opts.applicationId && !opts.actorUid;
+  // The wide window is only needed when entries are filtered in memory; an
+  // unfiltered feed page reads just one document past the page.
+  const windowSize = paged && !opts.action && !opts.team ? limit + 1 : AUDIT_FEED_WINDOW;
   let docs;
   if (opts.applicationId) {
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("applicationId", "==", opts.applicationId).limit(AUDIT_FEED_WINDOW).get()).docs;
@@ -211,13 +230,15 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditPage>
     docs = (await adminDb.collection(AUDIT_COLLECTION).where("actor.uid", "==", opts.actorUid).limit(AUDIT_FEED_WINDOW).get()).docs;
   } else {
     // Ordered by (at, id) so a cursor is exact even where a bulk write gave
-    // many entries the same timestamp; the document-id tiebreak needs no
-    // composite index.
+    // many entries the same timestamp; the document-id tiebreak restates
+    // Firestore's implicit ordering and needs no composite index.
     let q = adminDb.collection(AUDIT_COLLECTION).orderBy("at", "desc").orderBy(FieldPath.documentId(), "desc");
     if (opts.before) q = q.startAfter(opts.before.at, opts.before.id);
-    docs = (await q.limit(AUDIT_FEED_WINDOW).get()).docs;
+    docs = (await q.limit(windowSize).get()).docs;
   }
-  const windowFull = docs.length >= AUDIT_FEED_WINDOW;
+  const windowFull = docs.length >= windowSize;
+  // Raw timestamps, kept for the cursor (see ListAuditOptions.before).
+  const rawAt = new Map<string, Timestamp | undefined>(docs.map((d) => [d.id, d.get("at") as Timestamp | undefined]));
   let entries: AuditEntry[] = docs.map((d) => {
     const data = d.data();
     return { ...(data as Omit<AuditEntry, "id" | "at">), id: d.id, at: data.at?.toDate?.() ?? new Date(0) } as AuditEntry;
@@ -225,7 +246,9 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditPage>
   if (opts.action) entries = entries.filter((e) => e.action === opts.action);
   if (opts.actorUid) entries = entries.filter((e) => e.actor?.uid === opts.actorUid);
   if (opts.team) entries = entries.filter((e) => isVisibleToTeam(e, opts.team!));
-  if (!opts.before) entries.sort((a, b) => b.at.getTime() - a.at.getTime());
+  // The feed arrives in exact (at, id) order; the unordered lookups are sorted
+  // here, newest first.
+  if (!paged) entries.sort((a, b) => b.at.getTime() - a.at.getTime());
   const page = entries.slice(0, limit);
   // More to load when the window held more matches than returned, or the
   // window itself was full (older entries exist beyond it). The cursor is the
@@ -233,12 +256,14 @@ export async function listAudit(opts: ListAuditOptions = {}): Promise<AuditPage>
   // the last raw document examined, so nothing is skipped or repeated.
   const hasMore = entries.length > limit || windowFull;
   let nextCursor: AuditPage["nextCursor"];
-  if (entries.length > limit) {
+  if (paged && entries.length > limit) {
     const last = page[page.length - 1];
-    nextCursor = { at: last.at, id: last.id! };
-  } else if (windowFull) {
+    const at = rawAt.get(last.id!);
+    if (at) nextCursor = { at, id: last.id! };
+  } else if (paged && windowFull) {
     const lastDoc = docs[docs.length - 1];
-    nextCursor = { at: lastDoc.data().at?.toDate?.() ?? new Date(0), id: lastDoc.id };
+    const at = rawAt.get(lastDoc.id);
+    if (at) nextCursor = { at, id: lastDoc.id };
   }
   return { entries: page, truncated: hasMore, hasMore, nextCursor };
 }

--- a/scripts/qa/audit-regress.mjs
+++ b/scripts/qa/audit-regress.mjs
@@ -112,7 +112,7 @@ r = await api(adminC, "POST", "/api/admin/config/recruiting", { step: "reviewing
 all = await allEntries();
 check("recruiting step change recorded", r.status === 200 && all.some((x) => x.action === "config.recruiting_step" && x.before?.step === "open" && x.after?.step === "reviewing"), JSON.stringify(all.filter((x) => x.action === "config.recruiting_step").map((x) => x.detail)));
 
-r = await api(adminC, "POST", "/api/admin/applications/export-csv", { team: "Electric" });
+r = await api(adminC, "POST", "/api/admin/applications/export-csv", { teams: ["Electric"] });
 all = await allEntries();
 check("CSV export recorded with count and teams", all.some((x) => x.action === "application.export" && x.actor.uid === "seed-admin" && Array.isArray(x.after?.teams) && typeof x.after?.count === "number"), `${r.status} ${JSON.stringify(all.filter((x) => x.action === "application.export").map((x) => [x.detail, x.after]))}`);
 r = await api(adminC, "DELETE", "/api/admin/applications/au-2/notes/nonexistent-note");
@@ -147,23 +147,32 @@ r = await api(adminC, "GET", "/api/admin/audit?limit=500");
 check("truncated is false when everything fit", r.status === 200 && r.json.entries.length > 5 && r.json.truncated === false, `${r.json?.entries?.length} truncated=${r.json?.truncated}`);
 
 // ---- paging + exact total ----
+// A bulk batch bigger than the page: every entry shares one server timestamp,
+// so the page boundary falls inside it — the case a millisecond cursor breaks.
+for (const id of ["au-b1", "au-b2", "au-b3", "au-b4", "au-b5", "au-b6", "au-b7", "au-b8"]) await mk(id);
+r = await api(adminC, "POST", "/api/admin/applications/bulk-status", { applicationIds: ["au-b1", "au-b2", "au-b3", "au-b4", "au-b5", "au-b6", "au-b7", "au-b8"], action: "reject" });
+check("bulk of 8 for the paging walk", r.status === 200 && r.json?.summary?.success === 8, JSON.stringify(r.json?.summary));
 {
   const first = await api(adminC, "GET", "/api/admin/audit?limit=5");
   const total = first.json?.total;
   check("feed: first page carries an exact total >= what it returned", typeof total === "number" && total >= first.json.entries.length && total > 5, `total=${total} entries=${first.json?.entries?.length}`);
-  check("feed: hasMore + cursor when more exist", first.json.hasMore === true && !!first.json.nextCursor?.at && !!first.json.nextCursor?.id, JSON.stringify(first.json?.nextCursor));
+  check("feed: hasMore + a raw-timestamp cursor when more exist", first.json.hasMore === true && Number.isInteger(first.json.nextCursor?.seconds) && Number.isInteger(first.json.nextCursor?.nanos) && !!first.json.nextCursor?.id, JSON.stringify(first.json?.nextCursor));
   const seen = new Set(first.json.entries.map((x) => x.id));
   let cursor = first.json.nextCursor, pages = 1, overlap = 0, outOfOrder = 0, lastAt = first.json.entries[first.json.entries.length - 1]?.at;
   while (cursor && pages < 200) {
-    const page = await api(adminC, "GET", `/api/admin/audit?limit=5&before=${encodeURIComponent(cursor.at)}&beforeId=${encodeURIComponent(cursor.id)}`);
+    const page = await api(adminC, "GET", `/api/admin/audit?limit=5&beforeSeconds=${cursor.seconds}&beforeNanos=${cursor.nanos}&beforeId=${encodeURIComponent(cursor.id)}`);
     if (page.status !== 200) { check("feed: paging request ok", false, `${page.status} ${page.json?.error}`); break; }
     check(`feed: page ${pages + 1} carries no total (only the first page counts)`, !("total" in page.json), Object.keys(page.json).join(","));
     for (const x of page.json.entries) { if (seen.has(x.id)) overlap++; if (lastAt && x.at > lastAt) outOfOrder++; seen.add(x.id); lastAt = x.at; }
     cursor = page.json.hasMore ? page.json.nextCursor : null; pages++;
   }
-  check("feed: walking every page yields exactly `total` distinct entries, no repeats, never newer than the page before", seen.size === total && overlap === 0 && outOfOrder === 0, `distinct=${seen.size} total=${total} overlap=${overlap} outOfOrder=${outOfOrder} pages=${pages}`);
+  check("feed: walking every page yields exactly `total` distinct entries, no repeats, never newer than the page before (bulk batch straddling pages included)", seen.size === total && overlap === 0 && outOfOrder === 0, `distinct=${seen.size} total=${total} overlap=${overlap} outOfOrder=${outOfOrder} pages=${pages}`);
+  const bad = await api(adminC, "GET", "/api/admin/audit?limit=5&beforeSeconds=abc&beforeNanos=0&beforeId=x");
+  check("feed: a malformed cursor is a 400, not silently page 1", bad.status === 400, `${bad.status}`);
+  const byApp = await api(adminC, "GET", "/api/admin/audit?applicationId=au-2&limit=1");
+  check("exact lookup (applicationId) never hands out a cursor", byApp.status === 200 && byApp.json.entries.length === 1 && byApp.json.nextCursor === null, JSON.stringify([byApp.status, byApp.json?.nextCursor]));
   const capAll = await api(capC, "GET", "/api/admin/audit?limit=500");
-  check("captain: total equals their visible entries (no action filter)", capAll.status === 200 && capAll.json.total === capAll.json.entries.length && capAll.json.hasMore === false, `total=${capAll.json?.total} entries=${capAll.json?.entries?.length}`);
+  check("captain: total equals their visible entries (no action filter) — single-team export counted once", capAll.status === 200 && capAll.json.total === capAll.json.entries.length && capAll.json.hasMore === false && capAll.json.entries.some((x) => x.action === "application.export"), `total=${capAll.json?.total} entries=${capAll.json?.entries?.length}`);
   const capAct = await api(capC, "GET", "/api/admin/audit?limit=500&action=application.bulk");
   check("captain + action filter: total is null (composite index), entries still scoped and filtered", capAct.status === 200 && capAct.json.total === null && capAct.json.entries.length > 0 && capAct.json.entries.every((x) => x.action === "application.bulk" && x.applicantTeam === "Electric"), `total=${capAct.json?.total} n=${capAct.json?.entries?.length}`);
   const adminAct = await api(adminC, "GET", "/api/admin/audit?limit=500&action=application.status");


### PR DESCRIPTION
Follow-up to #130 from a post-merge Opus review (10 findings). Three matter on production right now; the rest ride along.

## What was wrong

- **The paging cursor lost precision.** `nextCursor.at` went through `Timestamp.toDate()` (milliseconds, rounded either way) and an ISO round-trip. Server timestamps carry microseconds, and `recordAuditMany` gives every entry of a bulk batch the *same* timestamp — so when a page boundary landed inside a batch (bulk of 400 rejects, page of 300), the next page started on the wrong side of it: either the rest of the batch was silently skipped (walk ends with fewer entries than `total`), or the whole batch was re-returned and, if larger than a page, "Load older" appended nothing forever. This is exactly the case the id tiebreak was added for, and the emulator can't reproduce it (its timestamps are millisecond-aligned).
- **Captains' `total` double-counted single-team CSV exports.** Those entries carry both `applicantTeam` and `after.teams`, so both counts included them; the feed showed them once. The harness missed it because it posted `team` where the export route reads `teams`, so its seeded export spanned two teams.
- **A failed `count()` took the whole feed down** — `Promise.all` with no guard on the cosmetic number.
- Smaller: "Load older" racing an action-filter change could append the old filter's rows and cursor to the new list; every page read 1,000 documents to return 300 (~3.3 reads per row); the unpaged `applicationId`/`actor` lookups handed out a cursor that did nothing and skipped their sort when one was passed; a malformed cursor silently returned page 1; `PAGE` lived inside the component.

## What changes

- The cursor is the **raw Firestore timestamp** end to end: `nextCursor` is `{seconds, nanos, id}`, the route takes `beforeSeconds`/`beforeNanos`/`beforeId`, and `startAfter` gets a `Timestamp`. A malformed cursor is a 400.
- Captain totals: `applicantTeam == team` count plus the **multi-team** exports only (exports are rare, so those are read rather than counted — exact, no composite index).
- `countAudit` failures are logged and return `null`; the page renders without a total.
- Unfiltered feed pages read `limit + 1` documents, not 1,000; the wide window remains only where entries are filtered in memory (action filter, captain scope). Exact lookups never emit a cursor and are always sorted newest-first.
- Activity view: a generation counter drops the result of a "Load older" that started under a previous filter; state resets when the filter changes; `PAGE` is module scope.

## Verification

- `scripts/qa/audit-regress.mjs` — **49 checks** (+4): a bulk of 8 (one batch, one timestamp) is added before the paging walk so a `limit=5` page boundary falls inside a same-timestamp batch; the walk still yields exactly `total` distinct entries with no repeats and in order. Malformed cursor → 400. `applicationId` lookup → no cursor. The export fixture now really is single-team (`teams: ["Electric"]`), and the captain's `total` equals their visible entries with that export counted once — the check that the old harness couldn't fail.
- Query shapes unchanged (only the `limit` value differs), so #130's production probe still applies.
- `npx tsc --noEmit` and `npm run build` clean.

## Migration / data

None.
