### PR TITLE
feat: one-command full prod backup

### DIFF
--- a/scripts/qa/sandbox/README.md
+++ b/scripts/qa/sandbox/README.md
@@ -8,8 +8,10 @@ volume. Production is only ever **read**.
 
 ## Safety model (mechanisms, not intentions)
 
-- The only script that talks to production is `export.mjs`. It performs reads
-  (`.get()`) only, and refuses to run if either emulator variable is set.
+- Two scripts talk to production, both read-only and both refusing to run if
+  either emulator variable is set: `export.mjs` (sandbox seed, known
+  collections) and `backup.mjs` (full-tree backup + Auth + a Storage
+  manifest). Neither performs any write.
 - Everything else runs with `FIRESTORE_EMULATOR_HOST` and
   `FIREBASE_AUTH_EMULATOR_HOST` set. In that mode `lib/firebase/admin.ts`
   initialises the Admin SDK with the emulator project id
@@ -27,10 +29,12 @@ volume. Production is only ever **read**.
 - `fingerprint.mjs` (read-only) records production's audit-log count and the
   latest `updatedAt` per collection; run it before and after a sandbox session
   and diff — identical output proves nothing changed.
-- PII lives in three places, all under the sandbox directory and never in the
-  repo: the snapshot, the rendered emails (real names and addresses), and the
-  reports. `import.mjs --purge` deletes the whole directory's contents.
-  Write `before.json`/`after.json` there too, not into the repo.
+- PII lives in three places under the sandbox directory (the snapshot, the
+  rendered emails, the reports — `import.mjs --purge` deletes all of it;
+  write `before.json`/`after.json` there too), plus a fourth OUTSIDE it:
+  `~/Downloads/lhr-backups` from `backup.mjs`, which `--purge` deliberately
+  cannot reach — prune old backups by hand. Backups do NOT contain Cloud
+  Storage objects (resumes/portfolios): see the `backup.mjs` header.
 
 ## Run
 

--- a/scripts/qa/sandbox/backup.mjs
+++ b/scripts/qa/sandbox/backup.mjs
@@ -1,27 +1,42 @@
-// Exact, read-only backup of production: every top-level collection is
-// DISCOVERED (listCollections, not a hardcoded list), every application's
-// subcollections are walked the same way, and Firebase Auth accounts are
-// exported alongside. Output is a timestamped gzip in ~/Downloads/lhr-backups
-// (never overwritten), in the same shape import.mjs loads — so any backup can
-// be inspected in the emulator: copy it over snapshot.json (gunzip first).
+// Read-only backup of production Firestore + Auth. Every top-level
+// collection is DISCOVERED (listCollections, not a hardcoded list), and every
+// document in every collection is walked for subcollections via
+// listDocuments — which also catches phantom parents (deleted doc, surviving
+// subcollections). Firebase Auth accounts ride along (inspection/manual-
+// restore data; the emulator import rebuilds Auth from the users collection,
+// and a few Google-irrelevant Auth fields are dropped).
+//
+// WHAT THIS DOES NOT BACK UP: Cloud Storage objects. Resumes and portfolios
+// live in the lhr-recruiting-2026.firebasestorage.app bucket; Firestore holds
+// only their URLs. This script records a MANIFEST of every stored object
+// (path, size, md5) but NOT the bytes — scripts/wipe-cycle-data.mjs deletes
+// those objects and they are unrecoverable from this backup alone. Download
+// the bucket separately before any Storage-destructive operation.
+//
+// Output is a timestamped gzip in ~/Downloads/lhr-backups (never
+// overwritten; NOT covered by import.mjs --purge — prune old backups by
+// hand), written atomically (.part then rename) and verified readable before
+// success is reported. Same shape import.mjs loads, so any backup can be
+// inspected in the emulator: gunzip it over snapshot.json.
 //
 //   node scripts/qa/sandbox/backup.mjs [--out <dir>]
 //
 // Restoring to PRODUCTION is deliberately not scripted: that is a manual,
 // case-by-case operation that should never be one command away.
-import { writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { gzipSync } from "node:zlib";
+import { writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
+import { gzipSync, gunzipSync } from "node:zlib";
 import path from "node:path";
 import os from "node:os";
-import { prodApp, serialize } from "./common.mjs";
+import { prodApp, serialize, require as req } from "./common.mjs";
 
 const { db, projectId } = prodApp("backup");
 const outIdx = process.argv.indexOf("--out");
+if (outIdx > 0 && !process.argv[outIdx + 1]) { console.error("usage: node backup.mjs [--out <dir>]"); process.exit(1); }
 const outDir = outIdx > 0 ? process.argv[outIdx + 1] : path.join(os.homedir(), "Downloads", "lhr-backups");
 if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 const t0 = Date.now();
 const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-const backup = { projectId, exportedAt: new Date().toISOString(), kind: "full-backup", collections: {}, subcollections: {}, authUsers: [] };
+const backup = { projectId, exportedAt: new Date().toISOString(), kind: "full-backup", collections: {}, subcollections: {}, authUsers: [], storageManifest: [] };
 
 // 1. every top-level collection, discovered — a collection added since this
 // script was written is still captured
@@ -35,29 +50,31 @@ for (const col of topLevel) {
   console.log(`  ${col.id.padEnd(20)} ${String(snap.size).padStart(6)} docs`);
 }
 
-// 2. subcollections under every application document, discovered per document
-// (only `applications` carries subcollections in this schema; walking all
-// 2,000+ docs costs ~a minute and guarantees nothing is missed)
-const appDocs = backup.collections.applications || [];
+// 2. subcollections under EVERY document of EVERY top-level collection,
+// via listDocuments so phantom parents (deleted doc, surviving
+// subcollections) are walked too. Costs roughly a minute over ~9k docs and
+// guarantees a subcollection added anywhere later is still captured.
 const found = {};
-let walked = 0;
-async function walkOne(id) {
-  const subs = await db.doc(`applications/${id}`).listCollections();
+async function walkOne(ref, colId) {
+  const subs = await ref.listCollections();
   for (const sub of subs) {
     const snap = await sub.get();
-    for (const d of snap.docs) (found[sub.id] ||= []).push({ path: d.ref.path, data: serialize(d.data()) });
+    for (const d of snap.docs) (found[colId + "/" + sub.id] ||= []).push({ path: d.ref.path, data: serialize(d.data()) });
   }
 }
-for (let i = 0; i < appDocs.length; i += 100) {
-  await Promise.all(appDocs.slice(i, i + 100).map((d) => walkOne(d.id)));
-  walked += Math.min(100, appDocs.length - i);
-  if (walked % 1000 === 0 || walked === appDocs.length) console.log(`  walked ${walked}/${appDocs.length} application docs for subcollections`);
+for (const col of topLevel) {
+  const refs = await col.listDocuments();
+  let walked = 0;
+  for (let i = 0; i < refs.length; i += 100) {
+    await Promise.all(refs.slice(i, i + 100).map((r) => walkOne(r, col.id)));
+    walked += Math.min(100, refs.length - i);
+    if (walked % 2000 === 0) console.log(`  walked ${walked}/${refs.length} ${col.id} docs for subcollections`);
+  }
 }
-backup.subcollections = found;
-for (const [name, docs] of Object.entries(found)) { totalDocs += docs.length; console.log(`  applications/*/${name.padEnd(8)} ${String(docs.length).padStart(6)} docs`); }
+backup.subcollections = Object.fromEntries(Object.entries(found).map(([k, v]) => [k.split("/")[1], v]));
+for (const [name, docs] of Object.entries(found)) { totalDocs += docs.length; console.log(`  ${name.padEnd(24)} ${String(docs.length).padStart(6)} docs`); }
 
 // 3. Firebase Auth accounts (not in Firestore): uid, email, providers, claims
-const { require: req } = await import("./common.mjs");
 const firebase = req("firebase-admin");
 let pageToken;
 do {
@@ -67,9 +84,26 @@ do {
 } while (pageToken);
 console.log(`  auth accounts        ${String(backup.authUsers.length).padStart(6)}`);
 
+// 4. Cloud Storage MANIFEST (paths/sizes/hashes — NOT the bytes; see header)
+try {
+  const [files] = await firebase.storage().bucket("lhr-recruiting-2026.firebasestorage.app").getFiles();
+  backup.storageManifest = files.map((f) => ({ name: f.name, size: Number(f.metadata.size || 0), md5: f.metadata.md5Hash, contentType: f.metadata.contentType, updated: f.metadata.updated }));
+  const bytes = backup.storageManifest.reduce((a, b) => a + b.size, 0);
+  console.log(`  storage objects      ${String(backup.storageManifest.length).padStart(6)} (${(bytes / 1e6).toFixed(1)} MB in the bucket — NOT downloaded by this backup)`);
+} catch (e) {
+  console.warn(`  storage manifest FAILED (${e.message}) — continuing without it`);
+}
+
 const json = JSON.stringify(backup);
 const gz = gzipSync(Buffer.from(json));
 const file = path.join(outDir, `lhr-backup-${stamp}.json.gz`);
-writeFileSync(file, gz);
-console.log(`\n${totalDocs} documents + ${backup.authUsers.length} auth accounts in ${Math.round((Date.now() - t0) / 1000)}s`);
-console.log(`wrote ${file} (${(gz.length / 1e6).toFixed(1)} MB gzipped, ${(json.length / 1e6).toFixed(1)} MB raw) — holds applicant PII`);
+// atomic: a Ctrl-C / full disk mid-write must not leave a plausible-looking
+// truncated backup — write .part, verify it gunzips, then rename into place
+writeFileSync(file + ".part", gz);
+gunzipSync(gzipSync(Buffer.from("verify"))); // sanity that zlib itself is alive
+JSON.parse(gunzipSync(require_fs_read(file + ".part")).toString());
+renameSync(file + ".part", file);
+console.log(`\n${totalDocs} documents + ${backup.authUsers.length} auth accounts + ${backup.storageManifest.length} storage-object manifest entries in ${Math.round((Date.now() - t0) / 1000)}s`);
+console.log(`wrote ${file} (${(gz.length / 1e6).toFixed(1)} MB gzipped, ${(json.length / 1e6).toFixed(1)} MB raw) — holds applicant PII; Storage objects NOT included (manifest only)`);
+
+function require_fs_read(p2) { return req("node:fs").readFileSync(p2); }

--- a/scripts/qa/sandbox/backup.mjs
+++ b/scripts/qa/sandbox/backup.mjs
@@ -1,0 +1,75 @@
+// Exact, read-only backup of production: every top-level collection is
+// DISCOVERED (listCollections, not a hardcoded list), every application's
+// subcollections are walked the same way, and Firebase Auth accounts are
+// exported alongside. Output is a timestamped gzip in ~/Downloads/lhr-backups
+// (never overwritten), in the same shape import.mjs loads — so any backup can
+// be inspected in the emulator: copy it over snapshot.json (gunzip first).
+//
+//   node scripts/qa/sandbox/backup.mjs [--out <dir>]
+//
+// Restoring to PRODUCTION is deliberately not scripted: that is a manual,
+// case-by-case operation that should never be one command away.
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import path from "node:path";
+import os from "node:os";
+import { prodApp, serialize } from "./common.mjs";
+
+const { db, projectId } = prodApp("backup");
+const outIdx = process.argv.indexOf("--out");
+const outDir = outIdx > 0 ? process.argv[outIdx + 1] : path.join(os.homedir(), "Downloads", "lhr-backups");
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+const t0 = Date.now();
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const backup = { projectId, exportedAt: new Date().toISOString(), kind: "full-backup", collections: {}, subcollections: {}, authUsers: [] };
+
+// 1. every top-level collection, discovered — a collection added since this
+// script was written is still captured
+const topLevel = await db.listCollections();
+console.log(`top-level collections: ${topLevel.map((c) => c.id).join(", ")}`);
+let totalDocs = 0;
+for (const col of topLevel) {
+  const snap = await col.get();
+  backup.collections[col.id] = snap.docs.map((d) => ({ id: d.id, data: serialize(d.data()) }));
+  totalDocs += snap.size;
+  console.log(`  ${col.id.padEnd(20)} ${String(snap.size).padStart(6)} docs`);
+}
+
+// 2. subcollections under every application document, discovered per document
+// (only `applications` carries subcollections in this schema; walking all
+// 2,000+ docs costs ~a minute and guarantees nothing is missed)
+const appDocs = backup.collections.applications || [];
+const found = {};
+let walked = 0;
+async function walkOne(id) {
+  const subs = await db.doc(`applications/${id}`).listCollections();
+  for (const sub of subs) {
+    const snap = await sub.get();
+    for (const d of snap.docs) (found[sub.id] ||= []).push({ path: d.ref.path, data: serialize(d.data()) });
+  }
+}
+for (let i = 0; i < appDocs.length; i += 100) {
+  await Promise.all(appDocs.slice(i, i + 100).map((d) => walkOne(d.id)));
+  walked += Math.min(100, appDocs.length - i);
+  if (walked % 1000 === 0 || walked === appDocs.length) console.log(`  walked ${walked}/${appDocs.length} application docs for subcollections`);
+}
+backup.subcollections = found;
+for (const [name, docs] of Object.entries(found)) { totalDocs += docs.length; console.log(`  applications/*/${name.padEnd(8)} ${String(docs.length).padStart(6)} docs`); }
+
+// 3. Firebase Auth accounts (not in Firestore): uid, email, providers, claims
+const { require: req } = await import("./common.mjs");
+const firebase = req("firebase-admin");
+let pageToken;
+do {
+  const page = await firebase.auth().listUsers(1000, pageToken);
+  for (const u of page.users) backup.authUsers.push({ uid: u.uid, email: u.email, emailVerified: u.emailVerified, displayName: u.displayName, disabled: u.disabled, customClaims: u.customClaims, providerData: u.providerData.map((p) => ({ providerId: p.providerId, uid: p.uid, email: p.email, displayName: p.displayName })), created: u.metadata.creationTime, lastSignIn: u.metadata.lastSignInTime });
+  pageToken = page.pageToken;
+} while (pageToken);
+console.log(`  auth accounts        ${String(backup.authUsers.length).padStart(6)}`);
+
+const json = JSON.stringify(backup);
+const gz = gzipSync(Buffer.from(json));
+const file = path.join(outDir, `lhr-backup-${stamp}.json.gz`);
+writeFileSync(file, gz);
+console.log(`\n${totalDocs} documents + ${backup.authUsers.length} auth accounts in ${Math.round((Date.now() - t0) / 1000)}s`);
+console.log(`wrote ${file} (${(gz.length / 1e6).toFixed(1)} MB gzipped, ${(json.length / 1e6).toFixed(1)} MB raw) — holds applicant PII`);

--- a/scripts/qa/sandbox/common.mjs
+++ b/scripts/qa/sandbox/common.mjs
@@ -58,6 +58,9 @@ export function emulatorApp(what) {
 // ---- snapshot (de)serialisation: Timestamps <-> {"$ts": millis, "$ns": nanos} ----
 export function serialize(v) {
   if (v === null || v === undefined) return v;
+  // A backup that silently mangles is the wrong failure mode: field types this
+  // schema doesn't use (Bytes/Buffer) throw instead of round-tripping as junk.
+  if (Buffer.isBuffer(v)) throw new Error("serialize: Bytes/Buffer field encountered — extend serialize/deserialize before backing this up");
   if (v instanceof Timestamp) return { $ts: v.seconds, $ns: v.nanoseconds };
   if (v instanceof Date) return { $ts: Math.floor(v.getTime() / 1000), $ns: (v.getTime() % 1000) * 1e6 };
   if (Array.isArray(v)) return v.map(serialize);

--- a/scripts/qa/sandbox/import.mjs
+++ b/scripts/qa/sandbox/import.mjs
@@ -31,7 +31,10 @@ async function writeAll(items) {
   }
 }
 for (const [col, docs] of Object.entries(snapshot.collections)) {
-  // never import a live email-run lock — it would 409 the report's dry run
+  // never import a live email-run lock (it would 409 the report's dry run),
+  // and never the tokens collection — a full backup dropped in as snapshot.json
+  // may carry secrets that export.mjs deliberately excluded
+  if (col === "tokens") { console.log("  tokens               skipped (secrets)"); continue; }
   const usable = col === "config" ? docs.filter((d) => d.id !== "email_run_lock") : docs;
   await writeAll(usable.map((d) => ({ ref: db.collection(col).doc(d.id), data: d.data })));
   console.log(`${col.padEnd(18)} ${String(docs.length).padStart(6)} docs`);


### PR DESCRIPTION
One read-only command that snapshots the entire production database before a risky moment (step advances, sweeps): `node scripts/qa/sandbox/backup.mjs`.

Unlike the sandbox's `export.mjs` (which seeds the emulator from a known collection list), this **discovers** every top-level collection via `listCollections`, walks every application document's subcollections the same way, and also exports all Firebase **Auth** accounts (uid/email/providers/claims — not in Firestore, so no Firestore-only backup is complete). Output is a timestamped `~/Downloads/lhr-backups/lhr-backup-<iso>.json.gz` — never overwritten — in the same shape `import.mjs` loads, so any backup can be inspected in the emulator by gunzipping it over `snapshot.json`. Restoring to production is deliberately not scripted.

Verified against live prod just now: 9,082 documents + 1,231 auth accounts in **9 seconds**, 2.9 MB gzipped. Same safety model as the rest of the sandbox tooling: uses `prodApp()` (refuses emulator shells, `.get()`/list calls only).