### PR TITLE
fix: interview config save uses stale doc id

### DIFF
--- a/lib/actions/interview-config.ts
+++ b/lib/actions/interview-config.ts
@@ -16,8 +16,11 @@ const toConfig = (doc: FirebaseFirestore.DocumentSnapshot): InterviewSlotConfig 
   if (!doc.exists) return null;
   const data = doc.data();
   return {
-    id: doc.id,
     ...data,
+    // doc.id must win: a few live docs carry a stale `id` field left over from
+    // the system renames, and letting it shadow the real doc id sends updates
+    // to a document that no longer exists.
+    id: doc.id,
   } as InterviewSlotConfig;
 };
 


### PR DESCRIPTION
Saving a signup link on **Electric → Vehicle Modeling & Software** in `/admin/configuration` always failed with "Failed to save configuration". No other system was affected.

## Root cause

Not the link being pasted — a stale field on one live document.

A dump of `interviewConfigs` shows all 26 docs have their stored `id` field matching their document ID, except one:

```
docId:           "electric-vehicle-modeling-software"
stored id field: "electric-software"     <- stale
```

Leftover from a2eaa60 ("rename electric software to vehicle modeling & software"), which changed the enum and the slugifier but shipped no data migration, so the doc got a new ID while its internal `id` field kept the old value.

The stale field only became fatal because of the spread order in `toConfig`:

```ts
return { id: doc.id, ...data }   // data.id overwrites the real doc id
```

The form therefore loaded that config holding `id = "electric-software"`, and Save called `.doc("electric-software").update(...)`. That document does not exist (verified: `exists? false`), and Firestore rejects `update()` on a missing doc with NOT_FOUND, which the form surfaces as a failed save.

## Fix

Flip the spread order so the document's real ID always wins.

The other ~20 `id: doc.id` sites in `lib/firebase/` and the API routes were checked — they all already use the safe `...data, id: doc.id` order or explicit field mapping. This was the only inverted one.

## Notes

- **The bad data self-heals.** `updateInterviewConfig` writes `...config` back, so the first save of that link writes the corrected `id` to the doc. No migration script needed; no production writes were made for this PR (reads only).
- **The applicant path was never affected.** `app/api/applications/[id]/interview/route.ts` resolves configs by team+system key, not by the `id` field.

## Verification

`npm run build` compiles clean.