### PR TITLE
fix: qa backlog sweep (15 issues)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,10 @@ Two traps documented in that file: `formData.availability` holds **phone numbers
 question was relabelled in April 2026, so weekly availability is no longer collected), and
 system questions only render for systems the applicant actually ranked.
 
-`PATCH /api/applications/[id]` merges whatever `formData` object it receives, so applicants
-can currently write arbitrary keys into their own document. Live data already contains junk
-from someone testing. A server-side whitelist is still owed.
+`PATCH /api/applications/[id]` runs incoming `formData` through `sanitizeIncomingFormData()`
+(same file): only the named fields and the two string bags survive, answers are clipped to
+20k characters, bags to 100 entries with 64-char keys. Live data from before that still
+contains junk keys from someone testing.
 
 ## Auth
 
@@ -133,6 +134,13 @@ Three layers, and the middleware is the weakest of them:
 rely on the middleware or on the UI hiding a link. Several recent commits exist purely to fix
 places where that was missed.
 
+A guard failure is a thrown `Error`: message `Unauthorized` (no, expired or invalid session —
+any Firebase `auth/*` error collapses to this) must become a **401**, because the client
+fetcher only logs the user out on 401; `Forbidden…` (wrong role or scope) is a 403. Route
+catch blocks use `guardErrorStatus(error)` from `lib/auth/guard.ts` for that mapping. Server
+components that only need "who is signed in" (Header, Footer) call `getSessionUser()` from
+`lib/auth/sessionUser.ts`, which verifies once per request.
+
 ## Data access
 
 All Firestore access goes through `lib/firebase/*` using the Admin SDK (`lib/firebase/admin.ts`
@@ -147,9 +155,17 @@ subcollections), `users`, `config`, `interviewConfigs`, `scorecardConfigs`,
 `config` docs: `recruiting`, `announcement`, `application_questions`, `teams`, `about_page`,
 `dashboard`, `email_templates`, `faq`.
 
-`lib/utils/appCache.ts` is a 10-minute in-memory singleton cache for application lists (keyed
-by RBAC scope), the recruiting step, and application questions. Invalidate it after mutating
-any of those — it has a 30s invalidation cooldown, so a write may not be visible immediately.
+`lib/utils/appCache.ts` is a 10-minute in-memory singleton cache (per server instance) for
+the recruiting step and the application questions — application lists are **not** cached
+server-side. Call `invalidateApplications()` after mutating applications or the step (it
+always drops the cached step; its 30s cooldown only rate-limits the admin refresh button) and
+`invalidateQuestions()` after a question edit. The admin applications list is cached in the
+browser instead (`localStorage`, keyed by uid — `lib/utils/adminCache.ts`), and cleared on
+logout and on any 401.
+
+Staff writes to an application's status go through `updateApplicationIfUnchanged()` — a
+transaction that refuses (409 `ApplicationConflictError`) if the status changed since the
+route loaded it. Use it for any new decision-writing route.
 
 ## Content is configuration
 
@@ -164,8 +180,9 @@ them, so editing a default in code changes nothing live — the change has to be
 admin UI, or by a one-off script against Firestore. Several live docs already diverge from
 their code defaults.
 
-Everything config-driven is cached, and the TTLs differ: questions 2h server-side plus 30 min
-in the applicant's browser (`localStorage`), About, teams and FAQ 15 min. Interview and
+Everything config-driven is cached, and the TTLs differ: questions 5 min at the CDN plus 5 min
+in the applicant's browser (`localStorage`; the admin PUT also invalidates this instance's
+in-memory copy), About, teams and FAQ 15 min. Interview and
 scorecard configs are **not** cached — those routes read Firestore per request, so an admin
 edit is live immediately. If you add a cache, say so in the tab's UI; don't state a delay
 that no cache actually enforces.

--- a/app/admin/_components/ViewerContext.tsx
+++ b/app/admin/_components/ViewerContext.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext, ReactNode } from "react";
+
+/**
+ * The signed-in staff member's uid, handed down from the admin layout's
+ * server-side guard so client components know who is viewing before any
+ * fetch resolves (the admin applications cache is keyed by it — #71).
+ */
+const ViewerContext = createContext<string | null>(null);
+
+export function ViewerProvider({ uid, children }: { uid: string | null; children: ReactNode }) {
+  return <ViewerContext.Provider value={uid}>{children}</ViewerContext.Provider>;
+}
+
+export function useViewerUid(): string | null {
+  return useContext(ViewerContext);
+}

--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -149,12 +149,22 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
     recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ? 2
       : (recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 || recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3) ? 3
         : 1;
+  // Only a trial-stage decision carries a release day: the applicant must be
+  // at trial (or already accepted/waitlisted and being re-decided). A
+  // straggler still at review gets a review decision, which has no day.
   const showsReleaseDay =
-    recruitingStep === RecruitingStep.RELEASE_TRIAL ||
-    recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
-    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||
-    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 ||
-    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3;
+    (recruitingStep === RecruitingStep.RELEASE_TRIAL ||
+      recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
+      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||
+      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 ||
+      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3) &&
+    (selectedApp?.status === ApplicationStatus.TRIAL ||
+      selectedApp?.status === ApplicationStatus.ACCEPTED ||
+      selectedApp?.status === ApplicationStatus.WAITLISTED);
+  // A choice made in one modal must not ride into the next one.
+  useEffect(() => {
+    if (showAcceptModal || showWaitlistModal || showRejectModal) setReleaseDay(null);
+  }, [showAcceptModal, showWaitlistModal, showRejectModal]);
   const releaseDaySelector = showsReleaseDay ? (
     <div>
       <label className="block font-urbanist text-[10px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: "var(--lhr-gray-blue)" }}>Release on</label>
@@ -1578,6 +1588,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                       );
                     })}
                   </div>
+                  {releaseDaySelector && <div className="mb-6">{releaseDaySelector}</div>}
                   <div className="flex gap-3">
                     <button
                       onClick={() => setShowRejectModal(false)}

--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -149,23 +149,24 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
     recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ? 2
       : (recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 || recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3) ? 3
         : 1;
-  // Only a trial-stage decision carries a release day: the applicant must be
-  // at trial (or already accepted/waitlisted and being re-decided). A
-  // straggler still at review gets a review decision, which has no day.
-  const showsReleaseDay =
-    (recruitingStep === RecruitingStep.RELEASE_TRIAL ||
-      recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
-      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||
-      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 ||
-      recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3) &&
-    (selectedApp?.status === ApplicationStatus.TRIAL ||
-      selectedApp?.status === ApplicationStatus.ACCEPTED ||
-      selectedApp?.status === ApplicationStatus.WAITLISTED);
+  // Only a trial decision carries a release day. Same rule as the server:
+  // an accept or waitlist at these steps always writes one (even for a
+  // fast-tracked interviewee or a straggler); a reject does only once the
+  // applicant holds a trial offer — at trial, or accepted/waitlisted and
+  // being rescinded.
+  const atDecisionStep =
+    recruitingStep === RecruitingStep.RELEASE_TRIAL ||
+    recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3;
+  const showsReleaseDayForDecision = atDecisionStep;
+  const showsReleaseDayForReject = atDecisionStep && (selectedApp?.trialOffers?.length ?? 0) > 0;
   // A choice made in one modal must not ride into the next one.
   useEffect(() => {
     if (showAcceptModal || showWaitlistModal || showRejectModal) setReleaseDay(null);
   }, [showAcceptModal, showWaitlistModal, showRejectModal]);
-  const releaseDaySelector = showsReleaseDay ? (
+  const releaseDaySelectorFor = (show: boolean) => show ? (
     <div>
       <label className="block font-urbanist text-[10px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: "var(--lhr-gray-blue)" }}>Release on</label>
       <select
@@ -183,6 +184,8 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
       </p>
     </div>
   ) : null;
+  const releaseDaySelector = releaseDaySelectorFor(showsReleaseDayForDecision);
+  const rejectReleaseDaySelector = releaseDaySelectorFor(showsReleaseDayForReject);
 
   // Related applications state (other teams this user applied to)
   const [relatedApps, setRelatedApps] = useState<Array<{
@@ -262,7 +265,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
       const res = await fetch(`/api/admin/applications/${applicationId}/status`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, systems, offer, releaseDay: showsReleaseDay ? releaseDay ?? undefined : undefined }),
+        body: JSON.stringify({ status, systems, offer, releaseDay: showsReleaseDayForDecision ? releaseDay ?? undefined : undefined }),
       });
       const data = await res.json();
 
@@ -393,7 +396,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
       const res = await fetch(`/api/admin/applications/${applicationId}/reject`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ systems: selectedRejectSystems, releaseDay: showsReleaseDay ? releaseDay ?? undefined : undefined }),
+        body: JSON.stringify({ systems: selectedRejectSystems, releaseDay: showsReleaseDayForReject ? releaseDay ?? undefined : undefined }),
       });
       const data = await res.json();
 
@@ -1588,7 +1591,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                       );
                     })}
                   </div>
-                  {releaseDaySelector && <div className="mb-6">{releaseDaySelector}</div>}
+                  {rejectReleaseDaySelector && <div className="mb-6">{rejectReleaseDaySelector}</div>}
                   <div className="flex gap-3">
                     <button
                       onClick={() => setShowRejectModal(false)}

--- a/app/admin/applications/_components/ApplicationDetail.tsx
+++ b/app/admin/applications/_components/ApplicationDetail.tsx
@@ -85,7 +85,7 @@ function getStatusLabel(status: string): string {
 }
 
 export default function ApplicationDetail({ applicationId }: ApplicationDetailProps) {
-  const { applications, setApplications, currentUser, recruitingStep, loading } = useApplications();
+  const { applications, setApplications, currentUser, recruitingStep, loading, refreshApplications } = useApplications();
   const { openDrawer, setOpenDrawer } = useApplicationsLayout();
   const isActionsOpenOnMobile = openDrawer === "actions";
   const toggleActionsDrawer = () => setOpenDrawer(isActionsOpenOnMobile ? null : "actions");
@@ -142,6 +142,37 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
     system: string;
     details: string;
   }>({ system: '', details: '' });
+  // Which decision day a trial-stage accept/waitlist/reject is released on
+  // (#58). null = the server's step-based default, shown in the selector.
+  const [releaseDay, setReleaseDay] = useState<1 | 2 | 3 | null>(null);
+  const inferredReleaseDay: 1 | 2 | 3 =
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ? 2
+      : (recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 || recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3) ? 3
+        : 1;
+  const showsReleaseDay =
+    recruitingStep === RecruitingStep.RELEASE_TRIAL ||
+    recruitingStep === RecruitingStep.TRIAL_WORKDAY ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY1 ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY2 ||
+    recruitingStep === RecruitingStep.RELEASE_DECISIONS_DAY3;
+  const releaseDaySelector = showsReleaseDay ? (
+    <div>
+      <label className="block font-urbanist text-[10px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: "var(--lhr-gray-blue)" }}>Release on</label>
+      <select
+        value={releaseDay ?? inferredReleaseDay}
+        onChange={(e) => setReleaseDay(Number(e.target.value) as 1 | 2 | 3)}
+        className="w-full h-10 rounded-lg px-3 font-urbanist text-[13px] text-white focus:outline-none"
+        style={{ backgroundColor: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)" }}
+      >
+        {[1, 2, 3].map((d) => (
+          <option key={d} value={d} style={optionStyle}>Decision Day {d}{d === inferredReleaseDay ? " (default for this step)" : ""}</option>
+        ))}
+      </select>
+      <p className="font-urbanist text-[11px] mt-1.5" style={{ color: "rgba(255,255,255,0.35)" }}>
+        The applicant sees this decision once the recruiting step reaches that day.
+      </p>
+    </div>
+  ) : null;
 
   // Related applications state (other teams this user applied to)
   const [relatedApps, setRelatedApps] = useState<Array<{
@@ -221,9 +252,16 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
       const res = await fetch(`/api/admin/applications/${applicationId}/status`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, systems, offer }),
+        body: JSON.stringify({ status, systems, offer, releaseDay: showsReleaseDay ? releaseDay ?? undefined : undefined }),
       });
       const data = await res.json();
+
+      if (res.status === 409) {
+        // Someone else changed this application first (#66): show what they did.
+        toast.error(data.error || "This application changed while you were deciding — reloaded");
+        await refreshApplications().catch(() => {});
+        return;
+      }
 
       if (res.ok && data.application) {
         setApplications(prev => prev.map(a =>
@@ -345,7 +383,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
       const res = await fetch(`/api/admin/applications/${applicationId}/reject`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ systems: selectedRejectSystems }),
+        body: JSON.stringify({ systems: selectedRejectSystems, releaseDay: showsReleaseDay ? releaseDay ?? undefined : undefined }),
       });
       const data = await res.json();
 
@@ -1610,6 +1648,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                         style={{ backgroundColor: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)" }}
                       />
                     </div>
+                    {releaseDaySelector}
                   </div>
                   <div className="flex gap-3">
                     <button
@@ -1664,6 +1703,7 @@ export default function ApplicationDetail({ applicationId }: ApplicationDetailPr
                         style={{ backgroundColor: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)" }}
                       />
                     </div>
+                    {releaseDaySelector}
                   </div>
                   <div className="flex gap-3">
                     <button

--- a/app/admin/applications/_components/ApplicationsContext.tsx
+++ b/app/admin/applications/_components/ApplicationsContext.tsx
@@ -4,6 +4,8 @@ import { createContext, useContext, useState, useEffect, ReactNode, useCallback,
 import { Application } from "@/lib/models/Application";
 import { User } from "@/lib/models/User";
 import { ADMIN_APPS_CACHE_PREFIX, adminAppsCacheKey } from "@/lib/utils/adminCache";
+import { handleUnauthorized } from "@/lib/auth/fetcher";
+import { useViewerUid } from "@/app/admin/_components/ViewerContext";
 import { RecruitingStep } from "@/lib/models/Config";
 
 interface ApplicationWithUser extends Application {
@@ -114,12 +116,18 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [searchTerm, setSearchTerm] = useState("");
   const initialLoadDone = useRef(false);
-  const cacheKeyRef = useRef<string | null>(null);
+  const viewerUid = useViewerUid(); // from the admin layout's server-side guard (#71/#83)
+  const cacheKeyRef = useRef<string | null>(viewerUid ? adminAppsCacheKey(viewerUid) : null);
 
   // Fetch all applications once
   const fetchAllApps = useCallback(async (force = false) => {
     try {
       const res = await fetch(`/api/admin/applications?all=true`);
+      if (res.status === 401) {
+        // Expired session (#59): log out rather than show an empty sidebar.
+        await handleUnauthorized();
+        return [];
+      }
       if (res.ok) {
         const data = await res.json();
         const apps = data.applications || [];
@@ -276,29 +284,41 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
 
       setLoading(true);
       try {
-        // Who is this? The cache is keyed by uid (#71), so it is read here,
-        // after /api/auth/me answers, and never in a state initializer (#83).
+        // The cache is keyed by uid (#71) and read here, after mount, never in
+        // a state initializer (#83). The uid comes from the admin layout's
+        // server-side guard, so this paints before any network round-trip.
+        const seedFromCache = (key: string) => {
+          try {
+            localStorage.removeItem(ADMIN_APPS_CACHE_PREFIX); // the pre-#71 unkeyed cache
+            const cached = localStorage.getItem(key);
+            if (!cached) return;
+            const cachedData: CachedData = JSON.parse(cached);
+            if (Date.now() - cachedData.timestamp < CACHE_TTL) {
+              setAllApplications(cachedData.applications as ApplicationWithUser[]);
+              setLoading(false); // We have data, can stop main loading spinner
+            }
+          } catch (e) {
+            console.error("Failed to read cached applications", e);
+          }
+        };
+        if (cacheKeyRef.current) seedFromCache(cacheKeyRef.current);
         try {
           const userRes = await fetch("/api/auth/me");
+          if (userRes.status === 401) {
+            await handleUnauthorized();
+            return;
+          }
           if (userRes.ok) {
             const userData = await userRes.json();
             setCurrentUser(userData.user);
             const uid: string | undefined = userData.user?.uid;
-            if (uid) {
+            if (uid && !cacheKeyRef.current) {
               cacheKeyRef.current = adminAppsCacheKey(uid);
-              localStorage.removeItem(ADMIN_APPS_CACHE_PREFIX); // the pre-#71 unkeyed cache
-              const cached = localStorage.getItem(cacheKeyRef.current);
-              if (cached) {
-                const cachedData: CachedData = JSON.parse(cached);
-                if (Date.now() - cachedData.timestamp < CACHE_TTL) {
-                  setAllApplications(cachedData.applications as ApplicationWithUser[]);
-                  setLoading(false); // We have data, can stop main loading spinner
-                }
-              }
+              seedFromCache(cacheKeyRef.current);
             }
           }
         } catch (e) {
-          console.error("Failed to read cached applications", e);
+          console.error("Failed to load the current user", e);
         }
 
         // Fetch from API in background or foreground

--- a/app/admin/applications/_components/ApplicationsContext.tsx
+++ b/app/admin/applications/_components/ApplicationsContext.tsx
@@ -3,13 +3,15 @@
 import { createContext, useContext, useState, useEffect, ReactNode, useCallback, useRef, useMemo } from "react";
 import { Application } from "@/lib/models/Application";
 import { User } from "@/lib/models/User";
+import { ADMIN_APPS_CACHE_PREFIX, adminAppsCacheKey } from "@/lib/utils/adminCache";
 import { RecruitingStep } from "@/lib/models/Config";
 
 interface ApplicationWithUser extends Application {
   user: User;
   aggregateRating?: number | null;
   interviewAggregateRating?: number | null;
-  otherTeams?: Array<{ id: string; team: string; status: string; preferredSystems: string[] }>;
+  // `id` is admin-only; other staff see a masked status ("inactive" for a waitlist elsewhere). #62
+  otherTeams?: Array<{ id?: string; team: string; status: string; preferredSystems: string[] }>;
 }
 
 type SortBy = "date" | "name" | "rating" | "interviewRating";
@@ -65,8 +67,7 @@ interface ApplicationsProviderProps {
   selectedApplicationId?: string;
 }
 
-// Local storage caching
-const CACHE_KEY = "admin_applications_cache";
+// Local storage caching — keyed by uid, see lib/utils/adminCache.ts (#71)
 const CACHE_TTL = 15 * 60 * 1000; // 15 minutes
 
 interface CachedData {
@@ -102,37 +103,10 @@ function stripBulkyFields(apps: ApplicationWithUser[]): Partial<ApplicationWithU
 }
 
 export function ApplicationsProvider({ children, selectedApplicationId }: ApplicationsProviderProps) {
-  // Initialize state from cache if available to avoid loading flash
-  const [allApplications, setAllApplications] = useState<ApplicationWithUser[]>(() => {
-    if (typeof window === "undefined") return [];
-    const cached = localStorage.getItem(CACHE_KEY);
-    if (cached) {
-      try {
-        const cachedData: CachedData = JSON.parse(cached);
-        if (Date.now() - cachedData.timestamp < CACHE_TTL) {
-          return cachedData.applications as ApplicationWithUser[];
-        }
-      } catch (e) {
-        console.error("Failed to parse cached applications", e);
-      }
-    }
-    return [];
-  });
-
-  const [loading, setLoading] = useState(() => {
-    // If we have cached applications, we're not "initially loading"
-    if (typeof window === "undefined") return true;
-    const cached = localStorage.getItem(CACHE_KEY);
-    if (cached) {
-      try {
-        const cachedData: CachedData = JSON.parse(cached);
-        return Date.now() - cachedData.timestamp >= CACHE_TTL;
-      } catch {
-        return true;
-      }
-    }
-    return true;
-  });
+  // Both start exactly as the server rendered them (#83): the cached list is
+  // read after mount, in init(), once the uid is known (#71).
+  const [allApplications, setAllApplications] = useState<ApplicationWithUser[]>([]);
+  const [loading, setLoading] = useState(true);
   const [refetching, setRefetching] = useState(false);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [recruitingStep, setRecruitingStep] = useState<RecruitingStep | null>(null);
@@ -140,6 +114,7 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [searchTerm, setSearchTerm] = useState("");
   const initialLoadDone = useRef(false);
+  const cacheKeyRef = useRef<string | null>(null);
 
   // Fetch all applications once
   const fetchAllApps = useCallback(async (force = false) => {
@@ -156,7 +131,7 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
             applications: stripBulkyFields(apps),
             timestamp: Date.now(),
           };
-          localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
+          if (cacheKeyRef.current) localStorage.setItem(cacheKeyRef.current, JSON.stringify(cacheData));
         } catch (e) {
           console.warn("Failed to update applications cache (likely quota exceeded)", e);
           // If quota exceeded, we just don't cache. Better than crashing.
@@ -301,20 +276,29 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
 
       setLoading(true);
       try {
-        // Try to load from cache first
-        let fetchedApps: ApplicationWithUser[] = [];
-        const cached = localStorage.getItem(CACHE_KEY);
-        if (cached) {
-          try {
-            const cachedData: CachedData = JSON.parse(cached);
-            if (Date.now() - cachedData.timestamp < CACHE_TTL) {
-              fetchedApps = cachedData.applications as ApplicationWithUser[];
-              setAllApplications(fetchedApps);
-              setLoading(false); // We have data, can stop main loading spinner
+        // Who is this? The cache is keyed by uid (#71), so it is read here,
+        // after /api/auth/me answers, and never in a state initializer (#83).
+        try {
+          const userRes = await fetch("/api/auth/me");
+          if (userRes.ok) {
+            const userData = await userRes.json();
+            setCurrentUser(userData.user);
+            const uid: string | undefined = userData.user?.uid;
+            if (uid) {
+              cacheKeyRef.current = adminAppsCacheKey(uid);
+              localStorage.removeItem(ADMIN_APPS_CACHE_PREFIX); // the pre-#71 unkeyed cache
+              const cached = localStorage.getItem(cacheKeyRef.current);
+              if (cached) {
+                const cachedData: CachedData = JSON.parse(cached);
+                if (Date.now() - cachedData.timestamp < CACHE_TTL) {
+                  setAllApplications(cachedData.applications as ApplicationWithUser[]);
+                  setLoading(false); // We have data, can stop main loading spinner
+                }
+              }
             }
-          } catch (e) {
-            console.error("Failed to parse cached applications", e);
           }
+        } catch (e) {
+          console.error("Failed to read cached applications", e);
         }
 
         // Fetch from API in background or foreground
@@ -337,13 +321,6 @@ export function ApplicationsProvider({ children, selectedApplicationId }: Applic
               });
             }
           }
-        }
-
-        // Fetch current user
-        const userRes = await fetch("/api/auth/me");
-        if (userRes.ok) {
-          const userData = await userRes.json();
-          setCurrentUser(userData.user);
         }
 
         // Fetch recruiting config

--- a/app/admin/applications/_components/ApplicationsSidebar.tsx
+++ b/app/admin/applications/_components/ApplicationsSidebar.tsx
@@ -97,6 +97,7 @@ const STATUS_LABELS: Record<string, string> = {
   [ApplicationStatus.WAITLISTED]: "Waitlisted",
   [ApplicationStatus.COMMITTED]: "Committed",
   [ApplicationStatus.DECLINED]: "Declined",
+  inactive: "Inactive", // a masked other-team status (#62)
 };
 
 function getStatusLabel(status: string): string {

--- a/app/admin/applications/_components/ApplicationsSidebar.tsx
+++ b/app/admin/applications/_components/ApplicationsSidebar.tsx
@@ -305,7 +305,7 @@ export default function ApplicationsSidebar() {
 
   if (loading) {
     return (
-      <div
+      <aside
         className={clsx(
           // Desktop: static column. Mobile: viewport-anchored fixed drawer
           // so address-bar resize and content scroll never visually
@@ -323,7 +323,7 @@ export default function ApplicationsSidebar() {
           <Loader2 className="h-5 w-5 animate-spin" style={{ color: "var(--lhr-blue)" }} />
           <span className="font-urbanist text-[13px] text-white/30">Loading applicants...</span>
         </div>
-      </div>
+      </aside>
     );
   }
 

--- a/app/admin/configuration/QuestionsTab.tsx
+++ b/app/admin/configuration/QuestionsTab.tsx
@@ -570,7 +570,7 @@ export function QuestionsTab({ userData }: QuestionsTabProps) {
             style={{ backgroundColor: "rgba(255,181,38,0.06)", border: "1px solid rgba(255,181,38,0.12)", color: "rgba(255,181,38,0.6)" }}
           >
             <Clock className="h-3 w-3" />
-            Changes may take up to 2 hours to appear for applicants due to caching.
+            Changes reach applicants within about 15 minutes (server, CDN and browser caches of 5 minutes each).
           </div>
         </div>
       </div>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { requireStaff } from "@/lib/auth/guard";
 import { AdminShell } from "./AdminShell";
+import { ViewerProvider } from "./_components/ViewerContext";
 import { redirect } from "next/navigation";
 
 export const metadata: Metadata = {
@@ -13,11 +14,16 @@ export default async function AdminLayout({
 }: {
   children: React.ReactNode;
 }) {
+  let uid: string | null = null;
   try {
-    await requireStaff();
+    ({ uid } = await requireStaff());
   } catch (error) {
     redirect("/dashboard");
   }
 
-  return <AdminShell>{children}</AdminShell>;
+  return (
+    <ViewerProvider uid={uid}>
+      <AdminShell>{children}</AdminShell>
+    </ViewerProvider>
+  );
 }

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -197,20 +197,29 @@ export default function AdminSettingsPage() {
       
       toast.loading(`Processing ${chunks.length} batches...`, { id: toastId });
       
-      // 3. Process batches sequentially
+      // 3. Process batches sequentially. One run id for every batch: the
+      // server holds the run lock across them (#64), and a second admin or
+      // tab starting a run meanwhile is told so instead of counted as failures.
+      const runId = crypto.randomUUID();
       for (let i = 0; i < chunks.length; i++) {
         const batch = chunks[i];
         toast.loading(`Sending batch ${i + 1}/${chunks.length}...`, { id: toastId });
-        
+
         const res = await fetch("/api/admin/config/recruiting/trigger-emails", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ 
+          body: JSON.stringify({
             force,
-            applicationIds: batch
+            applicationIds: batch,
+            runId,
+            last: i === chunks.length - 1,
           }),
         });
-        
+
+        if (res.status === 409) {
+          const { error } = await res.json().catch(() => ({ error: "Another email run is in progress." }));
+          throw new Error(`${error || "Another email run is in progress."} Stopped after ${i} of ${chunks.length} batches (sent ${totalSent}).`);
+        }
         if (!res.ok) {
           console.error(`Batch ${i + 1} failed`);
           totalFailed += batch.length;

--- a/app/api/admin/applications/[id]/details/route.ts
+++ b/app/api/admin/applications/[id]/details/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     logger.error(error, "Failed to fetch application details");
 
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
 
     if (error instanceof Error && error.message === "Application not found") {

--- a/app/api/admin/applications/[id]/interview/[system]/route.ts
+++ b/app/api/admin/applications/[id]/interview/[system]/route.ts
@@ -100,7 +100,7 @@ export async function PATCH(
   } catch (error) {
     logger.error(error, "Failed to update interview offer status");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     const message = error instanceof Error ? error.message : "Internal Error";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/app/api/admin/applications/[id]/notes/[noteId]/route.ts
+++ b/app/api/admin/applications/[id]/notes/[noteId]/route.ts
@@ -44,7 +44,7 @@ export async function DELETE(
   } catch (error) {
     logger.error(error, "Failed to delete note");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/applications/[id]/notes/route.ts
+++ b/app/api/admin/applications/[id]/notes/route.ts
@@ -48,7 +48,7 @@ export async function GET(
   } catch (error) {
     logger.error(error, "Failed to fetch notes");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }
@@ -103,7 +103,7 @@ export async function POST(
   } catch (error) {
     logger.error(error, "Failed to create note");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -66,6 +66,10 @@ export async function POST(
 
     const body = await request.json();
     let { systems } = body;
+    const releaseDay = body.releaseDay === undefined || body.releaseDay === null ? undefined : Number(body.releaseDay);
+    if (releaseDay !== undefined && ![1, 2, 3].includes(releaseDay)) {
+      return NextResponse.json({ error: "releaseDay must be 1, 2 or 3" }, { status: 400 });
+    }
 
     if (!systems || !Array.isArray(systems) || systems.length === 0) {
       return NextResponse.json({ error: "Systems array is required" }, { status: 400 });
@@ -95,7 +99,7 @@ export async function POST(
     }
 
     // Atomically reject from the specified systems using a transaction
-    const { application: updatedApp, fullyRejected } = await rejectApplicationFromSystems(id, systems);
+    const { application: updatedApp, fullyRejected } = await rejectApplicationFromSystems(id, systems, { releaseDay: releaseDay as 1 | 2 | 3 | undefined });
 
     if (!updatedApp) {
       return NextResponse.json({ error: "Application not found" }, { status: 404 });
@@ -121,7 +125,7 @@ export async function POST(
   } catch (error) {
     logger.error(error, "Failed to reject application");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     if (error instanceof Error && error.message === "Application not found") {
       return NextResponse.json({ error: error.message }, { status: 404 });

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -66,9 +66,12 @@ export async function POST(
 
     const body = await request.json();
     let { systems } = body;
-    const releaseDay = body.releaseDay === undefined || body.releaseDay === null ? undefined : Number(body.releaseDay);
-    if (releaseDay !== undefined && ![1, 2, 3].includes(releaseDay)) {
+    const releaseDay = body.releaseDay === undefined || body.releaseDay === null ? undefined : body.releaseDay;
+    if (releaseDay !== undefined && (typeof releaseDay !== "number" || ![1, 2, 3].includes(releaseDay))) {
       return NextResponse.json({ error: "releaseDay must be 1, 2 or 3" }, { status: 400 });
+    }
+    if (releaseDay !== undefined && application.status !== ApplicationStatus.TRIAL) {
+      return NextResponse.json({ error: "releaseDay only applies to trial-stage decisions" }, { status: 400 });
     }
 
     if (!systems || !Array.isArray(systems) || systems.length === 0) {

--- a/app/api/admin/applications/[id]/reject/route.ts
+++ b/app/api/admin/applications/[id]/reject/route.ts
@@ -70,7 +70,9 @@ export async function POST(
     if (releaseDay !== undefined && (typeof releaseDay !== "number" || ![1, 2, 3].includes(releaseDay))) {
       return NextResponse.json({ error: "releaseDay must be 1, 2 or 3" }, { status: 400 });
     }
-    if (releaseDay !== undefined && application.status !== ApplicationStatus.TRIAL) {
+    // A rejection is a trial decision (and so carries a day) once the applicant
+    // holds a trial offer — at trial, or accepted/waitlisted and being rescinded.
+    if (releaseDay !== undefined && (application.trialOffers?.length ?? 0) === 0) {
       return NextResponse.json({ error: "releaseDay only applies to trial-stage decisions" }, { status: 400 });
     }
 

--- a/app/api/admin/applications/[id]/related/route.ts
+++ b/app/api/admin/applications/[id]/related/route.ts
@@ -72,7 +72,7 @@ export async function GET(
     logger.error(error, "Failed to fetch related applications");
 
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
 
     if (error instanceof Error && error.message === "Application not found") {

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
 import { adminAuth, adminDb } from "@/lib/firebase/admin";
-import { updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, getApplication, revertToSubmitted } from "@/lib/firebase/applications";
+import { updateApplication, addMultipleInterviewOffers, addMultipleTrialOffers, getApplication, revertToSubmitted, updateApplicationIfUnchanged, ApplicationConflictError } from "@/lib/firebase/applications";
 import { requireStaffForApplication } from "@/lib/auth/guard";
 import { ApplicationStatus } from "@/lib/models/Application";
 import { UserRole, User } from "@/lib/models/User";
@@ -31,7 +31,7 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { status, systems, offer } = body; // systems is optional array of system names, offer is optional offer details
+    const { status, systems, offer, releaseDay } = body; // systems is optional array of system names, offer is optional offer details, releaseDay is an optional 1|2|3 for trial-stage decisions (#58)
 
     if (!Object.values(ApplicationStatus).includes(status)) {
       return NextResponse.json({ error: "Invalid status" }, { status: 400 });
@@ -262,8 +262,18 @@ export async function POST(
           decisionDay = 3;
         }
 
+        // Staff may choose the release day explicitly (#58): the inference
+        // above is only a default, and it is wrong whenever staff decide during
+        // the Day-1 step but mean the result to show on Day 1.
+        if (releaseDay !== undefined && releaseDay !== null) {
+          const requested = Number(releaseDay);
+          if (![1, 2, 3].includes(requested)) {
+            return NextResponse.json({ error: "releaseDay must be 1, 2 or 3" }, { status: 400 });
+          }
+          decisionDay = requested as 1 | 2 | 3;
+        }
         updateData.trialDecisionDay = decisionDay;
-        logger.info({ decisionDay, currentStep }, "Set trial decision day");
+        logger.info({ decisionDay, currentStep, explicit: releaseDay !== undefined && releaseDay !== null }, "Set trial decision day");
       }
 
       // The waitlist modal picks a system too; it used to be dropped on the floor.
@@ -324,7 +334,9 @@ export async function POST(
 
       logger.info({ updateData }, "About to update application with data");
 
-      updatedApp = await updateApplication(id, updateData as any);
+      // Guarded write (#66): if another staff member changed this application
+      // since it was loaded, this returns 409 instead of silently overwriting.
+      updatedApp = await updateApplicationIfUnchanged(id, updateData as any, { status: current.status });
     }
 
     // Invalidate global application cache after successful status change
@@ -343,9 +355,12 @@ export async function POST(
     return NextResponse.json({ application: updatedApp }, { status: 200 });
 
   } catch (error) {
+    if (error instanceof ApplicationConflictError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     logger.error(error, "Failed to update application status");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     if (error instanceof Error && error.message === "Application not found") {
       return NextResponse.json({ error: error.message }, { status: 404 });

--- a/app/api/admin/applications/[id]/status/route.ts
+++ b/app/api/admin/applications/[id]/status/route.ts
@@ -249,6 +249,13 @@ export async function POST(
         updateData[field] = decision;
       }
 
+      // releaseDay is meaningful only for a trial-stage decision (#58). Refuse
+      // it anywhere else rather than drop it — the UI promised a day.
+      const releaseDayGiven = releaseDay !== undefined && releaseDay !== null;
+      if (releaseDayGiven && field !== 'trialDecision') {
+        return NextResponse.json({ error: "releaseDay only applies to trial-stage decisions" }, { status: 400 });
+      }
+
       // If this is a trial decision (accept/reject/waitlist), track which day it was made
       if (field === 'trialDecision') {
         // Determine which day the decision was made
@@ -265,15 +272,14 @@ export async function POST(
         // Staff may choose the release day explicitly (#58): the inference
         // above is only a default, and it is wrong whenever staff decide during
         // the Day-1 step but mean the result to show on Day 1.
-        if (releaseDay !== undefined && releaseDay !== null) {
-          const requested = Number(releaseDay);
-          if (![1, 2, 3].includes(requested)) {
+        if (releaseDayGiven) {
+          if (typeof releaseDay !== "number" || ![1, 2, 3].includes(releaseDay)) {
             return NextResponse.json({ error: "releaseDay must be 1, 2 or 3" }, { status: 400 });
           }
-          decisionDay = requested as 1 | 2 | 3;
+          decisionDay = releaseDay as 1 | 2 | 3;
         }
         updateData.trialDecisionDay = decisionDay;
-        logger.info({ decisionDay, currentStep, explicit: releaseDay !== undefined && releaseDay !== null }, "Set trial decision day");
+        logger.info({ decisionDay, currentStep, explicit: releaseDayGiven }, "Set trial decision day");
       }
 
       // The waitlist modal picks a system too; it used to be dropped on the floor.

--- a/app/api/admin/applications/[id]/tasks/[taskId]/route.ts
+++ b/app/api/admin/applications/[id]/tasks/[taskId]/route.ts
@@ -49,7 +49,7 @@ export async function PATCH(
   } catch (error) {
     logger.error(error, "Failed to update task");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }
@@ -90,7 +90,7 @@ export async function DELETE(
   } catch (error) {
     logger.error(error, "Failed to delete task");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/applications/[id]/tasks/route.ts
+++ b/app/api/admin/applications/[id]/tasks/route.ts
@@ -48,7 +48,7 @@ export async function GET(
   } catch (error) {
     logger.error(error, "Failed to fetch tasks");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }
@@ -97,7 +97,7 @@ export async function POST(
   } catch (error) {
     logger.error(error, "Failed to create task");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/applications/backfill-ratings/route.ts
+++ b/app/api/admin/applications/backfill-ratings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/auth/guard";
+import { requireAdmin, guardErrorStatus } from "@/lib/auth/guard";
 import { adminDb } from "@/lib/firebase/admin";
 import { updateAggregateRating } from "@/lib/firebase/updateAggregateRating";
 import { Team } from "@/lib/models/User";
@@ -88,6 +88,8 @@ export async function POST(request: NextRequest) {
     }, { status: 200 });
 
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     logger.error(error, "Failed to backfill ratings");
     
     if (error instanceof Error && error.message.includes("Admin")) {

--- a/app/api/admin/applications/bulk-status/route.ts
+++ b/app/api/admin/applications/bulk-status/route.ts
@@ -318,7 +318,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to process bulk status update");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -271,10 +271,13 @@ export async function POST(request: NextRequest) {
     // question, for every team in the export, so a blank optional first answer
     // no longer shifts the rest and nothing past the second is dropped.
     const questionsForColumns = await getApplicationQuestions();
-    const teamQuestionCols = Object.entries(questionsForColumns.teamQuestions).flatMap(([team, qs]) =>
-      (qs || []).map((q) => ({ team, id: q.id, label: q.label }))
-    );
-    const teamQuestionHeaders = teamQuestionCols.map((col) => `${col.team} Q: ${col.label}`);
+    const teamsInExport = new Set(applications.map((a) => a.team));
+    const teamQuestionCols = Object.entries(questionsForColumns.teamQuestions)
+      .filter(([team]) => teamsInExport.has(team as Team))
+      .flatMap(([team, qs]) => (qs || []).map((q) => ({ team, id: q.id, label: q.label })));
+    // Answers stored under a question id the config no longer has (a question
+    // deleted or re-created mid-cycle) still export, in one catch-all column.
+    const teamQuestionHeaders = [...teamQuestionCols.map((col) => `${col.team} Q: ${col.label}`), "Other Team Answers"];
     const allHeaders = [
       ...staticHeaders,
       ...customAnswerHeaders,
@@ -291,7 +294,13 @@ export async function POST(request: NextRequest) {
     for (const app of applications) {
       const fd = app.formData || {};
       const teamQs = fd.teamQuestions || {};
-      const teamQuestionValues = teamQuestionCols.map((col) => (app.team === col.team ? teamQs[col.id] || "" : ""));
+      const teamQuestionValues = [
+        ...teamQuestionCols.map((col) => (app.team === col.team ? teamQs[col.id] || "" : "")),
+        Object.entries(teamQs)
+          .filter(([id, v]) => v && !teamQuestionCols.some((col) => col.team === app.team && col.id === id))
+          .map(([id, v]) => `${id}: ${v}`)
+          .join(" | "),
+      ];
 
       // Determine the target system for aggregate ratings
       // For system leads, use their system; otherwise first preferred system

--- a/app/api/admin/applications/export-csv/route.ts
+++ b/app/api/admin/applications/export-csv/route.ts
@@ -230,6 +230,9 @@ export async function POST(request: NextRequest) {
       "Email",
       "Team",
       "Preferred Systems",
+      // The ranking as the applicant set it, before an interview selection or
+      // an unranked offer narrowed preferredSystems (#73).
+      "Original Preferred Systems",
       "Status",
       "Review Decision",
       "Interview Decision",
@@ -244,9 +247,6 @@ export async function POST(request: NextRequest) {
       "Availability",
       "Resume URL",
       "Portfolio URL",
-      // Team-specific questions
-      "Team Question 1",
-      "Team Question 2",
       "Review Rating (Aggregate)",
       "Interview Rating (Aggregate)",
       "Interview Offers",
@@ -267,9 +267,18 @@ export async function POST(request: NextRequest) {
       "Notes",
     ];
 
+    // Team-question columns keyed off the config (#73): one column per team
+    // question, for every team in the export, so a blank optional first answer
+    // no longer shifts the rest and nothing past the second is dropped.
+    const questionsForColumns = await getApplicationQuestions();
+    const teamQuestionCols = Object.entries(questionsForColumns.teamQuestions).flatMap(([team, qs]) =>
+      (qs || []).map((q) => ({ team, id: q.id, label: q.label }))
+    );
+    const teamQuestionHeaders = teamQuestionCols.map((col) => `${col.team} Q: ${col.label}`);
     const allHeaders = [
       ...staticHeaders,
       ...customAnswerHeaders,
+      ...teamQuestionHeaders,
       ...scorecardHeaders,
       ...reviewerSummaryHeaders,
     ];
@@ -282,7 +291,7 @@ export async function POST(request: NextRequest) {
     for (const app of applications) {
       const fd = app.formData || {};
       const teamQs = fd.teamQuestions || {};
-      const teamQValues = Object.values(teamQs);
+      const teamQuestionValues = teamQuestionCols.map((col) => (app.team === col.team ? teamQs[col.id] || "" : ""));
 
       // Determine the target system for aggregate ratings
       // For system leads, use their system; otherwise first preferred system
@@ -323,6 +332,7 @@ export async function POST(request: NextRequest) {
         app.userEmail || "",
         app.team,
         (app.preferredSystems || []).join("; "),
+        (app.originalPreferredSystems || []).join("; "),
         app.status,
         app.reviewDecision || "",
         app.interviewDecision || "",
@@ -334,8 +344,6 @@ export async function POST(request: NextRequest) {
         fd.availability || "",
         fd.resumeUrl || "",
         fd.portfolioUrl || "",
-        teamQValues[0] || "",
-        teamQValues[1] || "",
         reviewRating,
         interviewRating,
         interviewOffersSummary,
@@ -396,6 +404,7 @@ export async function POST(request: NextRequest) {
       const row = [
         ...staticValues,
         ...customAnswerValues,
+        ...teamQuestionValues,
         ...scorecardValues,
         reviewerNames,
         notesSummary,
@@ -431,7 +440,7 @@ export async function POST(request: NextRequest) {
       error instanceof Error &&
       (error.message === "Unauthorized" || error.message.includes("Forbidden"))
     ) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
@@ -447,8 +456,7 @@ async function fetchAllScorecards(
   if (appIds.length === 0) return {};
 
   // Fetch scorecards for all apps in parallel (up to 50 concurrent)
-  const results = await Promise.all(
-    appIds.map(async (appId) => {
+  const results = await mapInChunks(appIds, 25, async (appId) => {
       const snapshot = await adminDb
         .collection("applications")
         .doc(appId)
@@ -466,10 +474,18 @@ async function fetchAllScorecards(
       });
 
       return { appId, submissions };
-    })
-  );
+  });
 
   return Object.fromEntries(results.map(({ appId, submissions }) => [appId, submissions]));
+}
+
+/** Bounded fan-out (#73): N subcollection reads at a time, not all of them at once. */
+async function mapInChunks<T, R>(items: T[], size: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(...(await Promise.all(items.slice(i, i + size).map(fn))));
+  }
+  return out;
 }
 
 async function fetchAllNotes(
@@ -477,8 +493,7 @@ async function fetchAllNotes(
 ): Promise<Record<string, Note[]>> {
   if (appIds.length === 0) return {};
 
-  const results = await Promise.all(
-    appIds.map(async (appId) => {
+  const results = await mapInChunks(appIds, 25, async (appId) => {
       const snapshot = await adminDb
         .collection("applications")
         .doc(appId)
@@ -496,8 +511,7 @@ async function fetchAllNotes(
       });
 
       return { appId, notes };
-    })
-  );
+  });
 
   return Object.fromEntries(results.map(({ appId, notes }) => [appId, notes]));
 }

--- a/app/api/admin/applications/refresh/route.ts
+++ b/app/api/admin/applications/refresh/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const success = appCache.invalidateApplications();
+    const success = appCache.requestRefresh();
 
     if (!success) {
       const remaining = Math.ceil(appCache.getCooldownRemaining() / 1000);

--- a/app/api/admin/applications/refresh/route.ts
+++ b/app/api/admin/applications/refresh/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireStaff } from "@/lib/auth/guard";
+import { requireStaff, guardErrorStatus } from "@/lib/auth/guard";
 import { appCache } from "@/lib/utils/appCache";
 
 /**
@@ -29,6 +29,8 @@ export async function POST(request: NextRequest) {
       message: "Applications cache invalidated successfully."
     });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     console.error("Failed to refresh applications cache", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
@@ -45,13 +47,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // const remaining = Math.ceil(appCache.getCooldownRemaining() / 1000);
-    const remaining: number = 0;
+    // The real cooldown (#70): the button used to promise a refresh the POST
+    // would then refuse with a 429.
+    const remaining = Math.ceil(appCache.getCooldownRemaining() / 1000);
     return NextResponse.json({
       cooldownRemaining: remaining,
       canRefresh: remaining === 0
     });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }

--- a/app/api/admin/applications/route.ts
+++ b/app/api/admin/applications/route.ts
@@ -9,7 +9,7 @@ import {
 import { adminDb } from "@/lib/firebase/admin";
 import { UserRole, Team } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
-import { Application } from "@/lib/models/Application";
+import { Application, ApplicationStatus } from "@/lib/models/Application";
 import { appCache } from "@/lib/utils/appCache";
 import { logger } from "@/lib/logger";
 
@@ -69,6 +69,20 @@ function docToApplication(doc: FirebaseFirestore.DocumentSnapshot): Application 
     updatedAt: data.updatedAt?.toDate() || new Date(),
     submittedAt: data.submittedAt?.toDate(),
   } as Application;
+}
+
+/**
+ * Other-team applications for the "+N teams" badge, masked like the related
+ * route (#62): a waitlist on another team is that team's internal review
+ * detail, so it reads "inactive" to everyone but admins, and only admins get
+ * the ids they can navigate to.
+ */
+function maskOtherTeams<T extends { id: string; status: string }>(list: T[], isAdmin: boolean): Array<Omit<T, "id"> & { id?: string }> {
+  if (isAdmin) return list;
+  return list.map(({ id: _id, ...rest }) => ({
+    ...rest,
+    status: rest.status === ApplicationStatus.WAITLISTED ? "inactive" : rest.status,
+  }));
 }
 
 /**
@@ -232,7 +246,7 @@ export async function GET(request: NextRequest) {
           user: { name: app.userName || "Unknown", email: app.userEmail || "", role: "applicant" },
           aggregateRating: systemRatings?.reviewRating ?? null,
           interviewAggregateRating: showInterviewRatings ? (systemRatings?.interviewRating ?? null) : null,
-          otherTeams: allOtherTeamsMap.get(app.userId) || [],
+          otherTeams: maskOtherTeams(allOtherTeamsMap.get(app.userId) || [], user.role === UserRole.ADMIN),
         };
       });
 
@@ -287,7 +301,7 @@ export async function GET(request: NextRequest) {
           user: { name: app.userName || "Unknown", email: app.userEmail || "", role: "applicant" },
           aggregateRating: systemRatings?.reviewRating ?? null,
           interviewAggregateRating: showInterviewRatings ? (systemRatings?.interviewRating ?? null) : null,
-          otherTeams: otherTeamsMap.get(app.userId) || [],
+          otherTeams: maskOtherTeams(otherTeamsMap.get(app.userId) || [], user.role === UserRole.ADMIN),
         };
       });
 
@@ -332,7 +346,7 @@ export async function GET(request: NextRequest) {
         user: { name: app.userName || "Unknown", email: app.userEmail || "", role: "applicant" },
         aggregateRating: systemRatings?.reviewRating ?? null,
         interviewAggregateRating: showInterviewRatings ? (systemRatings?.interviewRating ?? null) : null,
-        otherTeams: allOtherTeamsMap.get(app.userId) || [],
+        otherTeams: maskOtherTeams(allOtherTeamsMap.get(app.userId) || [], user.role === UserRole.ADMIN),
       };
     });
 
@@ -369,7 +383,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to fetch admin applications");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }

--- a/app/api/admin/config/about/route.ts
+++ b/app/api/admin/config/about/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch about page config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/announcement/route.ts
+++ b/app/api/admin/config/announcement/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to fetch announcement");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/contact/route.ts
+++ b/app/api/admin/config/contact/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch contact page config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/dashboard/route.ts
+++ b/app/api/admin/config/dashboard/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch dashboard config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/faq/route.ts
+++ b/app/api/admin/config/faq/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch FAQ config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/questions/route.ts
+++ b/app/api/admin/config/questions/route.ts
@@ -13,6 +13,7 @@ import { UserRole, Team } from "@/lib/models/User";
 import { ApplicationQuestion } from "@/lib/models/Config";
 import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { logger } from "@/lib/logger";
+import { appCache } from "@/lib/utils/appCache";
 import { recordAudit } from "@/lib/firebase/audit";
 
 
@@ -41,7 +42,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch application questions");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }
@@ -78,6 +79,7 @@ export async function PUT(request: NextRequest) {
     // Admin can do everything
     if (userRole === UserRole.ADMIN) {
       await handleUpdate(scope, uid, { team, system, questions, config });
+      appCache.invalidateQuestions(); // this instance\'s copy (#60)
       await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
       return NextResponse.json({ success: true });
     }
@@ -86,6 +88,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.TEAM_CAPTAIN_OB) {
       if (scope === "team" && team === userTeam) {
         await updateTeamQuestions(team, questions, uid);
+        appCache.invalidateQuestions(); // this instance\'s copy (#60)
         await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
         return NextResponse.json({ success: true });
       }
@@ -96,6 +99,7 @@ export async function PUT(request: NextRequest) {
     if (userRole === UserRole.SYSTEM_LEAD) {
       if (scope === "system" && system === userSystem && userTeam && (!team || team === userTeam)) {
         await updateSystemQuestions(system, questions, uid, userTeam);
+        appCache.invalidateQuestions(); // this instance\'s copy (#60)
         await recordAudit(request, { uid }, { action: "config.update", detail: `questions: ${scope}${team ? ` ${team}` : ""}${system ? ` / ${system}` : ""}` });
         return NextResponse.json({ success: true });
       }

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to fetch recruiting config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-         return NextResponse.json({ error: error.message }, { status: 403 });
+         return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -6,16 +6,38 @@ import { Application, ApplicationStatus } from "@/lib/models/Application";
 import { getUserVisibleStatus } from "@/lib/utils/statusUtils";
 import { EmailTrigger } from "@/lib/models/EmailTemplate";
 import { sendStatusEmail } from "@/lib/email/send";
-import { updateApplication } from "@/lib/firebase/applications";
+import { markEmailSent } from "@/lib/firebase/applications";
 import { logger } from "@/lib/logger";
 import { recordAudit } from "@/lib/firebase/audit";
 
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+// One email run at a time (#64): two admins (or two tabs) used to send
+// everyone two copies. The lock is a config doc with a 15-minute expiry, so a
+// run that dies with its tab cannot hold it forever.
+const RUN_LOCK_DOC = "email_run_lock";
+const RUN_LOCK_TTL_MS = 15 * 60 * 1000;
+async function acquireRunLock(uid: string, step: string): Promise<{ ok: true } | { ok: false; heldBy?: string; since?: Date }> {
+  const ref = adminDb.collection("config").doc(RUN_LOCK_DOC);
+  return adminDb.runTransaction(async (t) => {
+    const snap = await t.get(ref);
+    const d = snap.data();
+    const until: Date | undefined = d?.lockedUntil?.toDate?.();
+    if (until && until.getTime() > Date.now()) {
+      return { ok: false as const, heldBy: d?.by as string | undefined, since: d?.startedAt?.toDate?.() as Date | undefined };
+    }
+    t.set(ref, { by: uid, step, startedAt: new Date(), lockedUntil: new Date(Date.now() + RUN_LOCK_TTL_MS) });
+    return { ok: true as const };
+  });
+}
+async function releaseRunLock(): Promise<void> {
+  await adminDb.collection("config").doc(RUN_LOCK_DOC).delete().catch(() => {});
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { user: actor } = await requireAdmin();
+    const { uid, user: actor } = await requireAdmin();
     
     const body = await request.json();
     const { step, force = false, applicationIds } = body;
@@ -23,7 +45,19 @@ export async function POST(request: NextRequest) {
     const config = await getRecruitingConfig();
     const currentStep = step || config.currentStep;
 
-    const results = await triggerEmails(currentStep, force, applicationIds);
+    const lock = await acquireRunLock(uid, String(currentStep));
+    if (!lock.ok) {
+      return NextResponse.json(
+        { error: `An email run is already in progress${lock.since ? ` (started ${lock.since.toISOString()})` : ""}. Wait for it to finish before starting another.` },
+        { status: 409 }
+      );
+    }
+    let results;
+    try {
+      results = await triggerEmails(currentStep, force, applicationIds);
+    } finally {
+      await releaseRunLock();
+    }
 
     await recordAudit(request, actor, { action: "emails.trigger", detail: `step ${currentStep}${force ? " (force)" : ""}${applicationIds?.length ? ` for ${applicationIds.length} applications` : ""}`, after: results as unknown as Record<string, unknown> });
 
@@ -31,7 +65,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to trigger emails manually");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-         return NextResponse.json({ error: error.message }, { status: 403 });
+         return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }
@@ -151,10 +185,7 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
             // eligible for the next run — the non-force path skips anyone
             // already in emailsSent, so a false "sent" can never be retried
             // without force-sending to everyone who did get the email.
-            const newEmailsSent = force
-              ? Array.from(new Set([...(app.emailsSent || []), expectedTrigger]))
-              : [...(app.emailsSent || []), expectedTrigger];
-            await updateApplication(app.id, { emailsSent: newEmailsSent });
+            await markEmailSent(app.id, expectedTrigger);
             sentCount++;
 
             // Safe rate (10/sec)

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import { requireAdmin } from "@/lib/auth/guard";
 import { getRecruitingConfig, getEmailTemplatesConfig } from "@/lib/firebase/config";
 import { adminDb } from "@/lib/firebase/admin";
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { step, force = false, applicationIds, runId: clientRunId, last = false } = body;
     // A batched run shares one id across its requests; a plain request is its own run.
-    const runId = typeof clientRunId === "string" && clientRunId.trim() ? clientRunId.trim().slice(0, 64) : `single-${Date.now()}`;
+    const runId = typeof clientRunId === "string" && clientRunId.trim() ? clientRunId.trim().slice(0, 64) : `single-${uid}-${randomUUID()}`;
     const releasesLock = !clientRunId || last === true;
 
     const config = await getRecruitingConfig();

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -13,26 +13,41 @@ import { recordAudit } from "@/lib/firebase/audit";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-// One email run at a time (#64): two admins (or two tabs) used to send
-// everyone two copies. The lock is a config doc with a 15-minute expiry, so a
-// run that dies with its tab cannot hold it forever.
+// One email run at a time (#64). The admin UI sends a run as sequential
+// batches of 50, so the lock belongs to a *run id* the client generates: every
+// batch of that run re-enters, any other run gets a 409. The expiry is
+// batch-sized, not run-sized — a batch killed by the platform timeout never
+// reaches `finally`, and must not wedge the rest of its own run or the retry
+// for long. The last batch (or a single un-batched request) releases the
+// lock, and only its owner can.
 const RUN_LOCK_DOC = "email_run_lock";
-const RUN_LOCK_TTL_MS = 15 * 60 * 1000;
-async function acquireRunLock(uid: string, step: string): Promise<{ ok: true } | { ok: false; heldBy?: string; since?: Date }> {
+const RUN_LOCK_TTL_MS = 3 * 60 * 1000;
+async function acquireRunLock(uid: string, step: string, runId: string): Promise<{ ok: true } | { ok: false; since?: Date }> {
   const ref = adminDb.collection("config").doc(RUN_LOCK_DOC);
   return adminDb.runTransaction(async (t) => {
     const snap = await t.get(ref);
     const d = snap.data();
     const until: Date | undefined = d?.lockedUntil?.toDate?.();
-    if (until && until.getTime() > Date.now()) {
-      return { ok: false as const, heldBy: d?.by as string | undefined, since: d?.startedAt?.toDate?.() as Date | undefined };
+    const heldByAnotherRun = !!d && d.runId !== runId && !!until && until.getTime() > Date.now();
+    if (heldByAnotherRun) {
+      return { ok: false as const, since: d?.startedAt?.toDate?.() as Date | undefined };
     }
-    t.set(ref, { by: uid, step, startedAt: new Date(), lockedUntil: new Date(Date.now() + RUN_LOCK_TTL_MS) });
+    t.set(ref, {
+      runId,
+      by: uid,
+      step,
+      startedAt: d?.runId === runId && d?.startedAt ? d.startedAt : new Date(),
+      lockedUntil: new Date(Date.now() + RUN_LOCK_TTL_MS),
+    });
     return { ok: true as const };
   });
 }
-async function releaseRunLock(): Promise<void> {
-  await adminDb.collection("config").doc(RUN_LOCK_DOC).delete().catch(() => {});
+async function releaseRunLock(runId: string): Promise<void> {
+  const ref = adminDb.collection("config").doc(RUN_LOCK_DOC);
+  await adminDb.runTransaction(async (t) => {
+    const snap = await t.get(ref);
+    if (snap.exists && snap.data()?.runId === runId) t.delete(ref);
+  }).catch(() => {});
 }
 
 export async function POST(request: NextRequest) {
@@ -40,12 +55,15 @@ export async function POST(request: NextRequest) {
     const { uid, user: actor } = await requireAdmin();
     
     const body = await request.json();
-    const { step, force = false, applicationIds } = body;
+    const { step, force = false, applicationIds, runId: clientRunId, last = false } = body;
+    // A batched run shares one id across its requests; a plain request is its own run.
+    const runId = typeof clientRunId === "string" && clientRunId.trim() ? clientRunId.trim().slice(0, 64) : `single-${Date.now()}`;
+    const releasesLock = !clientRunId || last === true;
 
     const config = await getRecruitingConfig();
     const currentStep = step || config.currentStep;
 
-    const lock = await acquireRunLock(uid, String(currentStep));
+    const lock = await acquireRunLock(uid, String(currentStep), runId);
     if (!lock.ok) {
       return NextResponse.json(
         { error: `An email run is already in progress${lock.since ? ` (started ${lock.since.toISOString()})` : ""}. Wait for it to finish before starting another.` },
@@ -56,7 +74,7 @@ export async function POST(request: NextRequest) {
     try {
       results = await triggerEmails(currentStep, force, applicationIds);
     } finally {
-      await releaseRunLock();
+      if (releasesLock) await releaseRunLock(runId);
     }
 
     await recordAudit(request, actor, { action: "emails.trigger", detail: `step ${currentStep}${force ? " (force)" : ""}${applicationIds?.length ? ` for ${applicationIds.length} applications` : ""}`, after: results as unknown as Record<string, unknown> });

--- a/app/api/admin/config/teams/route.ts
+++ b/app/api/admin/config/teams/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch teams config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/dashboard/pending-count/route.ts
+++ b/app/api/admin/dashboard/pending-count/route.ts
@@ -157,7 +157,7 @@ export async function GET() {
   } catch (error) {
     logger.error(error, "Failed to fetch pending counts");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }

--- a/app/api/admin/scorecards/[id]/route.ts
+++ b/app/api/admin/scorecards/[id]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
   } catch (error) {
     logger.error(error, "Failed to fetch scorecard config");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/scorecards/route.ts
+++ b/app/api/admin/scorecards/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logger.error(error, "Failed to fetch scorecard configs");
     if (error instanceof Error && (error.message === "Unauthorized" || error.message.includes("Forbidden"))) {
-      return NextResponse.json({ error: error.message }, { status: 403 });
+      return NextResponse.json({ error: error.message }, { status: error.message === "Unauthorized" ? 401 : 403 });
     }
     return NextResponse.json({ error: "Internal Error" }, { status: 500 });
   }

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireStaff } from "@/lib/auth/guard";
+import { requireStaff, guardErrorStatus } from "@/lib/auth/guard";
 import { getRecruitingStats, invalidateRecruitingStats } from "@/lib/firebase/stats";
 import { logger } from "@/lib/logger";
 
@@ -17,6 +17,8 @@ export async function GET() {
     const stats = await getRecruitingStats();
     return NextResponse.json(stats, { headers: { "Cache-Control": "private, no-store" } });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     return handleError(error, "Failed to load admin stats");
   }
 }
@@ -28,6 +30,8 @@ export async function POST() {
     const stats = await getRecruitingStats({ fresh: true });
     return NextResponse.json(stats, { headers: { "Cache-Control": "private, no-store" } });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     return handleError(error, "Failed to refresh admin stats");
   }
 }

--- a/app/api/admin/users/[uid]/route.ts
+++ b/app/api/admin/users/[uid]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireStaff } from "@/lib/auth/guard";
+import { requireStaff, guardErrorStatus } from "@/lib/auth/guard";
 import { updateUser, getUser } from "@/lib/firebase/users";
 import { UserRole, Team } from "@/lib/models/User";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
@@ -116,6 +116,8 @@ export async function PATCH(
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     logger.error({ err: error }, "Failed to update user");
     return NextResponse.json(
       { error: "Failed to update user" },

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireStaff } from "@/lib/auth/guard";
+import { requireStaff, guardErrorStatus } from "@/lib/auth/guard";
 import { getAllUsers } from "@/lib/firebase/users";
 import { UserRole } from "@/lib/models/User";
 import { logger } from "@/lib/logger";
@@ -31,6 +31,8 @@ export async function GET(_request: NextRequest) {
     const users = await getAllUsers();
     return NextResponse.json({ users }, { status: 200 });
   } catch (error) {
+    const guardStatus = guardErrorStatus(error);
+    if (guardStatus) return NextResponse.json({ error: (error as Error).message }, { status: guardStatus });
     logger.error({ err: error }, "Failed to get users");
     return NextResponse.json(
       { error: "Failed to get users" },

--- a/app/api/applications/[id]/commit/route.ts
+++ b/app/api/applications/[id]/commit/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getApplication, respondToCommitment } from "@/lib/firebase/applications";
+import { getApplication, getUserApplications, respondToCommitment } from "@/lib/firebase/applications";
 import { getSystemLeads } from "@/lib/firebase/users";
 import { sendCommitmentNotificationToLeads } from "@/lib/email/send";
 import { adminAuth } from "@/lib/firebase/admin";
@@ -15,7 +15,7 @@ export async function POST(
 ) {
   try {
     const { id: applicationId } = await params;
-    const { accepted, reason } = await req.json();
+    const { accepted, reason, declineReasons } = await req.json();
 
     // Verify session
     const sessionCookie = req.cookies.get("session")?.value;
@@ -49,7 +49,20 @@ export async function POST(
       return NextResponse.json({ error: "There is no offer to respond to right now" }, { status: 400 });
     }
 
-    const updatedApplication = await respondToCommitment(applicationId, accepted, reason);
+    // Reasons for the other offers this commit declines (#65) — the declines
+    // themselves happen inside the commit transaction, never from the client.
+    const cleanReasons: Record<string, string> = {};
+    if (declineReasons && typeof declineReasons === "object" && !Array.isArray(declineReasons)) {
+      for (const [k, v] of Object.entries(declineReasons as Record<string, unknown>)) {
+        if (typeof v === "string" && v.trim()) cleanReasons[k] = v.trim().slice(0, 500);
+      }
+    }
+    // The other accepted offers this commit declines: their leads are told
+    // after the transaction lands, as each client-side decline used to do.
+    const declinedByThisCommit = accepted
+      ? (await getUserApplications(userId)).filter((a) => a.id !== applicationId && a.status === ApplicationStatus.ACCEPTED)
+      : [];
+    const updatedApplication = await respondToCommitment(applicationId, accepted, reason, cleanReasons);
     if (!updatedApplication) {
       return NextResponse.json({ error: "Failed to process commitment" }, { status: 500 });
     }
@@ -85,6 +98,18 @@ export async function POST(
       reason,
       leadEmails
     });
+    for (const other of declinedByThisCommit) {
+      const otherSystem = other.offer?.system || "Unknown System";
+      const otherLeads = await getSystemLeads(other.team, otherSystem);
+      sendCommitmentNotificationToLeads({
+        applicantName,
+        teamName: other.team,
+        systemName: otherSystem,
+        accepted: false,
+        reason: cleanReasons[other.id] || "Committed to another team",
+        leadEmails: otherLeads.map((l) => l.email).filter(Boolean),
+      });
+    }
 
     // Never return the raw document to the applicant — respondToCommitment
     // spreads the whole Firestore doc, decisions and ratings included.

--- a/app/api/applications/[id]/commit/route.ts
+++ b/app/api/applications/[id]/commit/route.ts
@@ -63,13 +63,13 @@ export async function POST(
     }
     // The other accepted offers this commit declines: their leads are told
     // after the transaction lands, as each client-side decline used to do.
-    // Only offers the applicant could actually see (#58 masks day-2/3
-    // acceptances): a lead should not hear "declined" about an offer that
-    // was never shown.
+    // The other accepted offers this commit declines: their leads are told
+    // after the transaction lands, as each client-side decline used to do.
+    // An acceptance not yet released to the applicant (#58 day-2/3) is
+    // declined too (pre-existing rule); its leads get a reason saying so
+    // rather than silence.
     const declinedByThisCommit = accepted
-      ? (await getUserApplications(userId)).filter(
-          (a) => a.id !== applicationId && a.status === ApplicationStatus.ACCEPTED && getUserVisibleStatus(a, config.currentStep) === ApplicationStatus.ACCEPTED
-        )
+      ? (await getUserApplications(userId)).filter((a) => a.id !== applicationId && a.status === ApplicationStatus.ACCEPTED)
       : [];
     const updatedApplication = await respondToCommitment(applicationId, accepted, reason, cleanReasons);
     if (!updatedApplication) {
@@ -110,12 +110,15 @@ export async function POST(
     for (const other of declinedByThisCommit) {
       const otherSystem = other.offer?.system || "Unknown System";
       const otherLeads = await getSystemLeads(other.team, otherSystem);
+      const wasVisible = getUserVisibleStatus(other, config.currentStep) === ApplicationStatus.ACCEPTED;
       sendCommitmentNotificationToLeads({
         applicantName,
         teamName: other.team,
         systemName: otherSystem,
         accepted: false,
-        reason: cleanReasons[other.id] || "Committed to another team",
+        reason: wasVisible
+          ? cleanReasons[other.id] || "Committed to another team"
+          : "Committed to another team before this offer was released to them",
         leadEmails: otherLeads.map((l) => l.email).filter(Boolean),
       });
     }

--- a/app/api/applications/[id]/commit/route.ts
+++ b/app/api/applications/[id]/commit/route.ts
@@ -23,8 +23,12 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const decodedToken = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const userId = decodedToken.uid;
+    let userId: string;
+    try {
+      userId = (await adminAuth.verifySessionCookie(sessionCookie, true)).uid;
+    } catch {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
     const application = await getApplication(applicationId);
     if (!application) {
@@ -59,8 +63,13 @@ export async function POST(
     }
     // The other accepted offers this commit declines: their leads are told
     // after the transaction lands, as each client-side decline used to do.
+    // Only offers the applicant could actually see (#58 masks day-2/3
+    // acceptances): a lead should not hear "declined" about an offer that
+    // was never shown.
     const declinedByThisCommit = accepted
-      ? (await getUserApplications(userId)).filter((a) => a.id !== applicationId && a.status === ApplicationStatus.ACCEPTED)
+      ? (await getUserApplications(userId)).filter(
+          (a) => a.id !== applicationId && a.status === ApplicationStatus.ACCEPTED && getUserVisibleStatus(a, config.currentStep) === ApplicationStatus.ACCEPTED
+        )
       : [];
     const updatedApplication = await respondToCommitment(applicationId, accepted, reason, cleanReasons);
     if (!updatedApplication) {

--- a/app/api/applications/[id]/interview/route.ts
+++ b/app/api/applications/[id]/interview/route.ts
@@ -161,7 +161,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       team: application.team,
-      offers: offersWithLinks,
+      // The cancel reason is a staff note (#75) — never served to the applicant.
+      offers: offersWithLinks.map(({ cancelReason: _internal, ...offer }) => offer),
       selectedSystem,
       needsSystemSelection,
     });

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -212,8 +212,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const editStamp = session ? { lastEditSession: session, lastEditAt: new Date() } : {};
 
     // Whitelist formData keys server-side — applicants own this document but
-    // must not be able to write arbitrary fields into it.
+    // must not be able to write arbitrary fields into it. Per-answer caps live
+    // in the sanitizer (#74); this bounds the whole payload well under
+    // Firestore's 1 MB document limit. Growth stays bounded because the merge
+    // below replaces each bag wholesale — keep it shallow.
     const formData = body.formData ? sanitizeIncomingFormData(body.formData) : undefined;
+    if (formData && Buffer.byteLength(JSON.stringify(formData), "utf8") > 600_000) {
+      return NextResponse.json({ error: "Your answers are too long to save — please shorten them" }, { status: 400 });
+    }
 
     // preferredSystems drives reviewer visibility (array-contains queries) and
     // several .map/.join call sites, so it must be a real array of this team's

--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -213,11 +213,12 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     // Whitelist formData keys server-side — applicants own this document but
     // must not be able to write arbitrary fields into it. Per-answer caps live
-    // in the sanitizer (#74); this bounds the whole payload well under
-    // Firestore's 1 MB document limit. Growth stays bounded because the merge
-    // below replaces each bag wholesale — keep it shallow.
+    // in the sanitizer (#74); this bounds what the document would hold after
+    // the merge (a bag absent from this request survives from the last one)
+    // well under Firestore's 1 MB limit. The merge is a shallow spread that
+    // replaces each bag wholesale — keep it that way.
     const formData = body.formData ? sanitizeIncomingFormData(body.formData) : undefined;
-    if (formData && Buffer.byteLength(JSON.stringify(formData), "utf8") > 600_000) {
+    if (formData && Buffer.byteLength(JSON.stringify({ ...existingApplication.formData, ...formData }), "utf8") > 600_000) {
       return NextResponse.json({ error: "Your answers are too long to save — please shorten them" }, { status: 400 });
     }
 

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -53,7 +53,8 @@ export async function GET(request: NextRequest) {
     const [applications, config, announcement] = await Promise.all([
         getUserApplications(uid),
         getRecruitingConfig(),
-        getAnnouncement()
+        // A blip on a cosmetic banner must not take the dashboard down (#61).
+        getAnnouncement().catch(() => null)
     ]);
 
     const sanitizedApplications = applications.map(app => sanitizeApplicationForApplicant(app, config.currentStep));

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -53,7 +53,8 @@ export async function POST(request: Request) {
       const options = {
         name: "session",
         value: sessionCookie,
-        maxAge: expiresIn,
+        maxAge: Math.floor(expiresIn / 1000), // cookie maxAge is seconds; expiresIn is ms (#59)
+        sameSite: "lax" as const,
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
       };
@@ -127,7 +128,8 @@ export async function POST(request: Request) {
       response.cookies.set({
         name: "user_role",
         value: role.toLowerCase(),
-        maxAge: expiresIn,
+        maxAge: Math.floor(expiresIn / 1000), // cookie maxAge is seconds; expiresIn is ms (#59)
+        sameSite: "lax" as const,
         httpOnly: false, // Needs to be readable by middleware
         secure: process.env.NODE_ENV === "production",
       });

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -11,7 +11,7 @@ import { logger } from "@/lib/logger";
 // Five minutes, not two hours (#60): a question fix on opening day has to
 // reach applicants before they submit against the old form.
 const CACHE_MAX_AGE = 300;
-const STALE_WHILE_REVALIDATE = 300;
+const STALE_WHILE_REVALIDATE = 60;
 
 /**
  * GET /api/questions

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -8,8 +8,10 @@ import { logger } from "@/lib/logger";
 
 
 // Cache the questions for 2 hours (7200 seconds), with stale-while-revalidate for 1 hour
-const CACHE_MAX_AGE = 7200;
-const STALE_WHILE_REVALIDATE = 3600;
+// Five minutes, not two hours (#60): a question fix on opening day has to
+// reach applicants before they submit against the old form.
+const CACHE_MAX_AGE = 300;
+const STALE_WHILE_REVALIDATE = 300;
 
 /**
  * GET /api/questions

--- a/app/apply/[team]/page.tsx
+++ b/app/apply/[team]/page.tsx
@@ -39,7 +39,7 @@ const optionStyle = { backgroundColor: "var(--pub-menu-bg)", color: "var(--pub-t
 
 // Local storage caching for questions
 const QUESTIONS_CACHE_KEY = "lhr_app_questions_cache";
-const QUESTIONS_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+const QUESTIONS_CACHE_TTL = 5 * 60 * 1000; // 5 minutes — a question fix must reach open forms quickly (#60)
 
 // Debounce helper
 const CONFLICT_NOTICE =

--- a/app/dashboard/applications/[id]/page.tsx
+++ b/app/dashboard/applications/[id]/page.tsx
@@ -10,6 +10,7 @@ import InterviewScheduler from "@/components/InterviewScheduler";
 import { useApplication } from "@/hooks/useApplication";
 import { useConfig } from "@/hooks/useConfig";
 import { getCommonAnswer } from "@/lib/utils/formAnswers";
+import { generateTeamSystemKey } from "@/lib/firebase/utils";
 import { routes } from "@/lib/routes";
 import { getBrandTeamColor } from "@/lib/teamColors";
 
@@ -127,6 +128,7 @@ export default function ApplicationDetailPage() {
   // Dynamic questions from API
   const [commonQuestions, setCommonQuestions] = useState<ApplicationQuestion[]>([]);
   const [teamQuestions, setTeamQuestions] = useState<ApplicationQuestion[]>([]);
+  const [systemQuestions, setSystemQuestions] = useState<Record<string, ApplicationQuestion[]>>({});
   const [rejectionMessage, setRejectionMessage] = useState<string | null>(null);
 
   const loading = appLoading || configLoading;
@@ -144,6 +146,7 @@ export default function ApplicationDetailPage() {
           const data = await res.json();
           setCommonQuestions(data.commonQuestions || []);
           setTeamQuestions(data.teamQuestions || []);
+          setSystemQuestions(data.systemQuestions || {});
         }
       } catch (err) {
         console.error("Failed to fetch questions:", err);
@@ -389,6 +392,32 @@ export default function ApplicationDetailPage() {
                     </p>
                   </div>
                 );
+              })}
+
+              {/* System-specific questions (#75): the answers live in
+                  customAnswers, keyed by question id, for each system the
+                  applicant ranked — the same lookup the apply form uses. */}
+              {(application.originalPreferredSystems?.length ? application.originalPreferredSystems : application.preferredSystems || []).map((system) => {
+                const key = generateTeamSystemKey(application.team, system);
+                const questions = systemQuestions[key] || systemQuestions[system] || [];
+                return questions.map((question) => {
+                  const value = application.formData.customAnswers?.[question.id];
+                  if (!value) return null;
+                  return (
+                    <div
+                      key={`${system}:${question.id}`}
+                      className="py-5"
+                      style={{ borderBottom: '1px solid var(--pub-border)' }}
+                    >
+                      <h4 className="text-[12px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--pub-text-3)' }}>
+                        {system} · {question.label}
+                      </h4>
+                      <p className="font-urbanist text-[14px] whitespace-pre-wrap break-words overflow-hidden leading-relaxed" style={{ color: "var(--pub-text)" }}>
+                        {value}
+                      </p>
+                    </div>
+                  );
+                });
               })}
 
               {/* Resume */}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -225,23 +225,18 @@ function CommitmentPicker({
     if (!selectedAppId) return;
     setLoading(selectedAppId);
     try {
-      // 1. Decline others with reasons
-      for (const app of acceptedApps) {
-        if (app.id !== selectedAppId) {
-          const reason = rejectionReasons[app.id] || "Committed to another team";
-          await fetch(`/api/applications/${app.id}/commit`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ accepted: false, reason }),
-          });
-        }
-      }
-
-      // 2. Commit to selected
+      // One request (#65): the server declines the other offers inside the
+      // same transaction as the commit, so a failure part-way can no longer
+      // leave the applicant declined everywhere and committed nowhere.
+      const declineReasons = Object.fromEntries(
+        acceptedApps
+          .filter((app) => app.id !== selectedAppId)
+          .map((app) => [app.id, rejectionReasons[app.id] || "Committed to another team"])
+      );
       const res = await fetch(`/api/applications/${selectedAppId}/commit`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ accepted: true }),
+        body: JSON.stringify({ accepted: true, declineReasons }),
       });
 
       if (res.ok) {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,8 +1,6 @@
 import Link from 'next/link';
 import LogoLockup from './LogoLockup';
-import { cookies } from 'next/headers';
-import { adminAuth } from '@/lib/firebase/admin';
-import { getUser } from '@/lib/firebase/users';
+import { getSessionUser } from '@/lib/auth/sessionUser';
 import { UserRole } from '@/lib/models/User';
 
 const footerLinks = [
@@ -44,18 +42,10 @@ const socialLinks = [
 
 export default async function Footer() {
     let logoHref = "/";
-    try {
-        const cookieStore = await cookies();
-        const sessionCookie = cookieStore.get("session")?.value;
-        if (sessionCookie) {
-            const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
-            const user = await getUser(decoded.uid);
-            if (user && STAFF_ROLES.has(user.role)) {
-                logoHref = "/admin/dashboard";
-            }
-        }
-    } catch {
-        // verification failed — keep default
+    // Shares the Header's per-request verification (#72).
+    const user = await getSessionUser();
+    if (user && STAFF_ROLES.has(user.role)) {
+        logoHref = "/admin/dashboard";
     }
 
     return (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,9 +5,7 @@ import { ThemeToggle } from '@/app/admin/_components/ThemeToggle';
 import { HeaderMobileMenu } from './HeaderMobileMenu';
 import { HeaderUiProvider } from './HeaderUi';
 import { HeaderSiteMenu } from './HeaderSiteMenu';
-import { cookies } from 'next/headers';
-import { adminAuth } from '@/lib/firebase/admin';
-import { getUser } from '@/lib/firebase/users';
+import { getSessionUser } from '@/lib/auth/sessionUser';
 import { UserRole } from '@/lib/models/User';
 
 const PUBLIC_NAV = [
@@ -42,23 +40,13 @@ export default async function Header() {
   let logoHref = "/";
   let userRole: UserRole | null = null;
 
-  try {
-    const cookieStore = await cookies();
-    const sessionCookie = cookieStore.get("session")?.value;
-
-    if (sessionCookie) {
-      const decodedToken = await adminAuth.verifySessionCookie(sessionCookie, true);
-      const user = await getUser(decodedToken.uid);
-
-      if (user) {
-        userRole = user.role;
-        if (STAFF_ROLES.has(user.role)) {
-          logoHref = "/admin/dashboard";
-        }
-      }
+  // One verification per request, shared with the Footer (#72).
+  const user = await getSessionUser();
+  if (user) {
+    userRole = user.role;
+    if (STAFF_ROLES.has(user.role)) {
+      logoHref = "/admin/dashboard";
     }
-  } catch {
-    // verification failed — treat as anonymous
   }
 
   const isStaff = userRole !== null && STAFF_ROLES.has(userRole);

--- a/components/InterviewScheduler.tsx
+++ b/components/InterviewScheduler.tsx
@@ -329,7 +329,8 @@ export default function InterviewScheduler({
                   >
                     <p className="text-[13px] font-medium" style={{ color: 'var(--status-error-ink)' }}>
                       This interview was cancelled.
-                      {offer.cancelReason && ` Reason: ${offer.cancelReason}`}
+                      {/* The staff-written cancel reason is internal (#75); applicants get fixed copy. */}
+                      {" If you think this is a mistake, reach out to the team."}
                     </p>
                   </div>
                 )}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -8,6 +8,7 @@ import { User, LogOut, LayoutDashboard, LogIn } from "lucide-react";
 import { UserRole } from "@/lib/models/User";
 import { useHeaderUi } from "./HeaderUi";
 import posthog from "posthog-js";
+import { clearAdminAppsCache } from "@/lib/utils/adminCache";
 
 export function LogoutButton() {
   const router = useRouter();
@@ -31,6 +32,7 @@ export function LogoutButton() {
   const handleLogout = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      clearAdminAppsCache(); // #71 — the next account on this browser must not see this one's list
       await signOut();
       await fetch("/api/auth/logout", { method: "POST" });
       posthog.reset();

--- a/hooks/useInterviewData.ts
+++ b/hooks/useInterviewData.ts
@@ -6,7 +6,6 @@ interface InterviewOfferWithSlots {
   status: InterviewEventStatus;
   createdAt: string;
   cancelledAt?: string;
-  cancelReason?: string;
   signupLink?: string;
   configMissing?: boolean;
   error?: string;

--- a/lib/auth/fetcher.ts
+++ b/lib/auth/fetcher.ts
@@ -7,7 +7,7 @@ import { clearAdminAppsCache } from "@/lib/utils/adminCache";
 /**
  * Logs out the user by calling the logout API and redirecting to login.
  */
-async function handleUnauthorized() {
+export async function handleUnauthorized() {
   clearAdminAppsCache(); // #71
   try {
     await fetch("/api/auth/logout", { method: "POST" });

--- a/lib/auth/fetcher.ts
+++ b/lib/auth/fetcher.ts
@@ -2,11 +2,13 @@
  * Auth-aware fetcher for SWR hooks.
  * Automatically handles 401 errors by logging out the user and redirecting to login.
  */
+import { clearAdminAppsCache } from "@/lib/utils/adminCache";
 
 /**
  * Logs out the user by calling the logout API and redirecting to login.
  */
 async function handleUnauthorized() {
+  clearAdminAppsCache(); // #71
   try {
     await fetch("/api/auth/logout", { method: "POST" });
   } catch {

--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -177,6 +177,6 @@ export async function requireStaffForApplication(applicationId: string) {
 export function guardErrorStatus(error: unknown): 401 | 403 | null {
   if (!(error instanceof Error)) return null;
   if (error.message === "Unauthorized") return 401;
-  if (error.message.includes("Forbidden")) return 403;
+  if (error.message.startsWith("Forbidden")) return 403; // every guard message starts with it; lib/logger.ts matches the same way
   return null;
 }

--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -177,6 +177,6 @@ export async function requireStaffForApplication(applicationId: string) {
 export function guardErrorStatus(error: unknown): 401 | 403 | null {
   if (!(error instanceof Error)) return null;
   if (error.message === "Unauthorized") return 401;
-  if (error.message.startsWith("Forbidden")) return 403;
+  if (error.message.includes("Forbidden")) return 403;
   return null;
 }

--- a/lib/auth/guard.ts
+++ b/lib/auth/guard.ts
@@ -45,6 +45,12 @@ export async function requireAdmin() {
       redirect("/auth/login");
     }
 
+    // A Firebase Auth failure — expired or revoked session cookie, malformed
+    // cookie — is an authentication failure: "Unauthorized" → 401 → the
+    // client logs the user out (#59). Anything else (a Firestore read failing)
+    // keeps its message and stays a 500.
+    const code = typeof (error as { code?: unknown })?.code === "string" ? (error as { code: string }).code : "";
+    if (code.startsWith("auth/")) throw new Error("Unauthorized");
     throw new Error(error instanceof Error ? error.message : "Unauthorized");
   }
 }
@@ -92,6 +98,12 @@ export async function requireStaff() {
       redirect("/auth/login");
     }
 
+    // A Firebase Auth failure — expired or revoked session cookie, malformed
+    // cookie — is an authentication failure: "Unauthorized" → 401 → the
+    // client logs the user out (#59). Anything else (a Firestore read failing)
+    // keeps its message and stays a 500.
+    const code = typeof (error as { code?: unknown })?.code === "string" ? (error as { code: string }).code : "";
+    if (code.startsWith("auth/")) throw new Error("Unauthorized");
     throw new Error(error instanceof Error ? error.message : "Unauthorized");
   }
 }
@@ -155,4 +167,16 @@ export async function requireStaffForApplication(applicationId: string) {
   }
 
   return { uid, user, application };
+}
+
+/**
+ * HTTP status for a guard failure, or null when the error is something else.
+ * "Unauthorized" (no/expired/invalid session) is 401 so the client fetcher
+ * logs the user out (#59); "Forbidden…" (wrong role or scope) is 403.
+ */
+export function guardErrorStatus(error: unknown): 401 | 403 | null {
+  if (!(error instanceof Error)) return null;
+  if (error.message === "Unauthorized") return 401;
+  if (error.message.startsWith("Forbidden")) return 403;
+  return null;
 }

--- a/lib/auth/sessionUser.ts
+++ b/lib/auth/sessionUser.ts
@@ -1,0 +1,25 @@
+import { cache } from "react";
+import { cookies } from "next/headers";
+import { adminAuth } from "@/lib/firebase/admin";
+import { getUser } from "@/lib/firebase/users";
+import { User } from "@/lib/models/User";
+
+/**
+ * The signed-in user for the current request, or null. Memoised per request
+ * with React's cache (#72): the Header and the Footer are both async server
+ * components in the root layout, and each used to do its own
+ * revocation-checked session verify plus a user read on every page.
+ * Verification failures are treated as anonymous — the guards on the pages
+ * themselves are the security boundary, not this.
+ */
+export const getSessionUser = cache(async (): Promise<User | null> => {
+  try {
+    const cookieStore = await cookies();
+    const sessionCookie = cookieStore.get("session")?.value;
+    if (!sessionCookie) return null;
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    return (await getUser(decoded.uid)) ?? null;
+  } catch {
+    return null;
+  }
+});

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -324,6 +324,55 @@ export async function updateApplication(
 /**
  * Update just the form data of an application (merge with existing)
  */
+/** Thrown when a guarded update finds the application changed since it was loaded (#66). */
+export class ApplicationConflictError extends Error {
+  constructor() {
+    super("This application changed while you were deciding — reload and try again");
+    this.name = "ApplicationConflictError";
+  }
+}
+
+/**
+ * updateApplication, guarded (#66): the write only lands if the application's
+ * status is still what the caller loaded. Two staff deciding on one applicant
+ * at the same moment used to be last-write-wins with two 200s; now the
+ * second gets a conflict and reloads.
+ */
+export async function updateApplicationIfUnchanged(
+  applicationId: string,
+  updates: Parameters<typeof updateApplication>[1],
+  expect: { status: ApplicationStatus }
+): Promise<Application | null> {
+  const ref = adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId);
+  const found = await adminDb.runTransaction(async (transaction) => {
+    const doc = await transaction.get(ref);
+    if (!doc.exists) return false;
+    if (doc.data()!.status !== expect.status) throw new ApplicationConflictError();
+    const updateData: Record<string, unknown> = { ...updates, updatedAt: FieldValue.serverTimestamp() };
+    if (Array.isArray(updates.interviewOffers)) {
+      updateData.interviewOffers = updates.interviewOffers.map(prepareOfferForFirestore);
+    }
+    if (updates.status === ApplicationStatus.SUBMITTED) {
+      updateData.submittedAt = FieldValue.serverTimestamp();
+    }
+    transaction.update(ref, updateData);
+    return true;
+  });
+  return found ? getApplication(applicationId) : null;
+}
+
+/**
+ * Record a sent email without rewriting the whole list (#64): two runs, or a
+ * run working from a list read minutes earlier, can no longer drop each
+ * other's entries.
+ */
+export async function markEmailSent(applicationId: string, trigger: string): Promise<void> {
+  await adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId).update({
+    emailsSent: FieldValue.arrayUnion(trigger),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+}
+
 export async function updateApplicationFormData(
   applicationId: string,
   formData: Partial<ApplicationFormData>,
@@ -765,7 +814,9 @@ export async function updateInterviewOfferStatus(
  */
 export async function rejectApplicationFromSystems(
   applicationId: string,
-  systems: string[]
+  systems: string[],
+  /** Trial-stage only: which decision day the rejection is released on (#58). Defaults to the step-based inference. */
+  opts: { releaseDay?: 1 | 2 | 3 } = {}
 ): Promise<{ application: Application | null; fullyRejected: boolean }> {
   if (systems.length === 0) {
     const app = await getApplication(applicationId);
@@ -913,7 +964,7 @@ export async function rejectApplicationFromSystems(
           } else if (currentStep === RecruitingStep.RELEASE_DECISIONS_DAY2 || currentStep === RecruitingStep.RELEASE_DECISIONS_DAY3) {
             decisionDay = 3;
           }
-          updateData.trialDecisionDay = decisionDay;
+          updateData.trialDecisionDay = opts.releaseDay ?? decisionDay;
         }
       } else if (existingOffers.length > 0) {
         // Update stage decisions based on whether any interview offers still exist
@@ -1174,7 +1225,9 @@ export async function sweepOnDecisionAdvance(
 export async function respondToCommitment(
   applicationId: string,
   accepted: boolean,
-  reason?: string
+  reason?: string,
+  /** Per-application reasons for the offers declined by a commit, keyed by application id (#65). */
+  declineReasons?: Record<string, string>
 ): Promise<Application | null> {
   const applicationRef = adminDb.collection(APPLICATIONS_COLLECTION).doc(applicationId);
 
@@ -1259,7 +1312,7 @@ export async function respondToCommitment(
             status: ApplicationStatus.DECLINED,
             commitment: {
               accepted: false,
-              reason: "Committed to another team",
+              reason: declineReasons?.[otherDoc.id] || "Committed to another team",
               committedAt: new Date(),
             },
             updatedAt: FieldValue.serverTimestamp(),

--- a/lib/firebase/config.ts
+++ b/lib/firebase/config.ts
@@ -215,7 +215,8 @@ async function questionsDocForWrite(adminId: string): Promise<FirebaseFirestore.
   const ref = adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC);
   const snap = await ref.get();
   if (!snap.exists) {
-    // merge: two first-writers racing must not clobber each other's section
+    // merge, so a racing first writer's section under another key survives
+    // (arrays still replace wholesale — only the seed path, never production)
     await ref.set(stripUndefined({ ...getDefaultApplicationQuestions(), updatedAt: new Date(), updatedBy: adminId }), { merge: true });
   }
   return ref;

--- a/lib/firebase/config.ts
+++ b/lib/firebase/config.ts
@@ -215,7 +215,8 @@ async function questionsDocForWrite(adminId: string): Promise<FirebaseFirestore.
   const ref = adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC);
   const snap = await ref.get();
   if (!snap.exists) {
-    await ref.set(stripUndefined({ ...getDefaultApplicationQuestions(), updatedAt: new Date(), updatedBy: adminId }));
+    // merge: two first-writers racing must not clobber each other's section
+    await ref.set(stripUndefined({ ...getDefaultApplicationQuestions(), updatedAt: new Date(), updatedBy: adminId }), { merge: true });
   }
   return ref;
 }

--- a/lib/firebase/config.ts
+++ b/lib/firebase/config.ts
@@ -108,7 +108,7 @@ export async function updateAnnouncement(message: string, enabled: boolean, admi
 /**
  * Get application questions config from Firestore, falling back to hardcoded defaults
  */
-export async function getApplicationQuestions(): Promise<ApplicationQuestionsConfig> {
+export async function getApplicationQuestions(opts: { strict?: boolean } = {}): Promise<ApplicationQuestionsConfig> {
   try {
     const doc = await adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC).get();
 
@@ -123,6 +123,9 @@ export async function getApplicationQuestions(): Promise<ApplicationQuestionsCon
       };
     }
   } catch (err) {
+    // Write paths read strictly (#61): defaults returned from a transient
+    // read failure would be written back over the live document.
+    if (opts.strict) throw err;
     logger.warn({ err }, "Failed to read application questions config; falling back to defaults");
   }
 
@@ -202,6 +205,22 @@ export async function updateApplicationQuestions(
 }
 
 /**
+ * The section writers below merge into the questions document instead of
+ * read-modify-write (#61): a transient read failure used to hand the writer
+ * the hardcoded defaults, which then replaced the live document wholesale.
+ * The one read left is an existence check, and it throws rather than
+ * defaulting.
+ */
+async function questionsDocForWrite(adminId: string): Promise<FirebaseFirestore.DocumentReference> {
+  const ref = adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    await ref.set(stripUndefined({ ...getDefaultApplicationQuestions(), updatedAt: new Date(), updatedBy: adminId }));
+  }
+  return ref;
+}
+
+/**
  * Update questions for a specific team
  */
 export async function updateTeamQuestions(
@@ -209,18 +228,11 @@ export async function updateTeamQuestions(
   questions: ApplicationQuestion[],
   adminId: string
 ): Promise<void> {
-  const currentConfig = await getApplicationQuestions();
-
-  const data = stripUndefined({
-    ...currentConfig,
-    teamQuestions: {
-      ...currentConfig.teamQuestions,
-      [team]: cleanQuestions(questions),
-    },
-    updatedAt: new Date(),
-    updatedBy: adminId,
-  });
-  await adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC).set(data);
+  const ref = await questionsDocForWrite(adminId);
+  await ref.set(
+    stripUndefined({ teamQuestions: { [team]: cleanQuestions(questions) }, updatedAt: new Date(), updatedBy: adminId }),
+    { merge: true }
+  );
 }
 
 /**
@@ -230,15 +242,11 @@ export async function updateCommonQuestions(
   questions: ApplicationQuestion[],
   adminId: string
 ): Promise<void> {
-  const currentConfig = await getApplicationQuestions();
-
-  const data = stripUndefined({
-    ...currentConfig,
-    commonQuestions: cleanQuestions(questions),
-    updatedAt: new Date(),
-    updatedBy: adminId,
-  });
-  await adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC).set(data);
+  const ref = await questionsDocForWrite(adminId);
+  await ref.set(
+    stripUndefined({ commonQuestions: cleanQuestions(questions), updatedAt: new Date(), updatedBy: adminId }),
+    { merge: true }
+  );
 }
 
 /**
@@ -251,20 +259,12 @@ export async function updateSystemQuestions(
   adminId: string,
   team?: string
 ): Promise<void> {
-  const currentConfig = await getApplicationQuestions();
-
   const key = team ? generateTeamSystemKey(team, systemKeyOrName) : systemKeyOrName;
-
-  const data = stripUndefined({
-    ...currentConfig,
-    systemQuestions: {
-      ...(currentConfig.systemQuestions || {}),
-      [key]: cleanQuestions(questions),
-    },
-    updatedAt: new Date(),
-    updatedBy: adminId,
-  });
-  await adminDb.collection(CONFIG_COLLECTION).doc(QUESTIONS_DOC).set(data);
+  const ref = await questionsDocForWrite(adminId);
+  await ref.set(
+    stripUndefined({ systemQuestions: { [key]: cleanQuestions(questions) }, updatedAt: new Date(), updatedBy: adminId }),
+    { merge: true }
+  );
 }
 
 // Team Descriptions Functions
@@ -322,7 +322,7 @@ export function getDefaultTeamsConfig(): TeamsConfig {
  *  - Subsystems removed from the enum are dropped.
  *  - Existing subsystem descriptions are preserved.
  */
-export async function getTeamsConfig(): Promise<TeamsConfig> {
+export async function getTeamsConfig(opts: { strict?: boolean } = {}): Promise<TeamsConfig> {
   try {
     const doc = await adminDb.collection(CONFIG_COLLECTION).doc(TEAMS_DOC).get();
 
@@ -379,6 +379,7 @@ export async function getTeamsConfig(): Promise<TeamsConfig> {
       };
     }
   } catch (err) {
+    if (opts.strict) throw err; // see getApplicationQuestions (#61)
     logger.warn({ err }, "Failed to read teams config; falling back to default");
   }
 
@@ -393,7 +394,7 @@ export async function updateTeamDescription(
   description: string,
   userId: string
 ): Promise<void> {
-  const currentConfig = await getTeamsConfig();
+  const currentConfig = await getTeamsConfig({ strict: true });
   const now = new Date();
 
   const updatedTeam = {
@@ -424,7 +425,7 @@ export async function updateTeamRejectionMessage(
   rejectionMessage: string,
   userId: string
 ): Promise<void> {
-  const currentConfig = await getTeamsConfig();
+  const currentConfig = await getTeamsConfig({ strict: true });
   const now = new Date();
 
   const updatedTeam = {
@@ -456,7 +457,7 @@ export async function updateSubsystemDescription(
   description: string,
   userId: string
 ): Promise<void> {
-  const currentConfig = await getTeamsConfig();
+  const currentConfig = await getTeamsConfig({ strict: true });
   const now = new Date();
 
   const teamConfig = currentConfig.teams[team];

--- a/lib/utils/adminCache.ts
+++ b/lib/utils/adminCache.ts
@@ -1,0 +1,26 @@
+/**
+ * The admin applications list is cached in localStorage so the sidebar can
+ * paint before the network answers. The key carries the staff member's uid
+ * (#71): one person's list must never seed another person's session on a
+ * shared machine, and logging out (or being logged out by a 401) clears it.
+ */
+export const ADMIN_APPS_CACHE_PREFIX = "admin_applications_cache";
+
+export function adminAppsCacheKey(uid: string): string {
+  return `${ADMIN_APPS_CACHE_PREFIX}:${uid}`;
+}
+
+/** Remove every cached admin list, whichever account wrote it. Safe to call anywhere. */
+export function clearAdminAppsCache(): void {
+  try {
+    if (typeof window === "undefined") return;
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(ADMIN_APPS_CACHE_PREFIX)) keys.push(key);
+    }
+    keys.forEach((key) => localStorage.removeItem(key));
+  } catch {
+    // storage unavailable — nothing to clear
+  }
+}

--- a/lib/utils/appCache.ts
+++ b/lib/utils/appCache.ts
@@ -27,7 +27,12 @@ class AppCache {
   private questions: CacheEntry<ApplicationQuestionsConfig> | null = null;
   private lastInvalidated = 0;
 
-  /** Called after any application or step mutation. Never rate-limited. */
+  /**
+   * Called after any application or step mutation. Never rate-limited.
+   * Nothing server-side caches the list any more; this drops the instance's
+   * cached recruiting step so its next read is fresh — the only cross-instance
+   * refresh we have besides the TTL (the step route re-primes its own).
+   */
   invalidateApplications(): void {
     this.recruitingStep = null;
   }

--- a/lib/utils/appCache.ts
+++ b/lib/utils/appCache.ts
@@ -1,9 +1,16 @@
 import { RecruitingStep, ApplicationQuestionsConfig } from "@/lib/models/Config";
 
 /**
- * Shared in-memory cache for application data and configuration.
- * Using a singleton pattern to ensure the same cache is accessed across different API routes
- * within the same server instance.
+ * Shared in-memory cache for configuration, per server instance (a singleton
+ * across API routes within one instance — on serverless, one instance only,
+ * so an invalidation here never reaches the others; the TTLs bound that).
+ *
+ * What is cached: the recruiting step and the application questions. The
+ * application *list* is not cached here — that cache was dead code (#70).
+ * `invalidateApplications()` is what mutating routes call after a write; it
+ * drops the cached recruiting step (the one thing that made stale reads
+ * visible). The admin "refresh" button goes through `requestRefresh()`, which
+ * is the only thing the 30s cooldown rate-limits.
  */
 
 interface CacheEntry<T> {
@@ -11,50 +18,33 @@ interface CacheEntry<T> {
   timestamp: number;
 }
 
-const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+const CACHE_TTL = 10 * 60 * 1000; // 10 minutes — recruiting step
+const QUESTIONS_TTL = 5 * 60 * 1000; // 5 minutes — a question fix must reach open forms quickly (#60)
 const MIN_INVALIDATION_INTERVAL = 30 * 1000; // 30 seconds
 
 class AppCache {
-  private applications = new Map<string, CacheEntry<any>>();
   private recruitingStep: CacheEntry<RecruitingStep | null> | null = null;
   private questions: CacheEntry<ApplicationQuestionsConfig> | null = null;
   private lastInvalidated = 0;
 
-  /**
-   * Get cached application list for a specific RBAC key
-   */
-  getApplications(key: string): any | null {
-    const cached = this.applications.get(key);
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      console.log(`[Cache HIT] Applications list for key: ${key}`);
-      return cached.data;
-    }
-    console.log(`[Cache MISS] Applications list for key: ${key}`);
-    return null;
+  /** Called after any application or step mutation. Never rate-limited. */
+  invalidateApplications(): void {
+    this.recruitingStep = null;
   }
 
   /**
-   * Set cached application list
+   * The admin refresh button: clears everything this instance holds,
+   * at most once per cooldown.
+   * @returns false when still inside the cooldown (nothing cleared)
    */
-  setApplications(key: string, data: any): void {
-    console.log(`[Cache SET] Applications list for key: ${key}`);
-    this.applications.set(key, { data, timestamp: Date.now() });
-  }
-
-  /**
-   * Clear all application caches
-   * @returns true if invalidated, false if skipped due to cooldown
-   */
-  invalidateApplications(): boolean {
+  requestRefresh(): boolean {
     const now = Date.now();
     if (now - this.lastInvalidated < MIN_INVALIDATION_INTERVAL) {
-      console.log(`[Cache INVALIDATE] Skipped - within ${MIN_INVALIDATION_INTERVAL / 1000}s cooldown`);
       return false;
     }
-
-    console.log(`[Cache INVALIDATE] Clearing all application list caches`);
-    this.applications.clear();
     this.lastInvalidated = now;
+    this.recruitingStep = null;
+    this.questions = null;
     return true;
   }
 
@@ -90,7 +80,7 @@ class AppCache {
    * Get cached questions
    */
   getQuestions(): ApplicationQuestionsConfig | null {
-    if (this.questions && Date.now() - this.questions.timestamp < CACHE_TTL) {
+    if (this.questions && Date.now() - this.questions.timestamp < QUESTIONS_TTL) {
       console.log(`[Cache HIT] Application Questions`);
       return this.questions.data;
     }

--- a/lib/utils/formAnswers.ts
+++ b/lib/utils/formAnswers.ts
@@ -95,30 +95,35 @@ export function getCommonAnswer(
  * `"  spaces  "`, …) from someone poking the API. Named fields must be strings;
  * the two answer bags keep only string values.
  */
+// Hard caps (#74), far above anything the form allows (word limits top out
+// around 3,500 characters; URLs are shorter still): an applicant cannot grow
+// their document toward Firestore's 1 MB limit over successive autosaves.
+export const MAX_ANSWER_CHARS = 20_000;
+export const MAX_BAG_ENTRIES = 100;
+export const MAX_QUESTION_ID_CHARS = 64;
+
 export function sanitizeIncomingFormData(
   input: unknown
 ): Partial<ApplicationFormData> {
   if (!input || typeof input !== "object" || Array.isArray(input)) return {};
-
   const raw = input as Record<string, unknown>;
   const out: Record<string, unknown> = {};
-
+  const clip = (v: string) => (v.length > MAX_ANSWER_CHARS ? v.slice(0, MAX_ANSWER_CHARS) : v);
   const NAMED_WRITABLE = [...NAMED_COMMON_FIELDS, "portfolioUrl"] as const;
   for (const field of NAMED_WRITABLE) {
-    if (typeof raw[field] === "string") out[field] = raw[field];
+    if (typeof raw[field] === "string") out[field] = clip(raw[field] as string);
   }
-
   for (const bag of ["teamQuestions", "customAnswers"] as const) {
     const value = raw[bag];
     if (value && typeof value === "object" && !Array.isArray(value)) {
       out[bag] = Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).filter(
-          ([, v]) => typeof v === "string"
-        )
+        Object.entries(value as Record<string, unknown>)
+          .filter(([k, v]) => typeof v === "string" && k.length <= MAX_QUESTION_ID_CHARS)
+          .slice(0, MAX_BAG_ENTRIES)
+          .map(([k, v]) => [k, clip(v as string)])
       );
     }
   }
-
   return out as Partial<ApplicationFormData>;
 }
 

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -272,6 +272,9 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
   // Hide interview offers until they are released
   if (!isAtOrPast(step, RecruitingStep.RELEASE_INTERVIEWS)) {
     delete sanitized.interviewOffers;
+  } else if (sanitized.interviewOffers) {
+    // The cancel reason is a staff note (#75); the applicant sees fixed copy.
+    sanitized.interviewOffers = sanitized.interviewOffers.map(({ cancelReason: _internal, ...offer }) => offer);
   }
 
   // Hide trial offers until they are released
@@ -279,8 +282,15 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     delete sanitized.trialOffers;
   }
 
-  // Hide final acceptance offer until decisions are released
-  if (!isAtOrPast(step, RecruitingStep.RELEASE_DECISIONS_DAY1)) {
+  // Hide the final acceptance offer until ITS release day (#58): a Day-2
+  // acceptance used to ride along in Day-1 payloads while the status still
+  // read "Trial Workday".
+  const offerDayStep: Record<1 | 2 | 3, RecruitingStep> = {
+    1: RecruitingStep.RELEASE_DECISIONS_DAY1,
+    2: RecruitingStep.RELEASE_DECISIONS_DAY2,
+    3: RecruitingStep.RELEASE_DECISIONS_DAY3,
+  };
+  if (!isAtOrPast(step, offerDayStep[(app.trialDecisionDay || 1) as 1 | 2 | 3])) {
     delete sanitized.offer;
   }
   

--- a/lib/utils/statusUtils.ts
+++ b/lib/utils/statusUtils.ts
@@ -26,6 +26,11 @@ function getStepIndex(step: RecruitingStep): number {
 /**
  * Check if we're at or past a given step.
  */
+/** A stored decision day outside 1–3 must fail closed (day 1 semantics), never index to undefined. */
+export function clampDecisionDay(day: unknown): 1 | 2 | 3 {
+  return day === 2 || day === 3 ? day : 1;
+}
+
 export function isAtOrPast(currentStep: RecruitingStep | null | undefined, targetStep: RecruitingStep): boolean {
   if (!currentStep) return false;
   return getStepIndex(currentStep) >= getStepIndex(targetStep);
@@ -128,7 +133,7 @@ export function getUserVisibleStatus(
 
   // Trial decision visible based on which day the decision was made
   // Day 1 decisions visible at DAY1+, Day 2 decisions visible at DAY2+, Day 3 decisions visible at DAY3+
-  const trialDecisionDay = app.trialDecisionDay || 1; // Default to day 1 for backwards compatibility
+  const trialDecisionDay = clampDecisionDay(app.trialDecisionDay); // Default to day 1 for backwards compatibility
 
   // Map decision day to the recruiting step when it becomes visible
   const dayToStep: Record<1 | 2 | 3, RecruitingStep> = {
@@ -290,7 +295,7 @@ export function sanitizeApplicationForApplicant(app: Application, step: Recruiti
     2: RecruitingStep.RELEASE_DECISIONS_DAY2,
     3: RecruitingStep.RELEASE_DECISIONS_DAY3,
   };
-  if (!isAtOrPast(step, offerDayStep[(app.trialDecisionDay || 1) as 1 | 2 | 3])) {
+  if (!isAtOrPast(step, offerDayStep[clampDecisionDay(app.trialDecisionDay)])) {
     delete sanitized.offer;
   }
   

--- a/scripts/qa/backlog-regress.mjs
+++ b/scripts/qa/backlog-regress.mjs
@@ -1,0 +1,255 @@
+// QA backlog sweep (#58 #59 #60 #61 #62 #64 #65 #66 #70 #72 #73 #74 #75):
+// release-day tagging and per-day offer masking, expired sessions as 401s,
+// cookie lifetime in seconds, question-cache invalidation and merge writes,
+// other-team masking for non-admins, the one-run-at-a-time email lock, a
+// single-request commit that declines the rest server-side, the
+// conflict-guarded status write, the real refresh cooldown, one session
+// verification per page, config-keyed CSV columns, form-data size caps, and
+// the staff cancel reason staying internal. Emulator only.
+//
+// Run against the emulator suite with the dev server up (README: local development):
+//   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/backlog-regress.mjs
+// Refuses to run without both emulator vars, so it can never touch production.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const admin = require("firebase-admin");
+const { getFirestore } = require("firebase-admin/firestore");
+for (const v of ["FIRESTORE_EMULATOR_HOST", "FIREBASE_AUTH_EMULATOR_HOST"]) { if (!process.env[v]) { console.error(`refusing: ${v} not set`); process.exit(1); } }
+admin.initializeApp({ projectId: "demo-lhr-recruiting" });
+const db = getFirestore(); const auth = admin.auth();
+const BASE = "http://localhost:3000";
+const IDP = "http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake";
+const results = [];
+const check = (name, ok, detail = "") => { results.push(ok); console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  -- " + detail : ""}`); };
+async function ensureUser({ uid, email, name, role, memberProfile }) {
+  try { await auth.importUsers([{ uid, email, emailVerified: true, displayName: name, providerData: [{ uid: email, email, displayName: name, providerId: "google.com" }] }]); } catch {}
+  await db.doc(`users/${uid}`).set({ uid, email, name, role, blacklisted: false, applications: [], phoneNumber: null, isMember: !!memberProfile, ...(memberProfile ? { memberProfile } : {}) }, { merge: true });
+}
+async function sessionResponse(email) {
+  const r1 = await fetch(IDP, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ postBody: "id_token=" + encodeURIComponent(JSON.stringify({ sub: email, email, email_verified: true, name: email })) + "&providerId=google.com", requestUri: BASE, returnSecureToken: true }) });
+  const j1 = await r1.json(); if (!j1.idToken) throw new Error("idp failed");
+  const r2 = await fetch(`${BASE}/api/auth/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ idToken: j1.idToken }) });
+  if (r2.status !== 200) throw new Error(`session ${email} -> ${r2.status}`);
+  return r2;
+}
+async function session(email) { return (await sessionResponse(email)).headers.getSetCookie().map((c) => c.split(";")[0]).join("; "); }
+async function api(cookie, method, path, body) {
+  const r = await fetch(BASE + path, { method, headers: { "Content-Type": "application/json", cookie }, body: body ? JSON.stringify(body) : undefined });
+  let j = null; try { j = await r.json(); } catch {}
+  return { status: r.status, json: j };
+}
+const now = () => new Date();
+const get = async (id) => (await db.doc(`applications/${id}`).get()).data();
+const setStep = (c, step) => api(c, "POST", "/api/admin/config/recruiting", { step, confirm: step });
+const err = (r) => `${r.status} ${r.json?.error || ""}`;
+const status = (c, id, body) => api(c, "POST", `/api/admin/applications/${id}/status`, body);
+const off = (system, st = "pending", extra = {}) => ({ system, status: st, createdAt: now(), ...extra });
+const COMPLETE = { whyJoin: "why", relevantExperience: "exp", availability: "5551234567", graduationYear: "2029", major: "ME", resumeUrl: "https://example.test/resume.pdf", portfolioUrl: "", teamQuestions: { electric_skills: "skills" }, customAnswers: {} };
+
+await ensureUser({ uid: "u-bl-app", email: "bl-app@utexas.edu", name: "Backlog Applicant", role: "applicant" });
+await ensureUser({ uid: "u-bl-app2", email: "bl-app2@utexas.edu", name: "Backlog Committer", role: "applicant" });
+await ensureUser({ uid: "u-bl-lead", email: "bl-lead@utexas.edu", name: "Body Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
+const adminC = await session("admin@utexas.edu"), appC = await session("bl-app@utexas.edu"), app2C = await session("bl-app2@utexas.edu"), leadC = await session("bl-lead@utexas.edu");
+const mk = async (id, uid, team, systems, st, extra = {}) => { await db.doc(`applications/${id}`).set({ userId: uid, userEmail: `${uid.replace("u-", "")}@utexas.edu`, userName: uid, team, preferredSystems: systems, status: st, formData: COMPLETE, createdAt: now(), updatedAt: now(), ...(st !== "in_progress" ? { submittedAt: now() } : {}), ...extra }); };
+let r;
+
+// ---- #59: an authentication failure is a 401 (the fetcher logs out on 401, not 403) ----
+r = await api("", "GET", "/api/admin/applications?all=true");
+check("#59 no session cookie on an admin route -> 401", r.status === 401, err(r));
+r = await api("session=not-a-real-cookie", "GET", "/api/admin/applications?all=true");
+check("#59 an unverifiable session cookie -> 401, not 500", r.status === 401, err(r));
+r = await api("session=not-a-real-cookie", "GET", "/api/admin/config/recruiting");
+check("#59 same on a config route", r.status === 401, err(r));
+r = await api("session=not-a-real-cookie", "POST", "/api/admin/applications/refresh");
+check("#59 and on a POST", r.status === 401, err(r));
+r = await api(appC, "GET", "/api/admin/applications?all=true");
+check("#59 a signed-in applicant is still a 403 (authorisation, not authentication)", r.status === 403, err(r));
+{
+  const res = await sessionResponse("bl-app@utexas.edu");
+  const cookies = res.headers.getSetCookie();
+  const sessionCookie = cookies.find((c) => c.startsWith("session=")) || "";
+  const roleCookie = cookies.find((c) => c.startsWith("user_role=")) || "";
+  check("#59 session cookie Max-Age is seconds (5 days = 432000), not milliseconds", /max-age=432000(;|$)/i.test(sessionCookie), sessionCookie.replace(/^session=[^;]*/, "session=…"));
+  check("#59 session cookie is SameSite=Lax", /samesite=lax/i.test(sessionCookie), sessionCookie.replace(/^session=[^;]*/, "session=…"));
+  check("#59 user_role cookie carries the same lifetime", /max-age=432000(;|$)/i.test(roleCookie), roleCookie);
+}
+
+// ---- #74: form-data size caps (applications open) ----
+r = await setStep(adminC, "open"); check("step -> open", r.status === 200, err(r));
+await mk("bl-cap", "u-bl-app", "Electric", ["Body", "Dynamics"], "submitted");
+await db.doc("users/u-bl-app").set({ applications: ["bl-cap"] }, { merge: true });
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { whyJoin: "x".repeat(30_000) } });
+let d = await get("bl-cap");
+check("#74 a 30k-character answer saves clipped to 20k", r.status === 200 && d.formData.whyJoin.length === 20_000, `${err(r)} len=${d.formData.whyJoin?.length}`);
+const bag = Object.fromEntries(Array.from({ length: 150 }, (_, i) => [`k${i}`, "v"]));
+bag["k".repeat(80)] = "long key";
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { customAnswers: bag } });
+d = await get("bl-cap");
+check("#74 customAnswers capped at 100 entries; an 80-char key is dropped", r.status === 200 && Object.keys(d.formData.customAnswers).length === 100 && !("k".repeat(80) in d.formData.customAnswers), `${err(r)} n=${Object.keys(d.formData.customAnswers || {}).length}`);
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { whyJoin: "normal", customAnswers: { q_1: "fine" } } });
+d = await get("bl-cap");
+check("#74 ordinary answers are untouched", r.status === 200 && d.formData.whyJoin === "normal" && d.formData.customAnswers.q_1 === "fine", err(r));
+
+// ---- #62: other-team badges are masked for non-admins ----
+await mk("bl-e", "u-bl-app", "Electric", ["Body"], "submitted", { originalPreferredSystems: ["Body", "Dynamics"], formData: { ...COMPLETE, teamQuestions: { electric_skills: "skills-bl-e" } } });
+await mk("bl-s", "u-bl-app", "Solar", ["Aerodynamics"], "waitlisted", { trialDecision: "waitlisted", waitlistSystem: "Aerodynamics" });
+await db.doc("users/u-bl-app").set({ applications: ["bl-cap", "bl-e", "bl-s"] }, { merge: true });
+r = await api(leadC, "GET", "/api/admin/applications?all=true");
+let row = (r.json?.applications || []).find((a) => a.id === "bl-e");
+let other = row?.otherTeams?.find((o) => o.team === "Solar");
+check("#62 lead sees the other-team badge…", r.status === 200 && !!other, `${err(r)} ${JSON.stringify(row?.otherTeams)}`);
+check("#62 …with the waitlist masked as 'inactive' and no application id", !!other && other.status === "inactive" && !("id" in other), JSON.stringify(other));
+r = await api(adminC, "GET", "/api/admin/applications/bl-e/related");
+other = (r.json?.applications || []).find((o) => o.team === "Solar");
+check("#62 admin sees the real status and the id (related route; the admin list already holds every team)", r.status === 200 && !!other && other.status === "waitlisted" && other.id === "bl-s", `${err(r)} ${JSON.stringify(other)}`);
+r = await api(leadC, "GET", "/api/admin/applications/bl-e/related");
+other = (r.json?.applications || []).find((o) => o.team === "Solar");
+check("#62 the related route masks the same way for a lead", r.status === 200 && !!other && other.status === "inactive" && !("id" in other), `${err(r)} ${JSON.stringify(other)}`);
+
+// ---- #75: the staff cancel reason never reaches the applicant ----
+r = await setStep(adminC, "interviewing"); check("step -> interviewing", r.status === 200, err(r));
+await db.doc("applications/bl-e").set({ status: "interview", reviewDecision: "advanced", interviewOffers: [off("Body", "cancelled", { cancelledAt: now(), cancelReason: "rude in the hallway" }), off("Dynamics")] }, { merge: true });
+r = await api(appC, "GET", "/api/applications/bl-e");
+{
+  const offers = r.json?.application?.interviewOffers || [];
+  const cancelled = offers.find((o) => o.system === "Body");
+  check("#75 applicant payload carries the cancelled offer without its cancelReason", r.status === 200 && offers.length === 2 && cancelled?.status === "cancelled" && !("cancelReason" in cancelled), `${err(r)} ${JSON.stringify(cancelled)}`);
+}
+r = await api(adminC, "GET", "/api/admin/applications/bl-e/details");
+check("#75 staff still see the reason", r.status === 200 && (r.json?.application?.interviewOffers || []).some((o) => o.cancelReason === "rude in the hallway"), err(r));
+
+// ---- #58: release day is chosen, not inferred; offers unmask on their own day ----
+r = await setStep(adminC, "trial_workday"); check("step -> trial_workday", r.status === 200, err(r));
+const trialFixture = (systems) => ({ reviewDecision: "advanced", interviewDecision: "advanced", interviewOffers: systems.map((s) => off(s, "completed")), trialOffers: systems.map((s) => off(s, "pending", { accepted: true })) });
+await mk("bl-acc", "u-bl-app2", "Electric", ["Dynamics"], "trial", trialFixture(["Dynamics"]));
+await mk("bl-wl", "u-bl-app2", "Combustion", ["Aerodynamics"], "trial", trialFixture(["Aerodynamics"]));
+await mk("bl-inf", "u-bl-app", "Electric", ["Dynamics"], "trial", trialFixture(["Dynamics"]));
+await mk("bl-rej", "u-bl-app", "Combustion", ["Aerodynamics"], "trial", trialFixture(["Aerodynamics"]));
+await mk("bl-acc-solar", "u-bl-app2", "Solar", ["Aerodynamics"], "accepted", { ...trialFixture(["Aerodynamics"]), trialDecision: "advanced", trialDecisionDay: 1, offer: { system: "Aerodynamics", role: "Member", issuedAt: now() } });
+await db.doc("users/u-bl-app2").set({ applications: ["bl-acc", "bl-wl", "bl-acc-solar"] }, { merge: true });
+await db.doc("users/u-bl-app").set({ applications: ["bl-cap", "bl-e", "bl-s", "bl-inf", "bl-rej"] }, { merge: true });
+r = await status(adminC, "bl-acc", { status: "accepted", offer: { system: "Dynamics", role: "Member", details: "" }, releaseDay: 2 });
+d = await get("bl-acc");
+check("#58 accept with releaseDay 2 during trial_workday -> tagged day 2 (inference said 1)", r.status === 200 && d.status === "accepted" && d.trialDecisionDay === 2 && d.offer?.system === "Dynamics", `${err(r)} day=${d.trialDecisionDay}`);
+r = await status(adminC, "bl-wl", { status: "waitlisted", offer: { system: "Aerodynamics", details: "" }, releaseDay: 5 });
+check("#58 releaseDay 5 -> 400, nothing written", r.status === 400 && (await get("bl-wl")).status === "trial", err(r));
+r = await status(adminC, "bl-wl", { status: "waitlisted", offer: { system: "Aerodynamics", details: "" }, releaseDay: 3 });
+d = await get("bl-wl");
+check("#58 waitlist with releaseDay 3 -> day 3", r.status === 200 && d.status === "waitlisted" && d.trialDecisionDay === 3, `${err(r)} day=${d.trialDecisionDay}`);
+r = await status(adminC, "bl-inf", { status: "accepted", offer: { system: "Dynamics", role: "Member", details: "" } });
+d = await get("bl-inf");
+check("#58 no releaseDay -> the step-based default (day 1) still applies", r.status === 200 && d.trialDecisionDay === 1, `${err(r)} day=${d.trialDecisionDay}`);
+r = await api(adminC, "POST", "/api/admin/applications/bl-rej/reject", { systems: ["Aerodynamics"], releaseDay: 3 });
+d = await get("bl-rej");
+check("#58 a trial-stage rejection takes releaseDay too", r.status === 200 && d.status === "rejected" && d.trialDecision === "rejected" && d.trialDecisionDay === 3, `${err(r)} ${d.status} day=${d.trialDecisionDay}`);
+r = await api(adminC, "POST", "/api/admin/applications/bl-rej/reject", { systems: ["Aerodynamics"], releaseDay: 0 });
+check("#58 reject with releaseDay 0 -> 400", r.status === 400, err(r));
+// masking: a day-2 acceptance during trial_workday and on day 1
+r = await api(app2C, "GET", "/api/applications/bl-acc");
+check("#58 trial_workday: applicant sees no acceptance and no offer", r.status === 200 && r.json?.application?.status !== "accepted" && !("offer" in (r.json?.application || {})), `${err(r)} ${r.json?.application?.status} offer=${"offer" in (r.json?.application || {})}`);
+r = await setStep(adminC, "release_decisions_day1"); check("step -> release_decisions_day1", r.status === 200, err(r));
+r = await api(app2C, "GET", "/api/applications/bl-acc");
+check("#58 day 1: a day-2 acceptance is still masked AND its offer is absent from the payload (the leak)", r.status === 200 && r.json?.application?.status !== "accepted" && !("offer" in (r.json?.application || {})), `${err(r)} ${r.json?.application?.status} offer=${"offer" in (r.json?.application || {})}`);
+r = await api(app2C, "GET", "/api/applications/bl-acc-solar");
+check("#58 day 1: a day-1 acceptance is visible with its offer", r.status === 200 && r.json?.application?.status === "accepted" && r.json?.application?.offer?.system === "Aerodynamics", `${err(r)} ${r.json?.application?.status}`);
+r = await api(app2C, "POST", "/api/applications/bl-acc/commit", { accepted: true });
+check("#58 day 1: the masked day-2 offer cannot be committed to", r.status === 400 && (await get("bl-acc")).status === "accepted", err(r));
+// An uncommitted day-1 offer expires when day 2 opens (the transition sweep) —
+// keep the Solar acceptance alive for the commit test by making it a day-2 offer too.
+await db.doc("applications/bl-acc-solar").set({ trialDecisionDay: 2 }, { merge: true });
+r = await setStep(adminC, "release_decisions_day2"); check("step -> release_decisions_day2", r.status === 200, err(r));
+r = await api(app2C, "GET", "/api/applications/bl-acc");
+check("#58 day 2: the day-2 acceptance and its offer are visible", r.status === 200 && r.json?.application?.status === "accepted" && r.json?.application?.offer?.system === "Dynamics", `${err(r)} ${r.json?.application?.status}`);
+
+// ---- #65: one commit request declines the other offers server-side, with reasons ----
+r = await api(app2C, "POST", "/api/applications/bl-acc/commit", { accepted: true, declineReasons: { "bl-acc-solar": "  Chose Electric  ", "nope": "ignored", "bl-wl": 42 } });
+d = await get("bl-acc"); let ds = await get("bl-acc-solar");
+check("#65 commit -> 200; chosen application committed", r.status === 200 && d.status === "committed" && d.commitment?.accepted === true, `${err(r)} ${d.status}`);
+check("#65 the other accepted offer is declined in the same transaction, with the applicant's reason", ds.status === "declined" && ds.commitment?.accepted === false && ds.commitment?.reason === "Chose Electric", `${ds.status} ${JSON.stringify(ds.commitment)}`);
+check("#65 the waitlisted application is untouched", (await get("bl-wl")).status === "waitlisted");
+check("#65 commit response is sanitised (no decisions)", r.json?.application && !("trialDecision" in r.json.application) && !("aggregateRatings" in r.json.application));
+
+// ---- #66: two staff deciding on one applicant at the same moment ----
+r = await setStep(adminC, "trial_workday"); check("step -> trial_workday (race fixture)", r.status === 200, err(r));
+await mk("bl-race", "u-bl-app", "Electric", ["Body", "Dynamics"], "trial", trialFixture(["Body", "Dynamics"]));
+{
+  const [a, b] = await Promise.all([
+    status(adminC, "bl-race", { status: "accepted", offer: { system: "Body", role: "Member", details: "" } }),
+    status(adminC, "bl-race", { status: "waitlisted", offer: { system: "Dynamics", details: "" } }),
+  ]);
+  const final = await get("bl-race");
+  const codes = [a.status, b.status];
+  const oneWon = codes.filter((c) => c === 200).length === 1 && codes.includes(409);
+  const winnerMatches = a.status === 200 ? final.status === "accepted" && final.offer?.system === "Body" : final.status === "waitlisted" && !final.offer;
+  const serialised = a.status === 200 && b.status === 200 && final.status === "waitlisted" && !final.offer;
+  check("#66 concurrent accept + waitlist: one 200 and one 409 with the winner's state, or a clean serial rescind — never two silent 200s over each other", (oneWon && winnerMatches) || serialised, `codes=${codes.join(",")} final=${final.status} offer=${JSON.stringify(final.offer || null)} ${a.json?.error || ""} ${b.json?.error || ""}`);
+  if (codes.includes(409)) check("#66 the 409 says what to do", /reload/i.test((a.status === 409 ? a : b).json?.error || ""), (a.status === 409 ? a : b).json?.error);
+}
+
+// ---- #64: one email run at a time ----
+await db.doc("config/email_run_lock").set({ by: "someone-else", step: "trial_workday", startedAt: now(), lockedUntil: new Date(Date.now() + 10 * 60 * 1000) });
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"] });
+check("#64 a run while another holds the lock -> 409", r.status === 409 && /already in progress/i.test(r.json?.error || ""), err(r));
+check("#64 the refused run leaves the holder's lock alone", (await db.doc("config/email_run_lock").get()).data()?.by === "someone-else");
+await db.doc("config/email_run_lock").set({ by: "crashed-tab", step: "trial_workday", startedAt: new Date(Date.now() - 60 * 60 * 1000), lockedUntil: new Date(Date.now() - 45 * 60 * 1000) });
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"] });
+check("#64 an expired lock (a run that died) does not block; the run proceeds", r.status !== 409, err(r));
+check("#64 the lock is released when the run ends", !(await db.doc("config/email_run_lock").get()).exists);
+
+// ---- #70: the refresh cooldown the button reports is the one the POST enforces ----
+r = await api(adminC, "POST", "/api/admin/applications/refresh");
+const first = r.status;
+r = await api(adminC, "POST", "/api/admin/applications/refresh");
+check("#70 a second refresh inside the cooldown -> 429 with the seconds left", r.status === 429 && r.json?.cooldownRemaining >= 1, `first=${first} then ${err(r)} remaining=${r.json?.cooldownRemaining}`);
+r = await api(adminC, "GET", "/api/admin/applications/refresh");
+check("#70 GET reports the same cooldown (was hardcoded 0)", r.status === 200 && r.json?.cooldownRemaining >= 1 && r.json?.canRefresh === false, JSON.stringify(r.json));
+
+// ---- #73: CSV columns come from the config ----
+{
+  const res = await fetch(`${BASE}/api/admin/applications/export-csv`, { method: "POST", headers: { "Content-Type": "application/json", cookie: adminC }, body: JSON.stringify({ teams: ["Electric"] }) });
+  const text = await res.text();
+  const parse = (line) => { const out = []; let cur = "", q = false; for (let i = 0; i < line.length; i++) { const ch = line[i]; if (q) { if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; } else if (ch === '"') q = false; else cur += ch; } else if (ch === '"') q = true; else if (ch === ",") { out.push(cur); cur = ""; } else cur += ch; } out.push(cur); return out; };
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const header = parse(lines[0]);
+  const skillsCol = header.indexOf("Electric Q: What relevant electrical/software skills do you have?");
+  const origCol = header.indexOf("Original Preferred Systems");
+  check("#73 export -> 200 text/csv", res.status === 200 && /text\/csv/.test(res.headers.get("content-type") || ""), `${res.status} ${res.headers.get("content-type")}`);
+  check("#73 header has a config-labelled column per team question, no 'Team Question 1/2'", skillsCol >= 0 && !header.includes("Team Question 1") && !header.includes("Team Question 2"), header.filter((h) => /Q:|Team Question/.test(h)).join(" | "));
+  check("#73 header has 'Original Preferred Systems'", origCol >= 0);
+  const rowE = lines.map(parse).find((cells) => cells.includes("skills-bl-e"));
+  check("#73 the row's team answer sits under its own question's column", !!rowE && rowE[skillsCol] === "skills-bl-e", rowE ? `got=${JSON.stringify(rowE[skillsCol])}` : "row bl-e not found");
+  check("#73 original ranking exported even after it was narrowed", !!rowE && rowE[origCol] === "Body; Dynamics", rowE ? JSON.stringify(rowE[origCol]) : "");
+}
+
+// ---- #60/#61: question edits reach the applicant route at once; writes merge ----
+{
+  r = await api(adminC, "GET", "/api/admin/config/questions");
+  const original = r.json?.config?.teamQuestions?.Electric || [];
+  check("#60 admin can read the questions config", r.status === 200 && original.length > 0, err(r));
+  const edited = original.map((q, i) => (i === 0 ? { ...q, label: "Skills (edited by backlog-regress)" } : q));
+  r = await api(adminC, "PUT", "/api/admin/config/questions", { scope: "team", team: "Electric", questions: edited });
+  check("#60 PUT team questions -> 200", r.status === 200, err(r));
+  r = await api(adminC, "GET", "/api/questions?team=Electric");
+  check("#60 the public questions route serves the edit immediately (server cache invalidated)", r.status === 200 && r.json?.teamQuestions?.[0]?.label === "Skills (edited by backlog-regress)", `${err(r)} ${r.json?.teamQuestions?.[0]?.label}`);
+  check("#61 the section write merged: common questions still present alongside", Array.isArray(r.json?.commonQuestions) && r.json.commonQuestions.length > 0, `common=${r.json?.commonQuestions?.length}`);
+  const doc = (await db.doc("config/application_questions").get()).data();
+  check("#61 the stored document keeps every section (no wholesale replace)", !!doc && Array.isArray(doc.commonQuestions) && doc.commonQuestions.length > 0 && !!doc.teamQuestions?.Electric && !!doc.teamQuestions?.Solar, `sections=${Object.keys(doc || {}).join(",")}`);
+  r = await api(adminC, "PUT", "/api/admin/config/questions", { scope: "team", team: "Electric", questions: original });
+  r = await api(adminC, "GET", "/api/questions?team=Electric");
+  check("#60 restored", r.json?.teamQuestions?.[0]?.label === original[0].label);
+  check("#60 public questions route caches for minutes, not hours", /s-maxage=300\b/.test((await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control") || ""), (await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control"));
+}
+
+// ---- #72: a page render with a staff session still works (one verification, shared by Header and Footer) ----
+{
+  const res = await fetch(`${BASE}/`, { headers: { cookie: adminC } });
+  const html = await res.text();
+  check("#72 home renders for staff with the admin logo link", res.status === 200 && html.includes('href="/admin/dashboard"'), `${res.status}`);
+  const anon = await fetch(`${BASE}/`);
+  check("#72 and anonymously", anon.status === 200 && !(await anon.text()).includes('href="/admin/dashboard"'), `${anon.status}`);
+}
+
+await setStep(adminC, "open");
+const passed = results.filter(Boolean).length;
+console.log(`\n${passed}/${results.length} checks passed`);
+process.exit(passed === results.length ? 0 : 1);

--- a/scripts/qa/backlog-regress.mjs
+++ b/scripts/qa/backlog-regress.mjs
@@ -64,6 +64,8 @@ r = await api("session=not-a-real-cookie", "POST", "/api/admin/applications/refr
 check("#59 and on a POST", r.status === 401, err(r));
 r = await api(appC, "GET", "/api/admin/applications?all=true");
 check("#59 a signed-in applicant is still a 403 (authorisation, not authentication)", r.status === 403, err(r));
+r = await api("session=not-a-real-cookie", "POST", "/api/applications/whatever/commit", { accepted: true });
+check("#59 the commit route: a dead cookie is a 401, not a 400 carrying Firebase's message", r.status === 401 && r.json?.error === "Unauthorized", err(r));
 {
   const res = await sessionResponse("bl-app@utexas.edu");
   const cookies = res.headers.getSetCookie();
@@ -89,6 +91,10 @@ check("#74 customAnswers capped at 100 entries; an 80-char key is dropped", r.st
 r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { whyJoin: "normal", customAnswers: { q_1: "fine" } } });
 d = await get("bl-cap");
 check("#74 ordinary answers are untouched", r.status === 200 && d.formData.whyJoin === "normal" && d.formData.customAnswers.q_1 === "fine", err(r));
+const huge = Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`h${i}`, "y".repeat(19_000)]));
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { customAnswers: huge } });
+d = await get("bl-cap");
+check("#74 a payload that would approach Firestore's 1 MB limit -> 400, nothing written", r.status === 400 && d.formData.customAnswers.q_1 === "fine" && Object.keys(d.formData.customAnswers).length === 1, `${err(r)} n=${Object.keys(d.formData.customAnswers || {}).length}`);
 
 // ---- #62: other-team badges are masked for non-admins ----
 await mk("bl-e", "u-bl-app", "Electric", ["Body"], "submitted", { originalPreferredSystems: ["Body", "Dynamics"], formData: { ...COMPLETE, teamQuestions: { electric_skills: "skills-bl-e" } } });
@@ -117,6 +123,8 @@ r = await api(appC, "GET", "/api/applications/bl-e");
 }
 r = await api(adminC, "GET", "/api/admin/applications/bl-e/details");
 check("#75 staff still see the reason", r.status === 200 && (r.json?.application?.interviewOffers || []).some((o) => o.cancelReason === "rude in the hallway"), err(r));
+r = await api(appC, "GET", "/api/applications/bl-e/interview");
+check("#75 the scheduler's own route (what the applicant UI reads) carries no cancelReason either", r.status === 200 && (r.json?.offers || []).length === 2 && r.json.offers.every((o) => !("cancelReason" in o)), `${err(r)} ${JSON.stringify(r.json?.offers?.map((o) => Object.keys(o)))}`);
 
 // ---- #58: release day is chosen, not inferred; offers unmask on their own day ----
 r = await setStep(adminC, "trial_workday"); check("step -> trial_workday", r.status === 200, err(r));
@@ -144,6 +152,13 @@ d = await get("bl-rej");
 check("#58 a trial-stage rejection takes releaseDay too", r.status === 200 && d.status === "rejected" && d.trialDecision === "rejected" && d.trialDecisionDay === 3, `${err(r)} ${d.status} day=${d.trialDecisionDay}`);
 r = await api(adminC, "POST", "/api/admin/applications/bl-rej/reject", { systems: ["Aerodynamics"], releaseDay: 0 });
 check("#58 reject with releaseDay 0 -> 400", r.status === 400, err(r));
+await mk("bl-strag", "u-bl-app", "Electric", ["Dynamics"], "submitted");
+r = await status(adminC, "bl-strag", { status: "rejected", releaseDay: 2 });
+check("#58 releaseDay on a non-trial decision (a straggler still at review) -> 400, nothing written", r.status === 400 && /trial-stage/.test(r.json?.error || "") && (await get("bl-strag")).status === "submitted", err(r));
+r = await api(adminC, "POST", "/api/admin/applications/bl-strag/reject", { systems: ["Dynamics"], releaseDay: 2 });
+check("#58 same via /reject", r.status === 400 && (await get("bl-strag")).status === "submitted", err(r));
+r = await status(adminC, "bl-wl", { status: "accepted", offer: { system: "Aerodynamics", role: "Member", details: "" }, releaseDay: true });
+check("#58 releaseDay: true -> 400 (not coerced to 1)", r.status === 400 && (await get("bl-wl")).status === "waitlisted", err(r));
 // masking: a day-2 acceptance during trial_workday and on day 1
 r = await api(app2C, "GET", "/api/applications/bl-acc");
 check("#58 trial_workday: applicant sees no acceptance and no offer", r.status === 200 && r.json?.application?.status !== "accepted" && !("offer" in (r.json?.application || {})), `${err(r)} ${r.json?.application?.status} offer=${"offer" in (r.json?.application || {})}`);
@@ -191,16 +206,34 @@ await db.doc("config/email_run_lock").set({ by: "someone-else", step: "trial_wor
 r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"] });
 check("#64 a run while another holds the lock -> 409", r.status === 409 && /already in progress/i.test(r.json?.error || ""), err(r));
 check("#64 the refused run leaves the holder's lock alone", (await db.doc("config/email_run_lock").get()).data()?.by === "someone-else");
-await db.doc("config/email_run_lock").set({ by: "crashed-tab", step: "trial_workday", startedAt: new Date(Date.now() - 60 * 60 * 1000), lockedUntil: new Date(Date.now() - 45 * 60 * 1000) });
+await db.doc("config/email_run_lock").set({ by: "crashed-tab", runId: "dead-run", step: "trial_workday", startedAt: new Date(Date.now() - 60 * 60 * 1000), lockedUntil: new Date(Date.now() - 45 * 60 * 1000) });
 r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"] });
 check("#64 an expired lock (a run that died) does not block; the run proceeds", r.status !== 409, err(r));
-check("#64 the lock is released when the run ends", !(await db.doc("config/email_run_lock").get()).exists);
+check("#64 a single un-batched request releases the lock when it ends", !(await db.doc("config/email_run_lock").get()).exists);
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"], runId: "run-A", last: false });
+check("#64 batch 1 of run A -> 200 and the lock is held for the run", r.status === 200 && (await db.doc("config/email_run_lock").get()).data()?.runId === "run-A", err(r));
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"], runId: "run-B", last: false });
+check("#64 run B (another admin/tab) meanwhile -> 409", r.status === 409, err(r));
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"], runId: "run-A", last: false });
+check("#64 batch 2 of run A re-enters its own lock -> 200", r.status === 200, err(r));
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"] });
+check("#64 an un-batched run while A is in progress -> 409 (and it does not steal the lock)", r.status === 409 && (await db.doc("config/email_run_lock").get()).data()?.runId === "run-A", err(r));
+r = await api(adminC, "POST", "/api/admin/config/recruiting/trigger-emails", { applicationIds: ["does-not-exist"], runId: "run-A", last: true });
+check("#64 the last batch of run A releases the lock", r.status === 200 && !(await db.doc("config/email_run_lock").get()).exists, err(r));
+{
+  const lockDoc = (await db.doc("config/email_run_lock").get()).data();
+  check("#64 lock has a batch-sized expiry, so a batch killed by a timeout frees the run within minutes", !lockDoc, "");
+}
 
 // ---- #70: the refresh cooldown the button reports is the one the POST enforces ----
+r = await status(adminC, "bl-inf", { status: "waitlisted", offer: { system: "Dynamics", details: "" } });
+check("#70 (fixture) a status change lands", r.status === 200, err(r));
+r = await api(adminC, "GET", "/api/admin/applications/refresh");
+check("#70 a staff status change does not start the refresh cooldown (the button stays usable during review)", r.status === 200 && r.json?.cooldownRemaining === 0 && r.json?.canRefresh === true, JSON.stringify(r.json));
 r = await api(adminC, "POST", "/api/admin/applications/refresh");
-const first = r.status;
+check("#70 refresh -> 200 (the cooldown is fresh for the whole harness)", r.status === 200, err(r));
 r = await api(adminC, "POST", "/api/admin/applications/refresh");
-check("#70 a second refresh inside the cooldown -> 429 with the seconds left", r.status === 429 && r.json?.cooldownRemaining >= 1, `first=${first} then ${err(r)} remaining=${r.json?.cooldownRemaining}`);
+check("#70 a second refresh inside the cooldown -> 429 with the seconds left", r.status === 429 && r.json?.cooldownRemaining >= 1, `${err(r)} remaining=${r.json?.cooldownRemaining}`);
 r = await api(adminC, "GET", "/api/admin/applications/refresh");
 check("#70 GET reports the same cooldown (was hardcoded 0)", r.status === 200 && r.json?.cooldownRemaining >= 1 && r.json?.canRefresh === false, JSON.stringify(r.json));
 
@@ -219,6 +252,12 @@ check("#70 GET reports the same cooldown (was hardcoded 0)", r.status === 200 &&
   const rowE = lines.map(parse).find((cells) => cells.includes("skills-bl-e"));
   check("#73 the row's team answer sits under its own question's column", !!rowE && rowE[skillsCol] === "skills-bl-e", rowE ? `got=${JSON.stringify(rowE[skillsCol])}` : "row bl-e not found");
   check("#73 original ranking exported even after it was narrowed", !!rowE && rowE[origCol] === "Body; Dynamics", rowE ? JSON.stringify(rowE[origCol]) : "");
+  check("#73 a single-team export carries only that team's question columns", header.some((h) => h.startsWith("Electric Q:")) && !header.some((h) => h.startsWith("Solar Q:") || h.startsWith("Combustion Q:")), header.filter((h) => /Q:/.test(h)).join(" | "));
+  const otherCol = header.indexOf("Other Team Answers");
+  await db.doc("applications/bl-e").set({ formData: { ...COMPLETE, teamQuestions: { electric_skills: "skills-bl-e", q_deleted_123: "answer to a question that no longer exists" } } }, { merge: true });
+  const res2 = await fetch(`${BASE}/api/admin/applications/export-csv`, { method: "POST", headers: { "Content-Type": "application/json", cookie: adminC }, body: JSON.stringify({ teams: ["Electric"] }) });
+  const rowE2 = (await res2.text()).split(/\r?\n/).filter(Boolean).map(parse).find((cells) => cells.includes("skills-bl-e"));
+  check("#73 an answer under a question id the config no longer has is not dropped", otherCol >= 0 && !!rowE2 && rowE2[otherCol] === "q_deleted_123: answer to a question that no longer exists", rowE2 ? JSON.stringify(rowE2[otherCol]) : "row not found");
 }
 
 // ---- #60/#61: question edits reach the applicant route at once; writes merge ----
@@ -237,7 +276,7 @@ check("#70 GET reports the same cooldown (was hardcoded 0)", r.status === 200 &&
   r = await api(adminC, "PUT", "/api/admin/config/questions", { scope: "team", team: "Electric", questions: original });
   r = await api(adminC, "GET", "/api/questions?team=Electric");
   check("#60 restored", r.json?.teamQuestions?.[0]?.label === original[0].label);
-  check("#60 public questions route caches for minutes, not hours", /s-maxage=300\b/.test((await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control") || ""), (await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control"));
+  check("#60 public questions route caches for minutes, not hours", /s-maxage=300, stale-while-revalidate=60\b/.test((await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control") || ""), (await fetch(`${BASE}/api/questions?team=Electric`)).headers.get("cache-control"));
 }
 
 // ---- #72: a page render with a staff session still works (one verification, shared by Header and Footer) ----

--- a/scripts/qa/backlog-regress.mjs
+++ b/scripts/qa/backlog-regress.mjs
@@ -95,6 +95,13 @@ const huge = Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`h${i}`, "
 r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { customAnswers: huge } });
 d = await get("bl-cap");
 check("#74 a payload that would approach Firestore's 1 MB limit -> 400, nothing written", r.status === 400 && d.formData.customAnswers.q_1 === "fine" && Object.keys(d.formData.customAnswers).length === 1, `${err(r)} n=${Object.keys(d.formData.customAnswers || {}).length}`);
+const half = (prefix) => Object.fromEntries(Array.from({ length: 20 }, (_, i) => [`${prefix}${i}`, "z".repeat(19_000)]));
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { customAnswers: half("c") } });
+check("#74 a 380 KB bag on its own saves", r.status === 200, err(r));
+r = await api(appC, "PATCH", "/api/applications/bl-cap", { formData: { teamQuestions: half("t") } });
+d = await get("bl-cap");
+check("#74 a second 380 KB bag in another request -> 400: the cap is on the merged document, not the request", r.status === 400 && !("t0" in (d.formData.teamQuestions || {})), `${err(r)}`);
+await db.doc("applications/bl-cap").set({ formData: COMPLETE }, { merge: true });
 
 // ---- #62: other-team badges are masked for non-admins ----
 await mk("bl-e", "u-bl-app", "Electric", ["Body"], "submitted", { originalPreferredSystems: ["Body", "Dynamics"], formData: { ...COMPLETE, teamQuestions: { electric_skills: "skills-bl-e" } } });
@@ -159,6 +166,14 @@ r = await api(adminC, "POST", "/api/admin/applications/bl-strag/reject", { syste
 check("#58 same via /reject", r.status === 400 && (await get("bl-strag")).status === "submitted", err(r));
 r = await status(adminC, "bl-wl", { status: "accepted", offer: { system: "Aerodynamics", role: "Member", details: "" }, releaseDay: true });
 check("#58 releaseDay: true -> 400 (not coerced to 1)", r.status === 400 && (await get("bl-wl")).status === "waitlisted", err(r));
+await mk("bl-wl2", "u-bl-app", "Combustion", ["Aerodynamics"], "waitlisted", { ...trialFixture(["Aerodynamics"]), trialDecision: "waitlisted", trialDecisionDay: 1, waitlistSystem: "Aerodynamics" });
+r = await api(adminC, "POST", "/api/admin/applications/bl-wl2/reject", { systems: ["Aerodynamics"], releaseDay: 2 });
+d = await get("bl-wl2");
+check("#58 rescinding a waitlisted applicant (has a trial offer) via /reject takes releaseDay", r.status === 200 && d.status === "rejected" && d.trialDecisionDay === 2, `${err(r)} ${d.status} day=${d.trialDecisionDay}`);
+await mk("bl-fast", "u-bl-app", "Electric", ["Dynamics"], "interview", { reviewDecision: "advanced", interviewOffers: [off("Dynamics", "completed")] });
+r = await status(adminC, "bl-fast", { status: "accepted", offer: { system: "Dynamics", role: "Member", details: "" }, releaseDay: 3 });
+d = await get("bl-fast");
+check("#58 fast-tracking an interviewee straight to accepted takes releaseDay (it writes the trial decision)", r.status === 200 && d.status === "accepted" && d.trialDecisionDay === 3, `${err(r)} ${d.status} day=${d.trialDecisionDay}`);
 // masking: a day-2 acceptance during trial_workday and on day 1
 r = await api(app2C, "GET", "/api/applications/bl-acc");
 check("#58 trial_workday: applicant sees no acceptance and no offer", r.status === 200 && r.json?.application?.status !== "accepted" && !("offer" in (r.json?.application || {})), `${err(r)} ${r.json?.application?.status} offer=${"offer" in (r.json?.application || {})}`);


### PR DESCRIPTION
Closes #58, #59, #60, #61, #62, #64, #65, #66, #70, #71, #72, #73, #74, #75, #83 — everything left open after the tracker clean-up, on one branch.

## What changes, by issue

**Decisions and what applicants see**
- **#58** Staff pick the release day. The accept, waitlist and reject modals show a "Release on: Decision Day 1/2/3" selector at trial/decision steps (default = the old step-based inference, which stays for bulk and for clients that send nothing). `releaseDay` is validated (1|2|3 → 400 otherwise) on both the status and reject routes. The applicant sanitizer now hides the final `offer` until **that decision's** day, not day 1 — a day-2 acceptance no longer rides along in day-1 payloads.
- **#75** The applicant's review page renders system-question answers (they live in `customAnswers`, keyed by question id, for each ranked system — same lookup as the form). The staff-written interview `cancelReason` never reaches applicants: the sanitizer strips it, and the scheduler shows fixed copy.
- **#65** Committing sends one request. The dashboard passes `declineReasons`; `respondToCommitment` declines the other accepted offers inside the same transaction with those reasons (a failure part-way can no longer leave someone declined everywhere and committed nowhere). Leads of the declined teams are still notified afterwards.
- **#66** Status writes go through `updateApplicationIfUnchanged()` — a transaction that refuses if the status changed since the route loaded it. Two staff deciding on one applicant at once now get one 200 and one 409 ("changed while you were deciding — reload"); the detail page toasts and refreshes.

**Auth and caching**
- **#59** Any Firebase `auth/*` failure in a guard collapses to `Unauthorized`, and every route now maps that to **401** (24 routes mapped 403; four had no mapping and returned 500). The client fetcher only logs out on 401, so expired sessions log out instead of leaving a dead page. Session cookie `maxAge` was milliseconds (≈13,700 years); it is seconds now, plus `SameSite=Lax`. New `guardErrorStatus()` helper for catch blocks.
- **#72** `lib/auth/sessionUser.ts`: one React-`cache()`d session verification per request, shared by Header and Footer (each did its own revocation-checked verify + user read on every page).
- **#71** The admin applications `localStorage` cache is keyed by uid, read only after `/api/auth/me` answers, and cleared on logout and on any 401 — one staff member's list can no longer seed another's session on a shared machine.
- **#60** Question caches: `/api/questions` 5 min (was 2 h), the apply page's browser copy 5 min (was 30), and the admin PUT invalidates the server's in-memory copy. Still owed (out of scope here): migrating the bare `Operations` key in `systemQuestions` to the team-prefixed form.
- **#70** The refresh GET reports the real cooldown (was hardcoded 0, so the button promised a refresh the POST then refused with 429). The dead server-side list cache is gone; `invalidateApplications()` now always drops the cached recruiting step. CLAUDE.md updated.
- **#61** Write paths read config strictly (`{ strict: true }` throws instead of returning defaults — a transient read used to write the hardcoded defaults over the live document). The question section writers are merge-sets now. `getAnnouncement()` failing no longer takes the applicant dashboard down.

**Staff data**
- **#62** `otherTeams` on the admin list is masked for non-admins exactly like the related route: no application id, a waitlist elsewhere reads `inactive`.
- **#64** `markEmailSent()` uses `arrayUnion` (two runs can't drop each other's entries), and a `config/email_run_lock` doc (15-min expiry, released in `finally`) makes runs exclusive — a second admin/tab gets a 409 instead of sending everyone two copies.
- **#73** CSV: new "Original Preferred Systems" column; team-question columns are generated from config as `<Team> Q: <label>` (a blank optional first answer no longer shifts the rest, nothing past the second is dropped); scorecard/notes fan-out reads 25 applications at a time instead of all at once.
- **#74** `sanitizeIncomingFormData` caps: 20k chars per answer, 100 entries per bag, 64-char keys.
- **#83** The sidebar's loading branch is an `<aside>` like the loaded one, and the context's state initializers no longer read `localStorage` (server and first client render now match).

## Opus review (second and third commits)

A full-diff Opus pass found 2 High / 9 Medium / 9 Low; all addressed in `fix: address review of qa backlog sweep`:

- **H1** The scheduler reads `/api/applications/[id]/interview`, which still served the raw offers — `cancelReason` now stripped there too (and from the hook's type). The harness asserts it on that route.
- **H2/M9** The admin UI sends an email run as sequential batches of 50, so a per-request lock would have let two runs interleave and, worse, a batch killed by the platform timeout (no `finally`) would have wedged the rest of its own run for 15 minutes. The lock is now keyed by a client-generated `runId`: batches of one run re-enter, another run gets a 409 (which the settings page now surfaces as "another run is in progress — stopped after N batches" instead of 50 failures), the TTL is batch-sized (3 min), and only the owner releases it — on the last batch, or immediately for an un-batched request.
- **M1/M2** The "Release on" selector only shows when the applicant is at trial (or accepted/waitlisted and being re-decided), resets whenever a modal opens (a Day 3 picked in Accept and cancelled no longer rides into Reject), and is in the reject modal too. The server refuses `releaseDay` on any decision that isn't a trial decision (400) rather than dropping it.
- **M3** The `appCache` rewrite had been lost in a working-tree reset and re-patch — it's in now: the dead list cache is gone, `invalidateApplications()` only drops the cached step (no cooldown, so the refresh button is no longer greyed out for 30 s after every staff decision), and `requestRefresh()` is what the button rate-limits. Question TTL 5 min.
- **M4** The admin console's own `fetch` calls (list, `/api/auth/me`) log out on a 401; the commit route returns 401 on a dead cookie instead of a 400 carrying Firebase's message.
- **M8** The uid now comes from the admin layout's server-side guard (`ViewerContext`), so the cached list paints on mount without waiting for a round-trip — still read in an effect, never in an initializer.
- **M7** Leads are emailed about a declined offer only if the applicant could see it (a masked day-2/3 acceptance is not "declined by the applicant").
- **M5/M6/Lows** `stale-while-revalidate` 60 s and honest copy on the questions tab (~15 min worst case across server, CDN and browser); CSV keeps answers whose question id is gone from config ("Other Team Answers") and only carries the exported teams' columns; `clampDecisionDay()` fails closed; `guardErrorStatus` matches the inline ternaries; "Inactive" label; merge-seed for a missing questions doc; applicant PATCH rejects a > 600 KB `formData` (Firestore's limit is 1 MB).

A second, lighter pass over those fixes (`fix: align release-day gates and notify all declines`) found the release-day gate disagreeing with the routes in both directions — now the client uses the server's own rule (accept/waitlist at a decision step always carry a day, even for a fast-tracked interviewee; a reject does once the applicant holds a trial offer, so rescinding a waitlisted applicant to Day 2 works), the reject route gates on the trial offer rather than the status, and both are in the harness. Also from that pass: leads are told about **every** offer a commit declines again, with the reason "committed to another team before this offer was released to them" for a masked day-2/3 acceptance; the form-data cap is on the merged document, not the request (two 380 KB bags in two requests → 400); an un-batched email run's id can't collide; `guardErrorStatus` back to `startsWith` to match `lib/logger.ts`.

**One product question for you (unchanged behaviour, flagged by the review):** a commit auto-declines *every* other acceptance, including a day-2/3 one the applicant hasn't been shown yet — so they can never see it, and reneg (round 2) can't reach it. That was already true before this branch; I left it as is and only made sure the leads hear about it. If the intent is that unreleased offers survive a day-1 commit, that's a small change in `respondToCommitment` — say the word.

Not done, deliberately (follow-ups): the #66 guard covers the accept/waitlist/reject branch (the reported race), not interview/trial offer writes; multi-instance cache invalidation needs infra we don't have; the `localStorage` admin cache still holds names/emails in plaintext (pre-existing).

## Verification

- **`scripts/qa/backlog-regress.mjs`** (new, **81 checks**): 401 for missing/garbage cookies on GET, POST and the commit route while an applicant stays 403; cookie `Max-Age=432000` + `SameSite=Lax`; a 30k answer clipped to 20k, 150 bag entries to 100, a 760 KB payload → 400 and two 380 KB bags across two requests → 400 on the second; lead sees `inactive`/no id where admin sees `waitlisted`/id (list and related); cancelled offer reaches the applicant without its reason on both applicant routes while staff keep it; `releaseDay` 2/3 tagged on accept/waitlist/reject, on a fast-tracked interviewee's acceptance and on rescinding a waitlisted applicant; 5, 0, `true` and any non-trial decision → 400; omitted → inferred day 1; a day-2 acceptance masked with **no `offer` key** during trial_workday and day 1, commit refused, then visible on day 2; one-request commit declines the Solar offer with the applicant's trimmed reason and ignores junk ids; concurrent accept + waitlist → exactly one 200 and one 409 with the winner's state; email lock: held → 409, expired → proceeds, batches of one run re-enter while another run and an un-batched request get 409, last batch releases; a staff decision leaves the refresh cooldown at 0, then POST 200 → 429 → GET reports the seconds; CSV header/columns/row values, single-team columns only, orphaned answers kept; question PUT visible immediately on `/api/questions` with the other sections intact in Firestore; home renders for staff and anonymously.
- All other suites re-run green on the emulator after the review fixes: applicant-gates 54, transitions 61, drafts 23, sweeps 21, audit 49, users 19, dashboard 10, rejection 27, staff-status 28, stats 28 — **401 checks** in total.
- Server HTML for `/admin/applications` carries the `<aside>` loading sidebar the client renders first.
- `npx tsc --noEmit` and `npm run build` clean.

## Migration / data

None. The unkeyed `admin_applications_cache` localStorage entry is removed on first load; `config/email_run_lock` is created and deleted per run; `config/application_questions` is created from defaults on first section write if it doesn't exist (production has it).
