### PR TITLE
feat: per-step stats with frozen snapshots

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -138,12 +138,17 @@ export default function AdminSettingsPage() {
 
         // The step is saved either way; the sweep that runs on the Day 2/3
         // transitions can still fail, and a half-swept cycle must not look
-        // like a clean one.
-        const { sweepError } = await res.json().catch(() => ({ sweepError: undefined }));
+        // like a clean one. Same for the end-of-step stats snapshot — a
+        // missed freeze should be visible now, not weeks later as a bare
+        // "no snapshot" on the stats rail.
+        const { sweepError, snapshotError } = await res.json().catch(() => ({ sweepError: undefined, snapshotError: undefined }));
         if (sweepError) {
           toast.error(sweepError, { duration: 12000 });
         } else {
           toast.success("Recruiting step updated!");
+        }
+        if (snapshotError) {
+          toast.error(snapshotError, { duration: 12000 });
         }
 
         // If transitioning to a release step, automatically trigger the batching email process

--- a/app/admin/stats/StatsView.tsx
+++ b/app/admin/stats/StatsView.tsx
@@ -3,12 +3,15 @@
 import { downloadCsv } from "@/lib/utils/downloadFile";
 import { useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { Download, Loader2, RefreshCw } from "lucide-react";
-import { useStats } from "@/hooks/useStats";
+import { Loader2, RefreshCw } from "lucide-react";
+import { useStats, useStatsSnapshots } from "@/hooks/useStats";
 import { Team } from "@/lib/models/User";
 import { ApplicationStatus } from "@/lib/models/Application";
+import { RecruitingStep } from "@/lib/models/Config";
 import { getTeamColor } from "@/lib/teamColors";
 import type { RecruitingStats, SystemDemand } from "@/lib/firebase/stats";
+import { Bar, Card, ExportButton, fmtInt, GOLD, pct, Segmented, Tile } from "./atoms";
+import { PhaseSection, StepRail } from "./phases";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -40,8 +43,6 @@ const STATUS_LABELS: Record<ApplicationStatus, string> = {
   [ApplicationStatus.REJECTED]: "Rejected",
 };
 
-const GOLD = "var(--lhr-gold)";
-
 type Metric = "submitted" | "created" | "accounts";
 type Mode = "cumulative" | "per-bucket";
 type Range = "24h" | "7d" | "all";
@@ -50,9 +51,6 @@ type BucketMinutes = 15 | 60 | 1440;
 // ---------------------------------------------------------------------------
 // Small helpers
 // ---------------------------------------------------------------------------
-
-const fmtInt = (n: number) => n.toLocaleString("en-US");
-const pct = (n: number, d: number) => (d > 0 ? `${Math.round((100 * n) / d)}%` : "—");
 
 function startOfLocalDay(ms: number): number {
   const d = new Date(ms);
@@ -209,71 +207,14 @@ function niceStep(max: number): number {
 }
 
 // ---------------------------------------------------------------------------
-// UI atoms
-// ---------------------------------------------------------------------------
-
-function Segmented<T extends string | number>({ value, options, onChange }: { value: T; options: { value: T; label: string; disabled?: boolean }[]; onChange: (v: T) => void }) {
-  return (
-    <div className="inline-flex rounded-lg border border-white/10 bg-white/[0.04] p-0.5">
-      {options.map((o) => (
-        <button key={String(o.value)} disabled={o.disabled} onClick={() => onChange(o.value)}
-          className={clsx("px-2.5 h-7 rounded-md text-[12px] font-semibold transition-colors",
-            o.value === value ? "bg-white/10 text-white" : "text-white/50 hover:text-white/80",
-            o.disabled && "opacity-30 cursor-not-allowed")}>
-          {o.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function Card({ title, right, children, className }: { title?: string; right?: React.ReactNode; children: React.ReactNode; className?: string }) {
-  return (
-    <section className={clsx("rounded-xl border border-white/10 bg-white/[0.04] p-5", className)}>
-      {(title || right) && (
-        <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
-          {title && <h2 className="text-[14px] font-semibold text-white">{title}</h2>}
-          {right}
-        </div>
-      )}
-      {children}
-    </section>
-  );
-}
-
-function Tile({ value, label, sub }: { value: string; label: string; sub?: string }) {
-  return (
-    <div className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3.5">
-      <div className="text-[26px] font-bold text-white tracking-tight tabular-nums leading-none">{value}</div>
-      <div className="text-[12px] text-white/60 mt-1.5">{label}</div>
-      {sub && <div className="text-[11px] text-white/35 mt-0.5">{sub}</div>}
-    </div>
-  );
-}
-
-function ExportButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button onClick={onClick} className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md border border-white/10 text-[12px] font-semibold text-white/50 hover:text-white hover:bg-white/5">
-      <Download className="h-3 w-3" /> CSV
-    </button>
-  );
-}
-
-function Bar({ value, max, color }: { value: number; max: number; color: string }) {
-  return (
-    <div className="h-1.5 rounded-full bg-white/5 w-full overflow-hidden">
-      <div className="h-full rounded-full" style={{ width: `${max > 0 ? (100 * value) / max : 0}%`, background: color }} />
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export function StatsView() {
   const { stats, error, isLoading, refreshing, refresh } = useStats();
+  const { snapshots } = useStatsSnapshots();
 
+  const [selStep, setSelStep] = useState<RecruitingStep | null>(null);
   const [metric, setMetric] = useState<Metric>("submitted");
   const [mode, setMode] = useState<Mode>("cumulative");
   const [bucket, setBucket] = useState<BucketMinutes>(60);
@@ -311,6 +252,8 @@ export function StatsView() {
   const toggleSort = (key: keyof SystemDemand) =>
     setSysSort((s) => (s.key === key ? { key, dir: s.dir === "desc" ? "asc" : "desc" } : { key, dir: key === "system" ? "asc" : "desc" }));
 
+  const phaseStep = selStep ?? stats?.step ?? null;
+
   return (
     <div className="min-h-screen pt-24 pb-20 relative">
       <div className="fixed inset-0 -z-10" style={{ background: "radial-gradient(ellipse at 20% 0%, rgba(4,95,133,0.07) 0%, transparent 50%), #030608" }} />
@@ -347,6 +290,19 @@ export function StatsView() {
               <Tile value={pct(stats.applications.submitted, stats.applications.total)} label="Submit rate" sub={`${fmtInt(stats.applications.byStatus[ApplicationStatus.IN_PROGRESS])} still in progress`} />
               <Tile value={fmtInt(stats.crossTeam.applicants)} label="Distinct applicants" sub={`${fmtInt(stats.crossTeam.byTeamCount[2] + stats.crossTeam.byTeamCount[3])} applied to 2+ teams`} />
             </div>
+
+            {/* Step rail + per-step deep dive */}
+            {phaseStep && (
+              <>
+                <StepRail current={stats.step} selected={phaseStep} snapshots={snapshots} onSelect={setSelStep} />
+                <PhaseSection
+                  step={phaseStep}
+                  currentStep={stats.step}
+                  live={stats}
+                  snapshot={snapshots.find((s) => s.snapshotStep === phaseStep)}
+                />
+              </>
+            )}
 
             {/* Time series */}
             <Card title="Over time" right={

--- a/app/admin/stats/StatsView.tsx
+++ b/app/admin/stats/StatsView.tsx
@@ -212,7 +212,7 @@ function niceStep(max: number): number {
 
 export function StatsView() {
   const { stats, error, isLoading, refreshing, refresh } = useStats();
-  const { snapshots } = useStatsSnapshots();
+  const { snapshots, error: snapshotsError } = useStatsSnapshots();
 
   const [selStep, setSelStep] = useState<RecruitingStep | null>(null);
   const [metric, setMetric] = useState<Metric>("submitted");
@@ -295,6 +295,9 @@ export function StatsView() {
             {phaseStep && (
               <>
                 <StepRail current={stats.step} selected={phaseStep} snapshots={snapshots} onSelect={setSelStep} />
+                {snapshotsError && (
+                  <p className="text-[11px] text-amber-300/80">Couldn&apos;t load step snapshots — past steps are showing live numbers.</p>
+                )}
                 <PhaseSection
                   step={phaseStep}
                   currentStep={stats.step}

--- a/app/admin/stats/atoms.tsx
+++ b/app/admin/stats/atoms.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import clsx from "clsx";
+import { Download } from "lucide-react";
+
+// Shared building blocks for /admin/stats (StatsView + the per-step phase
+// panels). Pure presentation — no data fetching here.
+
+export const fmtInt = (n: number) => n.toLocaleString("en-US");
+export const pct = (n: number, d: number) => (d > 0 ? `${Math.round((100 * n) / d)}%` : "—");
+
+export const GOLD = "var(--lhr-gold)";
+
+export function Segmented<T extends string | number>({ value, options, onChange }: { value: T; options: { value: T; label: string; disabled?: boolean }[]; onChange: (v: T) => void }) {
+  return (
+    <div className="inline-flex rounded-lg border border-white/10 bg-white/[0.04] p-0.5">
+      {options.map((o) => (
+        <button key={String(o.value)} disabled={o.disabled} onClick={() => onChange(o.value)}
+          className={clsx("px-2.5 h-7 rounded-md text-[12px] font-semibold transition-colors",
+            o.value === value ? "bg-white/10 text-white" : "text-white/50 hover:text-white/80",
+            o.disabled && "opacity-30 cursor-not-allowed")}>
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function Card({ title, right, children, className }: { title?: string; right?: React.ReactNode; children: React.ReactNode; className?: string }) {
+  return (
+    <section className={clsx("rounded-xl border border-white/10 bg-white/[0.04] p-5", className)}>
+      {(title || right) && (
+        <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+          {title && <h2 className="text-[14px] font-semibold text-white">{title}</h2>}
+          {right}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export function Tile({ value, label, sub, tone }: { value: string; label: string; sub?: string; tone?: "warn" | "good" }) {
+  return (
+    <div className={clsx("rounded-xl border px-4 py-3.5",
+      tone === "warn" ? "border-amber-400/25 bg-amber-400/[0.06]" : tone === "good" ? "border-emerald-400/20 bg-emerald-400/[0.05]" : "border-white/10 bg-white/[0.04]")}>
+      <div className={clsx("text-[26px] font-bold tracking-tight tabular-nums leading-none", tone === "warn" ? "text-amber-300" : "text-white")}>{value}</div>
+      <div className="text-[12px] text-white/60 mt-1.5">{label}</div>
+      {sub && <div className="text-[11px] text-white/35 mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+export function ExportButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button onClick={onClick} className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md border border-white/10 text-[12px] font-semibold text-white/50 hover:text-white hover:bg-white/5">
+      <Download className="h-3 w-3" /> CSV
+    </button>
+  );
+}
+
+export function Bar({ value, max, color }: { value: number; max: number; color: string }) {
+  return (
+    <div className="h-1.5 rounded-full bg-white/5 w-full overflow-hidden">
+      <div className="h-full rounded-full" style={{ width: `${max > 0 ? (100 * value) / max : 0}%`, background: color }} />
+    </div>
+  );
+}

--- a/app/admin/stats/phases.tsx
+++ b/app/admin/stats/phases.tsx
@@ -23,7 +23,7 @@ const TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
 /** Everything the phase panels need — RecruitingStats or a snapshot of one. */
 export type PhaseData = Omit<RecruitingStats, "series">;
 
-export const STEP_LABELS: Record<RecruitingStep, string> = {
+const STEP_LABELS: Record<RecruitingStep, string> = {
   [RecruitingStep.PRE_OPEN]: "Pre-open",
   [RecruitingStep.OPEN]: "Open",
   [RecruitingStep.REVIEWING]: "Reviewing",
@@ -209,7 +209,7 @@ function ReviewPanel({ data }: { data: PhaseData }) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <TallyTile tally={data.review.pendingReview} label="Awaiting first review" sub="submitted, no review decision" tone="warn" />
         <TallyTile tally={data.review.unranked} label="Submitted with no ranking" sub="invisible to every lead's queue — captains only (#131)" tone="warn" />
-        <TallyTile tally={data.interviews.atInterview} label="Advanced to interview" />
+        <TallyTile tally={data.interviews.atInterview} label="Currently at interview stage" />
         <Tile value={fmtInt(data.applications.byStatus.rejected)} label="Rejected so far" sub="internal status — releases mask it" />
       </div>
       <Card title="Still waiting on each system" right={
@@ -238,7 +238,7 @@ function ReviewPanel({ data }: { data: PhaseData }) {
             </tbody>
           </table>
         </div>
-        <p className="text-[11px] text-white/30 mt-3">Per ranked (application, system) pair — the same predicate the admin dashboard's pending counts use, so this always matches what each lead sees.</p>
+        <p className="text-[11px] text-white/30 mt-3">Per ranked (application, system) pair — the same predicate as the admin dashboard&apos;s pending counts (seeded fake applications excluded here).</p>
       </Card>
     </>
   );
@@ -255,7 +255,7 @@ function InterviewsPanel({ data }: { data: PhaseData }) {
         <TallyTile tally={iv.picked} label="Picked their system" tone="good" sub="one-way pick made" />
         <TallyTile tally={iv.awaitingPick} label="Awaiting pick" tone="warn" sub="multiple live offers, no pick yet" />
         <TallyTile tally={iv.singleLive} label="Single live offer" sub="no picker — staff mark completed / no-show" />
-        <TallyTile tally={iv.sweepPreview} label="Close sweep would reject" tone="warn" sub="same predicate the CLOSE_INTERVIEWS sweep runs" />
+        <TallyTile tally={iv.sweepPreview} label="Close sweep would reject" tone="warn" sub="same predicate the sweep runs; seeded fake data excluded" />
       </div>
 
       {iv.signupLinks.missing.length > 0 && (

--- a/app/admin/stats/phases.tsx
+++ b/app/admin/stats/phases.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useState } from "react";
+import clsx from "clsx";
+import { downloadCsv } from "@/lib/utils/downloadFile";
+import { Team } from "@/lib/models/User";
+import { RecruitingStep } from "@/lib/models/Config";
+import { STEP_ORDER } from "@/lib/utils/statusUtils";
+import { getTeamColor } from "@/lib/teamColors";
+import type { EmailTrigger } from "@/lib/models/EmailTemplate";
+import type { RecruitingStats, StatsSnapshot, Tally } from "@/lib/firebase/stats";
+import { Bar, Card, ExportButton, fmtInt, GOLD, pct, Segmented, Tile } from "./atoms";
+
+// ---------------------------------------------------------------------------
+// The per-step deep dive: a rail over the whole pipeline, and a phase panel
+// group per step. A past step renders from its frozen snapshot (captured by
+// the step-change route the moment the step ended); the current and future
+// steps render live numbers.
+// ---------------------------------------------------------------------------
+
+const TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
+
+/** Everything the phase panels need — RecruitingStats or a snapshot of one. */
+export type PhaseData = Omit<RecruitingStats, "series">;
+
+export const STEP_LABELS: Record<RecruitingStep, string> = {
+  [RecruitingStep.PRE_OPEN]: "Pre-open",
+  [RecruitingStep.OPEN]: "Open",
+  [RecruitingStep.REVIEWING]: "Reviewing",
+  [RecruitingStep.RELEASE_INTERVIEWS]: "Interviews out",
+  [RecruitingStep.INTERVIEWING]: "Interviewing",
+  [RecruitingStep.CLOSE_INTERVIEWS]: "Interviews close",
+  [RecruitingStep.RELEASE_TRIAL]: "Trials out",
+  [RecruitingStep.TRIAL_WORKDAY]: "Trial workday",
+  [RecruitingStep.RELEASE_DECISIONS_DAY1]: "Decisions D1",
+  [RecruitingStep.RELEASE_DECISIONS_DAY2]: "Decisions D2",
+  [RecruitingStep.RELEASE_DECISIONS_DAY3]: "Decisions D3",
+};
+
+type PhaseGroup = "review" | "interviews" | "trial" | "decisions";
+
+const STEP_GROUP: Record<RecruitingStep, PhaseGroup> = {
+  [RecruitingStep.PRE_OPEN]: "review",
+  [RecruitingStep.OPEN]: "review",
+  [RecruitingStep.REVIEWING]: "review",
+  [RecruitingStep.RELEASE_INTERVIEWS]: "interviews",
+  [RecruitingStep.INTERVIEWING]: "interviews",
+  [RecruitingStep.CLOSE_INTERVIEWS]: "interviews",
+  [RecruitingStep.RELEASE_TRIAL]: "trial",
+  [RecruitingStep.TRIAL_WORKDAY]: "trial",
+  [RecruitingStep.RELEASE_DECISIONS_DAY1]: "decisions",
+  [RecruitingStep.RELEASE_DECISIONS_DAY2]: "decisions",
+  [RecruitingStep.RELEASE_DECISIONS_DAY3]: "decisions",
+};
+
+const TRIGGER_LABELS: Record<EmailTrigger, string> = {
+  interview_offered: "Interview offer",
+  trial_offered: "Trial offer",
+  accepted: "Acceptance",
+  rejected: "Rejection",
+  waitlisted: "Waitlist",
+};
+
+const fmtWhen = (iso: string) =>
+  new Date(iso).toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+
+// ---------------------------------------------------------------------------
+// Step rail
+// ---------------------------------------------------------------------------
+
+export function StepRail({ current, selected, snapshots, onSelect }: {
+  current: RecruitingStep;
+  selected: RecruitingStep;
+  snapshots: StatsSnapshot[];
+  onSelect: (s: RecruitingStep) => void;
+}) {
+  const currentIdx = STEP_ORDER.indexOf(current);
+  const snapFor = (s: RecruitingStep) => snapshots.find((x) => x.snapshotStep === s);
+  return (
+    <div className="overflow-x-auto -mx-1 px-1">
+      <div className="flex items-stretch gap-1.5 min-w-max py-1">
+        {STEP_ORDER.map((s, i) => {
+          const isCurrent = s === current;
+          const isSelected = s === selected;
+          const isPast = i < currentIdx;
+          const snap = snapFor(s);
+          return (
+            <button key={s} onClick={() => onSelect(s)}
+              className={clsx(
+                "relative flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left transition-colors min-w-[92px]",
+                isSelected ? "border-white/30 bg-white/10" : "border-white/10 bg-white/[0.03] hover:bg-white/[0.07]",
+              )}>
+              <span className="flex items-center gap-1.5">
+                <i className={clsx("inline-block w-1.5 h-1.5 rounded-full",
+                  isCurrent ? "" : isPast ? "bg-white/40" : "bg-white/15")}
+                  style={isCurrent ? { background: GOLD } : undefined} />
+                <span className={clsx("text-[12px] font-semibold whitespace-nowrap", isCurrent ? "text-white" : isPast ? "text-white/70" : "text-white/40")}>
+                  {STEP_LABELS[s]}
+                </span>
+              </span>
+              <span className="text-[10px] text-white/30 whitespace-nowrap">
+                {isCurrent ? "now" : snap ? `ended ${fmtWhen(snap.capturedAt)}` : isPast ? "no snapshot" : "upcoming"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared pieces
+// ---------------------------------------------------------------------------
+
+function TeamDots({ tally }: { tally: Tally }) {
+  return (
+    <span className="inline-flex items-center gap-2.5 text-[11px] text-white/60 tabular-nums">
+      {TEAMS.map((t) => (
+        <span key={t} className="inline-flex items-center gap-1" title={t}>
+          <i className="inline-block w-2 h-2 rounded-sm" style={{ background: getTeamColor(t) }} />
+          {fmtInt(tally.byTeam[t])}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function TallyTile({ tally, label, sub, tone }: { tally: Tally; label: string; sub?: string; tone?: "warn" | "good" }) {
+  return (
+    <div className={clsx("rounded-xl border px-4 py-3.5",
+      tone === "warn" && tally.total > 0 ? "border-amber-400/25 bg-amber-400/[0.06]" : tone === "good" ? "border-emerald-400/20 bg-emerald-400/[0.05]" : "border-white/10 bg-white/[0.04]")}>
+      <div className={clsx("text-[26px] font-bold tracking-tight tabular-nums leading-none", tone === "warn" && tally.total > 0 ? "text-amber-300" : "text-white")}>{fmtInt(tally.total)}</div>
+      <div className="text-[12px] text-white/60 mt-1.5">{label}</div>
+      <div className="mt-1.5"><TeamDots tally={tally} /></div>
+      {sub && <div className="text-[11px] text-white/35 mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+function Th({ children, first }: { children?: React.ReactNode; first?: boolean }) {
+  return <th className={clsx("font-semibold py-2 px-3 whitespace-nowrap", first ? "text-left pl-0" : "text-right")}>{children}</th>;
+}
+
+function Td({ children, first, dim, strong }: { children: React.ReactNode; first?: boolean; dim?: boolean; strong?: boolean }) {
+  return (
+    <td className={clsx("py-2.5 px-3", first ? "text-left pl-0 font-semibold text-white whitespace-nowrap" : "text-right",
+      !first && (dim ? "text-white/20" : strong ? "text-white font-semibold" : "text-white/80"))}>
+      {children}
+    </td>
+  );
+}
+
+function EmailCoverage({ data, triggers }: { data: PhaseData; triggers: EmailTrigger[] }) {
+  const rows = data.emails.rows.filter((r) => triggers.includes(r.trigger));
+  const byTrigger = triggers.map((trigger) => {
+    const cells = TEAMS.map((team) => rows.find((r) => r.trigger === trigger && r.team === team) || { trigger, team, eligible: 0, sent: 0 });
+    const eligible = cells.reduce((a, c) => a + c.eligible, 0);
+    const sent = cells.reduce((a, c) => a + c.sent, 0);
+    return { trigger, cells, eligible, sent, unsent: eligible - sent };
+  });
+  const anyUnsent = byTrigger.some((r) => r.unsent > 0);
+  return (
+    <Card title="Email coverage" right={<span className="text-[11px] text-white/35">owed at this step (visible status) vs recorded as sent</span>}>
+      <div className="overflow-x-auto">
+        <table className="w-full text-[13px] tabular-nums">
+          <thead>
+            <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+              <Th first>Email</Th>
+              {TEAMS.map((t) => <Th key={t}>{t}</Th>)}
+              <Th>Sent / owed</Th>
+              <Th>Unsent</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {byTrigger.map((r) => (
+              <tr key={r.trigger} className="border-t border-white/5">
+                <Td first>{TRIGGER_LABELS[r.trigger]}</Td>
+                {r.cells.map((c) => (
+                  <Td key={c.team} dim={c.eligible === 0}>{fmtInt(c.sent)} / {fmtInt(c.eligible)}</Td>
+                ))}
+                <Td strong>{fmtInt(r.sent)} / {fmtInt(r.eligible)}</Td>
+                <td className={clsx("py-2.5 px-3 text-right font-semibold", r.unsent > 0 ? "text-amber-300" : "text-white/20")}>{fmtInt(r.unsent)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-[11px] text-white/30 mt-3">
+        {anyUnsent
+          ? "Unsent > 0 means applicants are owed an email at the current step — run Send Emails in Admin → Settings, or expect it if the release hasn't been sent yet."
+          : "Everyone owed one of these emails at the current step has it recorded."}
+        {" "}Same trigger derivation as the send job (visible status, never the raw one).
+      </p>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Phase panels
+// ---------------------------------------------------------------------------
+
+function ReviewPanel({ data }: { data: PhaseData }) {
+  const [team, setTeam] = useState<Team>(Team.ELECTRIC);
+  const rows = data.review.bySystem[team];
+  const max = Math.max(1, ...rows.map((r) => r.review + r.decision));
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <TallyTile tally={data.review.pendingReview} label="Awaiting first review" sub="submitted, no review decision" tone="warn" />
+        <TallyTile tally={data.review.unranked} label="Submitted with no ranking" sub="invisible to every lead's queue — captains only (#131)" tone="warn" />
+        <TallyTile tally={data.interviews.atInterview} label="Advanced to interview" />
+        <Tile value={fmtInt(data.applications.byStatus.rejected)} label="Rejected so far" sub="internal status — releases mask it" />
+      </div>
+      <Card title="Still waiting on each system" right={
+        <div className="flex items-center gap-2 flex-wrap">
+          <Segmented value={team} onChange={setTeam} options={TEAMS.map((t) => ({ value: t, label: t }))} />
+          <ExportButton onClick={() => downloadCsv(`pending-by-system-${team.toLowerCase()}.csv`, [["system", "review pending", "decision pending"], ...rows.map((r) => [r.system, r.review, r.decision])])} />
+        </div>
+      }>
+        <div className="overflow-x-auto">
+          <table className="w-full text-[13px] tabular-nums">
+            <thead>
+              <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                <Th first>System</Th><Th>Review pending</Th><Th>Decision pending</Th>
+                <th className="text-left font-semibold py-2 pl-4 w-40">Load</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.system} className="border-t border-white/5">
+                  <Td first>{r.system}</Td>
+                  <Td dim={r.review === 0} strong={r.review > 0}>{fmtInt(r.review)}</Td>
+                  <Td dim={r.decision === 0}>{fmtInt(r.decision)}</Td>
+                  <td className="pl-4"><Bar value={r.review + r.decision} max={max} color={getTeamColor(team)} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-[11px] text-white/30 mt-3">Per ranked (application, system) pair — the same predicate the admin dashboard's pending counts use, so this always matches what each lead sees.</p>
+      </Card>
+    </>
+  );
+}
+
+function InterviewsPanel({ data }: { data: PhaseData }) {
+  const [team, setTeam] = useState<Team>(Team.ELECTRIC);
+  const iv = data.interviews;
+  const sysRows = data.systems[team].filter((r) => r.interviewOffers > 0);
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        <TallyTile tally={iv.atInterview} label="At interview stage" />
+        <TallyTile tally={iv.picked} label="Picked their system" tone="good" sub="one-way pick made" />
+        <TallyTile tally={iv.awaitingPick} label="Awaiting pick" tone="warn" sub="multiple live offers, no pick yet" />
+        <TallyTile tally={iv.singleLive} label="Single live offer" sub="no picker — staff mark completed / no-show" />
+        <TallyTile tally={iv.sweepPreview} label="Close sweep would reject" tone="warn" sub="same predicate the CLOSE_INTERVIEWS sweep runs" />
+      </div>
+
+      {iv.signupLinks.missing.length > 0 && (
+        <Card title="Signup links missing" className="border-amber-400/25 bg-amber-400/[0.04]">
+          <p className="text-[13px] text-amber-200/90 mb-2">
+            {iv.signupLinks.missing.length} system{iv.signupLinks.missing.length === 1 ? " has" : "s have"} live interview offers but no signup link in the interview config — applicants there can see an offer but can&apos;t book:
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {iv.signupLinks.missing.map((m) => (
+              <span key={`${m.team}|${m.system}`} className="inline-flex items-center gap-1.5 rounded-md border border-amber-400/25 px-2 py-1 text-[12px] text-amber-100">
+                <i className="inline-block w-2 h-2 rounded-sm" style={{ background: getTeamColor(m.team) }} />{m.system}
+              </span>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <Card title="Offers by team">
+          <div className="overflow-x-auto">
+            <table className="w-full text-[13px] tabular-nums">
+              <thead>
+                <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                  <Th first>Team</Th><Th>Pending</Th><Th>Completed</Th><Th>No-show</Th><Th>Cancelled</Th><Th>Total</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {TEAMS.map((t) => {
+                  const o = iv.offersByTeam[t];
+                  return (
+                    <tr key={t} className="border-t border-white/5">
+                      <td className="py-2.5 pl-0 pr-3 font-semibold text-white"><span className="flex items-center gap-2"><i className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: getTeamColor(t) }} />{t}</span></td>
+                      <Td dim={o.pending === 0} strong={o.pending > 0}>{fmtInt(o.pending)}</Td>
+                      <Td dim={o.completed === 0}>{fmtInt(o.completed)}</Td>
+                      <Td dim={o.noShow === 0}>{fmtInt(o.noShow)}</Td>
+                      <Td dim={o.cancelled === 0}>{fmtInt(o.cancelled)}</Td>
+                      <Td strong>{fmtInt(o.total)}</Td>
+                    </tr>
+                  );
+                })}
+                <tr className="border-t border-white/10">
+                  <Td first>All</Td>
+                  <Td strong>{fmtInt(iv.offers.pending)}</Td>
+                  <Td strong>{fmtInt(iv.offers.completed)}</Td>
+                  <Td strong>{fmtInt(iv.offers.noShow)}</Td>
+                  <Td strong>{fmtInt(iv.offers.cancelled)}</Td>
+                  <Td strong>{fmtInt(iv.offers.total)}</Td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[11px] text-white/30 mt-3">
+            Signup links: {fmtInt(iv.signupLinks.withLink)} of {fmtInt(iv.signupLinks.needed)} systems with live offers have one configured.
+            Booking happens on external links, so completed / no-show are staff-marked.
+          </p>
+        </Card>
+
+        <Card title="Offers by system" right={
+          <div className="flex items-center gap-2 flex-wrap">
+            <Segmented value={team} onChange={setTeam} options={TEAMS.map((t) => ({ value: t, label: t }))} />
+            <ExportButton onClick={() => downloadCsv(`interview-offers-${team.toLowerCase()}.csv`, [["system", "offers", "pending", "completed", "no-show", "cancelled", "picked by"], ...sysRows.map((r) => [r.system, r.interviewOffers, r.intPending, r.intCompleted, r.intNoShow, r.intCancelled, r.picked])])} />
+          </div>
+        }>
+          {sysRows.length === 0 ? <p className="text-[12px] text-white/30">No interview offers on this team yet.</p> : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-[13px] tabular-nums">
+                <thead>
+                  <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                    <Th first>System</Th><Th>Offers</Th><Th>Pending</Th><Th>Done</Th><Th>No-show</Th><Th>Cancelled</Th><Th>Picked by</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sysRows.map((r) => (
+                    <tr key={r.system} className="border-t border-white/5">
+                      <Td first>{r.system}</Td>
+                      <Td strong>{fmtInt(r.interviewOffers)}</Td>
+                      <Td dim={r.intPending === 0}>{fmtInt(r.intPending)}</Td>
+                      <Td dim={r.intCompleted === 0}>{fmtInt(r.intCompleted)}</Td>
+                      <Td dim={r.intNoShow === 0}>{fmtInt(r.intNoShow)}</Td>
+                      <Td dim={r.intCancelled === 0}>{fmtInt(r.intCancelled)}</Td>
+                      <Td dim={r.picked === 0} strong={r.picked > 0}>{fmtInt(r.picked)}</Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          <p className="text-[11px] text-white/30 mt-3">&ldquo;Picked by&rdquo; counts one-way picks that landed on this system, whatever stage those applicants are at now.</p>
+        </Card>
+      </div>
+
+      <EmailCoverage data={data} triggers={["interview_offered", "rejected"]} />
+    </>
+  );
+}
+
+function TrialPanel({ data }: { data: PhaseData }) {
+  const dc = data.decisions;
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <TallyTile tally={dc.trialOffers} label="Trial offers extended" sub="offer count, not applicants" />
+        <TallyTile tally={dc.trialDecisions.advanced} label="Advanced (accept coming)" tone="good" />
+        <TallyTile tally={dc.trialDecisions.waitlisted} label="Waitlist decisions" />
+        <TallyTile tally={dc.trialDecisions.rejected} label="Trial-stage rejections" sub="masked until their decision day" />
+      </div>
+      <EmailCoverage data={data} triggers={["trial_offered", "rejected"]} />
+    </>
+  );
+}
+
+function DecisionsPanel({ data }: { data: PhaseData }) {
+  const dc = data.decisions;
+  const days = ["1", "2", "3"] as const;
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        <TallyTile tally={dc.committed} label="Committed" tone="good" />
+        <TallyTile tally={dc.awaitingResponse} label="Offer out, awaiting response" tone="warn" sub="unanswered offers expire at the next advance" />
+        <TallyTile tally={dc.declined} label="Declined" />
+        <TallyTile tally={dc.waitlisted} label="On the waitlist" sub="the reneg / promotion pathway" />
+        <Tile value={fmtInt(dc.reneged)} label="Renegs" sub={`auto-rejected: ${fmtInt(dc.autoRejected.offerExpired)} expired · ${fmtInt(dc.autoRejected.committedElsewhere)} committed elsewhere`} />
+      </div>
+
+      <Card title="Final offers by release day">
+        <div className="overflow-x-auto">
+          <table className="w-full text-[13px] tabular-nums">
+            <thead>
+              <tr className="text-white/40 text-[11px] uppercase tracking-wider">
+                <Th first>Day</Th><Th>Offers</Th><Th>Committed</Th><Th>Declined</Th><Th>Awaiting</Th><Th>Expired</Th><Th>Commit rate</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {days.map((d) => {
+                const r = dc.byDay[d];
+                const resolved = r.committed + r.declined + r.expired;
+                return (
+                  <tr key={d} className="border-t border-white/5">
+                    <Td first>Day {d}</Td>
+                    <Td strong>{fmtInt(r.decided)}</Td>
+                    <Td dim={r.committed === 0} strong={r.committed > 0}>{fmtInt(r.committed)}</Td>
+                    <Td dim={r.declined === 0}>{fmtInt(r.declined)}</Td>
+                    <td className={clsx("py-2.5 px-3 text-right", r.awaiting > 0 ? "text-amber-300 font-semibold" : "text-white/20")}>{fmtInt(r.awaiting)}</td>
+                    <Td dim={r.expired === 0}>{fmtInt(r.expired)}</Td>
+                    <Td dim={resolved === 0}>{pct(r.committed, resolved)}</Td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-[11px] text-white/30 mt-3">
+          An offer counts on the day it was stamped for, which is also the day the applicant first sees it. Day 2/3 offers stamped early sit in &ldquo;Awaiting&rdquo; until their own release day. Commit rate is committed ÷ resolved (committed + declined + expired).
+        </p>
+      </Card>
+
+      <EmailCoverage data={data} triggers={["accepted", "waitlisted", "rejected"]} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section wrapper: picks panel group + data source (live vs snapshot)
+// ---------------------------------------------------------------------------
+
+export function PhaseSection({ step, currentStep, live, snapshot }: {
+  step: RecruitingStep;
+  currentStep: RecruitingStep;
+  live: RecruitingStats;
+  snapshot?: StatsSnapshot;
+}) {
+  const idx = STEP_ORDER.indexOf(step);
+  const currentIdx = STEP_ORDER.indexOf(currentStep);
+  const isPast = idx < currentIdx;
+  const data: PhaseData = isPast && snapshot ? snapshot : live;
+  const group = STEP_GROUP[step];
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3 flex-wrap">
+        <h2 className="text-[15px] font-semibold text-white">{STEP_LABELS[step]}</h2>
+        {isPast && snapshot && (
+          <span className="text-[11px] rounded-md border border-white/10 bg-white/[0.04] px-2 py-1 text-white/50">
+            Frozen as this step ended — {STEP_LABELS[snapshot.snapshotStep]} → {STEP_LABELS[snapshot.nextStep]}, {fmtWhen(snapshot.capturedAt)}
+          </span>
+        )}
+        {isPast && !snapshot && (
+          <span className="text-[11px] rounded-md border border-amber-400/25 bg-amber-400/[0.06] px-2 py-1 text-amber-200/90">
+            No snapshot was captured for this step — showing live numbers instead
+          </span>
+        )}
+        {idx > currentIdx && (
+          <span className="text-[11px] rounded-md border border-white/10 bg-white/[0.04] px-2 py-1 text-white/50">
+            Not reached yet — live numbers as a preview
+          </span>
+        )}
+      </div>
+      {group === "review" && <ReviewPanel data={data} />}
+      {group === "interviews" && <InterviewsPanel data={data} />}
+      {group === "trial" && <TrialPanel data={data} />}
+      {group === "decisions" && <DecisionsPanel data={data} />}
+    </div>
+  );
+}

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -4,6 +4,7 @@ import { getRecruitingConfig, updateRecruitingStep, updateRenegEnabled } from "@
 import { RecruitingStep } from "@/lib/models/Config";
 import { autoRejectUnscheduledInterviewApplicants, sweepOnDecisionAdvance } from "@/lib/firebase/applications";
 import { appCache } from "@/lib/utils/appCache";
+import { captureStatsSnapshot, invalidateRecruitingStats } from "@/lib/firebase/stats";
 import { logger } from "@/lib/logger";
 import { STEP_ORDER } from "@/lib/utils/statusUtils";
 import { recordAudit } from "@/lib/firebase/audit";
@@ -68,6 +69,19 @@ export async function POST(request: NextRequest) {
       }, { status: 400 });
     }
 
+    // Freeze end-of-step stats BEFORE the step (and its sweeps) rewrite the
+    // world — this is what lets /admin/stats show what a past step looked
+    // like. Forward transitions only; a failure is reported, never fatal.
+    let snapshotError: string | undefined;
+    if (toIdx > fromIdx) {
+      try {
+        await captureStatsSnapshot(before, step, uid);
+      } catch (err) {
+        logger.error({ err, before, step }, "Failed to capture stats snapshot on step change");
+        snapshotError = `The step was saved, but freezing the end-of-${before} stats snapshot failed — that transition's numbers were not recorded.`;
+      }
+    }
+
     await updateRecruitingStep(step, uid);
     await recordAudit(request, { uid }, { action: "config.recruiting_step", before: { step: before }, after: { step }, detail: `${before} → ${step}${confirm ? " (typed confirmation)" : ""}` });
 
@@ -109,8 +123,10 @@ export async function POST(request: NextRequest) {
     appCache.setRecruitingStep(step);
     // Invalidate applications because their computed status/ratings depend on the step
     appCache.invalidateApplications();
+    // The 5-min stats cache still says the old step (and pre-sweep counts).
+    invalidateRecruitingStats();
 
-    return NextResponse.json({ success: true, step, ...(sweepError ? { sweepError } : {}) });
+    return NextResponse.json({ success: true, step, ...(sweepError ? { sweepError } : {}), ...(snapshotError ? { snapshotError } : {}) });
   } catch (error) {
     logger.error(error, "Failed to update recruiting step");
     

--- a/app/api/admin/config/recruiting/route.ts
+++ b/app/api/admin/config/recruiting/route.ts
@@ -9,6 +9,9 @@ import { logger } from "@/lib/logger";
 import { STEP_ORDER } from "@/lib/utils/statusUtils";
 import { recordAudit } from "@/lib/firebase/audit";
 
+// Step changes now snapshot the stats and run one-shot sweeps in-request; on
+// a full cycle's data that must not hit the platform's shorter defaults.
+export const maxDuration = 300;
 
 export async function GET(request: NextRequest) {
   try {
@@ -75,7 +78,13 @@ export async function POST(request: NextRequest) {
     let snapshotError: string | undefined;
     if (toIdx > fromIdx) {
       try {
-        await captureStatsSnapshot(before, step, uid);
+        // Bounded: the step write below must never be starved by this scan.
+        // On timeout the capture keeps running detached — its compute read the
+        // config before the step flips, so a late write still lands correctly.
+        await Promise.race([
+          captureStatsSnapshot(before, step, uid),
+          new Promise((_, reject) => setTimeout(() => reject(new Error("stats snapshot timed out")), 8000)),
+        ]);
       } catch (err) {
         logger.error({ err, before, step }, "Failed to capture stats snapshot on step change");
         snapshotError = `The step was saved, but freezing the end-of-${before} stats snapshot failed — that transition's numbers were not recorded.`;

--- a/app/api/admin/config/recruiting/trigger-emails/route.ts
+++ b/app/api/admin/config/recruiting/trigger-emails/route.ts
@@ -5,7 +5,7 @@ import { getRecruitingConfig, getEmailTemplatesConfig } from "@/lib/firebase/con
 import { adminDb } from "@/lib/firebase/admin";
 import { Application, ApplicationStatus } from "@/lib/models/Application";
 import { getUserVisibleStatus } from "@/lib/utils/statusUtils";
-import { EmailTrigger } from "@/lib/models/EmailTemplate";
+import { STATUS_EMAIL_TRIGGERS } from "@/lib/models/EmailTemplate";
 import { sendStatusEmail } from "@/lib/email/send";
 import { markEmailSent } from "@/lib/firebase/applications";
 import { logger } from "@/lib/logger";
@@ -146,16 +146,10 @@ async function triggerEmails(step: any, force: boolean, applicationIds?: string[
   for (const app of applications) {
     try {
       const visibleStatus = getUserVisibleStatus(app, step);
-      
-      const triggerMap: Partial<Record<ApplicationStatus, EmailTrigger>> = {
-        [ApplicationStatus.INTERVIEW]: "interview_offered",
-        [ApplicationStatus.TRIAL]: "trial_offered",
-        [ApplicationStatus.ACCEPTED]: "accepted",
-        [ApplicationStatus.REJECTED]: "rejected",
-        [ApplicationStatus.WAITLISTED]: "waitlisted",
-      };
 
-      const expectedTrigger = triggerMap[visibleStatus];
+      // Visible status → trigger lives in the model (STATUS_EMAIL_TRIGGERS)
+      // and is shared with the stats email-coverage numbers.
+      const expectedTrigger = STATUS_EMAIL_TRIGGERS[visibleStatus];
       
       if (expectedTrigger) {
         const alreadySent = !force && app.emailsSent && app.emailsSent.includes(expectedTrigger);

--- a/app/api/admin/dashboard/pending-count/route.ts
+++ b/app/api/admin/dashboard/pending-count/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { requireStaff } from "@/lib/auth/guard";
 import { adminDb } from "@/lib/firebase/admin";
 import { UserRole, Team } from "@/lib/models/User";
-import { ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
+import { ApplicationStatus } from "@/lib/models/Application";
+import { systemPending } from "@/lib/utils/systemPending";
 import { logger } from "@/lib/logger";
 
 
@@ -17,36 +18,6 @@ interface PendingCounts {
     total: number;
     byGroup: Record<string, number>;
   };
-}
-
-/**
- * What one system still has to decide on an application (#131). The global
- * status is the applicant's pipeline stage — a per-system rejection leaves it
- * `submitted` until every ranked system has rejected, and another system's
- * offer moves it to `interview` — so for a lead or reviewer the count has to
- * be per-system, the same lens as the applicants list (#126):
- *  - review pending: the application is still in play (submitted, interview
- *    or trial stage) and this system has neither rejected it nor extended an
- *    offer — another system's advance does not review it for us;
- *  - decision pending: this system's interview offer is out with no
- *    rejection or trial offer after it, or this system's trial offer is out
- *    and the final decision has not been made.
- * A cancelled offer is no offer; completed and no-show offers still stand.
- */
-function systemPending(app: FirebaseFirestore.DocumentData, system: string): { review: boolean; decision: boolean } {
-  const live = (o: { system?: string; status?: string }) => o.system === system && o.status !== InterviewEventStatus.CANCELLED;
-  const rejected = ((app.rejectedBySystems as string[] | undefined) || []).includes(system);
-  const interviewOffer = ((app.interviewOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
-  const trialOffer = ((app.trialOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
-  const S = ApplicationStatus;
-  const inPlay = app.status === S.SUBMITTED || app.status === S.INTERVIEW || app.status === S.TRIAL;
-  const review = inPlay && !rejected && !interviewOffer && !trialOffer;
-  const decision =
-    !rejected &&
-    ((app.status === S.INTERVIEW && interviewOffer && !trialOffer) ||
-      (app.status === S.TRIAL && trialOffer && !app.trialDecision) ||
-      (app.status === S.TRIAL && interviewOffer && !trialOffer));
-  return { review, decision };
 }
 
 export async function GET() {

--- a/app/api/admin/stats/snapshots/route.ts
+++ b/app/api/admin/stats/snapshots/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { requireStaff, guardErrorStatus } from "@/lib/auth/guard";
+import { getStatsSnapshots } from "@/lib/firebase/stats";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/stats/snapshots — the per-step stats snapshots frozen by each
+ * forward step transition (staff only). Same aggregate-only rule as the live
+ * stats: nothing in a snapshot identifies an applicant.
+ */
+export async function GET() {
+  try {
+    await requireStaff();
+    const snapshots = await getStatsSnapshots();
+    return NextResponse.json({ snapshots }, { headers: { "Cache-Control": "private, no-store" } });
+  } catch (error) {
+    const status = guardErrorStatus(error);
+    if (status) return NextResponse.json({ error: (error as Error).message }, { status });
+    logger.error({ err: error }, "Failed to load stats snapshots");
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -748,9 +748,24 @@ body {
 [data-theme="light"] .bg-white\/\[0\.08\] { background-color: rgba(0, 0, 0, 0.06) !important; }
 [data-theme="light"] .hover\:bg-white\/\[0\.08\]:hover { background-color: rgba(0, 0, 0, 0.08) !important; }
 [data-theme="light"] .bg-white\/\[0\.02\] { background-color: rgba(0, 0, 0, 0.02) !important; }
+[data-theme="light"] .bg-white\/\[0\.03\] { background-color: rgba(0, 0, 0, 0.03) !important; }
+[data-theme="light"] .hover\:bg-white\/\[0\.07\]:hover { background-color: rgba(0, 0, 0, 0.07) !important; }
 [data-theme="light"] .border-white\/\[0\.06\] { border-color: rgba(0, 0, 0, 0.10) !important; }
 [data-theme="light"] .border-white\/\[0\.12\] { border-color: rgba(0, 0, 0, 0.14) !important; }
 [data-theme="light"] .hover\:border-white\/\[0\.12\]:hover { border-color: rgba(0, 0, 0, 0.14) !important; }
+
+/* Amber/emerald status colours on /admin/stats (needs-attention tiles, email
+   coverage, signup-link warnings). The dark palette's pale ambers are near-
+   invisible on the light surface, so remap to their dark ends. */
+[data-theme="light"] .text-amber-300 { color: #b45309 !important; }
+[data-theme="light"] .text-amber-300\/80 { color: rgba(180, 83, 9, 0.9) !important; }
+[data-theme="light"] .text-amber-200\/90 { color: #92400e !important; }
+[data-theme="light"] .text-amber-100 { color: #78350f !important; }
+[data-theme="light"] .border-amber-400\/25 { border-color: rgba(180, 83, 9, 0.40) !important; }
+[data-theme="light"] .bg-amber-400\/\[0\.06\] { background-color: rgba(180, 83, 9, 0.08) !important; }
+[data-theme="light"] .bg-amber-400\/\[0\.04\] { background-color: rgba(180, 83, 9, 0.06) !important; }
+[data-theme="light"] .border-emerald-400\/20 { border-color: rgba(4, 120, 87, 0.35) !important; }
+[data-theme="light"] .bg-emerald-400\/\[0\.05\] { background-color: rgba(4, 120, 87, 0.07) !important; }
 
 /* ─── Dark-scope re-assertion ───────────────────────────────────────────
    Some sections (the Hero with its dark video background) must remain dark

--- a/hooks/useStats.ts
+++ b/hooks/useStats.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import useSWR from "swr";
 import { authFetcher } from "@/lib/auth/fetcher";
-import type { RecruitingStats } from "@/lib/firebase/stats";
+import type { RecruitingStats, StatsSnapshot } from "@/lib/firebase/stats";
 
 /**
  * Aggregate recruiting stats for /admin/stats. Server-cached for 5 minutes;
@@ -27,4 +27,17 @@ export function useStats() {
   }, [mutate]);
 
   return { stats: data ?? null, error, isLoading, refreshing, refresh };
+}
+
+/**
+ * The per-step snapshots frozen by each forward step transition. Changes only
+ * when an admin advances the cycle, so a long deduping window is fine.
+ */
+export function useStatsSnapshots() {
+  const { data, error, isLoading } = useSWR<{ snapshots: StatsSnapshot[] }>(
+    "/api/admin/stats/snapshots",
+    authFetcher,
+    { revalidateOnFocus: false, dedupingInterval: 5 * 60_000 }
+  );
+  return { snapshots: data?.snapshots ?? [], error, isLoading };
 }

--- a/hooks/useStats.ts
+++ b/hooks/useStats.ts
@@ -31,13 +31,14 @@ export function useStats() {
 
 /**
  * The per-step snapshots frozen by each forward step transition. Changes only
- * when an admin advances the cycle, so a long deduping window is fine.
+ * when an admin advances the cycle; a minute of deduping keeps the rail fresh
+ * shortly after an advance without hammering the route.
  */
 export function useStatsSnapshots() {
   const { data, error, isLoading } = useSWR<{ snapshots: StatsSnapshot[] }>(
     "/api/admin/stats/snapshots",
     authFetcher,
-    { revalidateOnFocus: false, dedupingInterval: 5 * 60_000 }
+    { revalidateOnFocus: false, dedupingInterval: 60_000 }
   );
   return { snapshots: data?.snapshots ?? [], error, isLoading };
 }

--- a/lib/firebase/applications.ts
+++ b/lib/firebase/applications.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/models/Application";
 import { Team, ElectricSystem, SolarSystem, CombustionSystem } from "@/lib/models/User";
 import { RecruitingStep } from "@/lib/models/Config";
+import { closeInterviewsWouldReject } from "@/lib/utils/interviewSweep";
 import { FieldValue } from "firebase-admin/firestore";
 
 const APPLICATIONS_COLLECTION = "applications";
@@ -1038,32 +1039,9 @@ export async function autoRejectUnscheduledInterviewApplicants(): Promise<string
     const offers = normalizeInterviewOffers(data.interviewOffers) || [];
     if (offers.length === 0) continue;
 
-    // Booking happens on an external link, so offer status is the only record
-    // of what happened. In order:
-    //  1. An interview that took place is never swept, whatever else is on
-    //     the record — a second offer added afterwards used to get the
-    //     applicant rejected because they never used the picker.
-    //  2. Offers that all ended explicitly (no-show, cancelled) are closed out
-    //     for every team; those applicants otherwise sit at "Interview" with a
-    //     live signup link through decision day 3.
-    //  3. Applicants holding several offers who never picked one never booked
-    //     anything (every team picks one system — PM, 2026-08-30).
-    // A lone PENDING offer is ambiguous (never booked, or interviewed and not
-    // yet marked) and is left alone rather than rejected on a guess.
-    const statuses = offers.map((o) => o.status);
-    if (statuses.includes(InterviewEventStatus.COMPLETED)) continue;
-    const allEnded = statuses.every(
-      (s) => s === InterviewEventStatus.NO_SHOW || s === InterviewEventStatus.CANCELLED
-    );
-    // Note [no_show, pending] lands here as pendingCount 1 -> spared: the
-    // no-show at one system says nothing about the OTHER system's interview,
-    // which happened (or not) on an external link we cannot verify — so what
-    // remains is exactly the lone-pending ambiguity above, handled the same
-    // way. Staff resolve it by marking the pending offer completed/no-show;
-    // re-saving this step re-runs the sweep.
-    const pendingCount = statuses.filter((s) => s === InterviewEventStatus.PENDING).length;
-    const neverPicked = pendingCount > 1 && !data.selectedInterviewSystem;
-    if (!allEnded && !neverPicked) continue;
+    // The verdict itself lives in lib/utils/interviewSweep.ts (with the full
+    // rationale) so the stats sweep preview and this sweep can never disagree.
+    if (!closeInterviewsWouldReject(offers.map((o) => o.status), data.selectedInterviewSystem)) continue;
 
     await rejectApplicationFromSystems(doc.id, offers.map((o) => o.system));
     rejectedIds.push(doc.id);

--- a/lib/firebase/stats.ts
+++ b/lib/firebase/stats.ts
@@ -1,5 +1,6 @@
 import { adminDb } from "./admin";
 import { getRecruitingConfig } from "./config";
+import { slugifySystem } from "./utils";
 import { Team, UserRole } from "@/lib/models/User";
 import { Application, ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
 import { RecruitingStep } from "@/lib/models/Config";
@@ -15,9 +16,11 @@ import { closeInterviewsWouldReject } from "@/lib/utils/interviewSweep";
  * Everything here is a count. No document in the response carries a name, an
  * email, a uid, or free text — the stats page is meant to be safe to
  * screenshot into Slack, and /api/stats hands a further-reduced subset to the
- * recruiting bot. Keep it that way: add numbers, never records. (The one
- * deliberate exception: system/team names in `interviews.signupLinks` — those
- * are staff configuration, not applicants.)
+ * recruiting bot. Keep it that way: add numbers, never records. (Two
+ * deliberate exceptions: system/team names in `interviews.signupLinks` —
+ * staff configuration, not applicants — and the staff uid in a snapshot's
+ * `capturedBy`, the admin who saved the transition, which the audit log
+ * records anyway.)
  *
  * History is derived from timestamps already on the data (createdAt,
  * submittedAt, user createdAt) rather than stored snapshots, so there is no
@@ -43,6 +46,10 @@ const STATS_TTL_MS = 5 * 60 * 1000;
 const SERIES_MAX_DAYS = 90;
 const DEMOGRAPHIC_TOP_N = 15;
 const SNAPSHOT_COLLECTION = "stats_snapshots";
+// Bump when a phase-section shape changes incompatibly: snapshots are durable
+// docs, and getStatsSnapshots drops mismatched ones (the UI then falls back
+// to live numbers) instead of letting an old shape crash the panels.
+const SNAPSHOT_SCHEMA_VERSION = 1;
 
 export const STATS_TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
 const STATUSES = Object.values(ApplicationStatus) as ApplicationStatus[];
@@ -178,6 +185,7 @@ export interface RecruitingStats {
  * step left it. Doc id = the step being left.
  */
 export interface StatsSnapshot extends Omit<RecruitingStats, "series"> {
+  schemaVersion: number;
   snapshotStep: RecruitingStep;
   nextStep: RecruitingStep;
   capturedAt: string;
@@ -324,7 +332,9 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
   const review: RecruitingStats["review"] = {
     pendingReview: zeroTally(),
     unranked: zeroTally(),
-    bySystem: Object.fromEntries(STATS_TEAMS.map((t) => [t, []])) as RecruitingStats["review"]["bySystem"],
+    bySystem: Object.fromEntries(
+      STATS_TEAMS.map((t) => [t, [] as { system: string; review: number; decision: number }[]])
+    ) as RecruitingStats["review"]["bySystem"],
   };
   const offersByTeam = Object.fromEntries(
     STATS_TEAMS.map((t) => [t, zeroOffers()])
@@ -398,10 +408,18 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
       if (typeof sys === "string") demand(team, sys).rejectedBy++;
     }
 
-    const iOffers = (Array.isArray(a.interviewOffers) ? a.interviewOffers : [])
-      .filter((o: unknown): o is { system: string; status?: unknown } => !!o && typeof (o as { system?: unknown }).system === "string");
+    // Same normalisation as the sweep's normalizeInterviewOffers: a legacy doc
+    // may store a single offer object instead of an array, and the sweep does
+    // not require `system` to be a string — the preview must not diverge.
+    const rawInterviewOffers: unknown[] = Array.isArray(a.interviewOffers)
+      ? a.interviewOffers
+      : a.interviewOffers && typeof a.interviewOffers === "object" ? [a.interviewOffers] : [];
+    const iOffers = rawInterviewOffers.filter(
+      (o): o is { system?: unknown; status?: unknown } => !!o && typeof o === "object"
+    );
     const iStatuses = iOffers.map((o) => String(o.status ?? ""));
     for (const o of iOffers) {
+      if (typeof o.system !== "string") continue; // demand rows need a name
       const dm = demand(team, o.system);
       dm.interviewOffers++;
       const tc = offersByTeam[team];
@@ -455,12 +473,12 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
       else if (liveCount === 1) bump(interviews.singleLive, team);
       if (closeInterviewsWouldReject(iStatuses, a.selectedInterviewSystem)) bump(interviews.sweepPreview, team);
       for (const o of iOffers) {
-        if (String(o.status ?? "") === InterviewEventStatus.PENDING) neededLinks.add(`${team}|${o.system}`);
+        if (typeof o.system === "string" && String(o.status ?? "") === InterviewEventStatus.PENDING) neededLinks.add(`${team}|${o.system}`);
       }
     }
 
     // ---- trial + decision days ----
-    const td = a.trialDecision;
+    const td = a.trialDecision as string | undefined;
     if (td === "advanced" || td === "rejected" || td === "waitlisted") bump(decisions.trialDecisions[td], team);
     if (status === ApplicationStatus.COMMITTED) bump(decisions.committed, team);
     if (status === ApplicationStatus.DECLINED) bump(decisions.declined, team);
@@ -508,20 +526,24 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
     interviews.offers.noShow += tc.noShow;
     interviews.offers.total += tc.total;
   }
+  // Mirror the applicant-facing lookup (app/api/applications/[id]/interview):
+  // doc id first, team+system fields as fallback. Several live docs carry
+  // stale identity fields from the system renames, and keying on fields alone
+  // would raise false "missing link" warnings for systems that book fine.
   const linkByKey = new Map<string, string>();
+  const linkById = new Map<string, string>();
   for (const d of interviewConfigsSnap.docs) {
     const c = d.data();
-    if (typeof c.team === "string" && typeof c.system === "string") {
-      linkByKey.set(`${c.team}|${c.system}`, typeof c.signupLink === "string" ? c.signupLink.trim() : "");
-    }
+    const link = typeof c.signupLink === "string" ? c.signupLink.trim() : "";
+    linkById.set(d.id, link);
+    if (typeof c.team === "string" && typeof c.system === "string") linkByKey.set(`${c.team}|${c.system}`, link);
   }
   interviews.signupLinks.needed = neededLinks.size;
   for (const key of neededLinks) {
-    if (linkByKey.get(key)) interviews.signupLinks.withLink++;
-    else {
-      const [team, system] = key.split("|");
-      interviews.signupLinks.missing.push({ team: team as Team, system });
-    }
+    const [team, system] = key.split("|");
+    const docId = `${team.toLowerCase().replace(/\s+/g, "-")}-${slugifySystem(system)}`;
+    if (linkById.get(docId) || linkByKey.get(key)) interviews.signupLinks.withLink++;
+    else interviews.signupLinks.missing.push({ team: team as Team, system });
   }
   interviews.signupLinks.missing.sort((a, b) => a.team.localeCompare(b.team) || a.system.localeCompare(b.system));
 
@@ -595,11 +617,17 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
 let cached: { stats: RecruitingStats; at: number } | null = null;
 let inflight: Promise<RecruitingStats> | null = null;
 
+// Bumped by invalidateRecruitingStats so a compute that was already running
+// when the world changed (step advanced, a sweep fired) can't land afterwards
+// and re-cache pre-change numbers for five minutes.
+let generation = 0;
+
 export async function getRecruitingStats(opts: { fresh?: boolean } = {}): Promise<RecruitingStats> {
   if (!opts.fresh && cached && Date.now() - cached.at < STATS_TTL_MS) return cached.stats;
   if (!inflight) {
+    const startedAt = generation;
     inflight = computeRecruitingStats()
-      .then((stats) => { cached = { stats, at: Date.now() }; return stats; })
+      .then((stats) => { if (generation === startedAt) cached = { stats, at: Date.now() }; return stats; })
       .finally(() => { inflight = null; });
   }
   return inflight;
@@ -607,6 +635,11 @@ export async function getRecruitingStats(opts: { fresh?: boolean } = {}): Promis
 
 export function invalidateRecruitingStats(): void {
   cached = null;
+  generation++;
+  // A compute started before this point may still be running; the generation
+  // check stops it from re-caching, and dropping inflight makes the next
+  // caller start a fresh one instead of adopting the stale promise.
+  inflight = null;
 }
 
 /**
@@ -625,6 +658,7 @@ export async function captureStatsSnapshot(
   const { series: _series, ...counts } = await computeRecruitingStats();
   const snapshot: StatsSnapshot = {
     ...counts,
+    schemaVersion: SNAPSHOT_SCHEMA_VERSION,
     step: fromStep,
     snapshotStep: fromStep,
     nextStep: toStep,
@@ -639,7 +673,7 @@ export async function getStatsSnapshots(): Promise<StatsSnapshot[]> {
   const snap = await adminDb.collection(SNAPSHOT_COLLECTION).get();
   const rows = snap.docs
     .map((d) => d.data() as StatsSnapshot)
-    .filter((s) => STEP_ORDER.includes(s.snapshotStep));
+    .filter((s) => s.schemaVersion === SNAPSHOT_SCHEMA_VERSION && STEP_ORDER.includes(s.snapshotStep));
   rows.sort((a, b) => STEP_ORDER.indexOf(a.snapshotStep) - STEP_ORDER.indexOf(b.snapshotStep));
   return rows;
 }

--- a/lib/firebase/stats.ts
+++ b/lib/firebase/stats.ts
@@ -1,9 +1,13 @@
 import { adminDb } from "./admin";
 import { getRecruitingConfig } from "./config";
 import { Team, UserRole } from "@/lib/models/User";
-import { ApplicationStatus } from "@/lib/models/Application";
+import { Application, ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
 import { RecruitingStep } from "@/lib/models/Config";
 import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
+import { EmailTrigger, STATUS_EMAIL_TRIGGERS } from "@/lib/models/EmailTemplate";
+import { getUserVisibleStatus, clampDecisionDay, STEP_ORDER } from "@/lib/utils/statusUtils";
+import { systemPending } from "@/lib/utils/systemPending";
+import { closeInterviewsWouldReject } from "@/lib/utils/interviewSweep";
 
 /**
  * Aggregate recruiting statistics.
@@ -11,28 +15,53 @@ import { TEAM_SYSTEMS } from "@/lib/models/teamQuestions";
  * Everything here is a count. No document in the response carries a name, an
  * email, a uid, or free text — the stats page is meant to be safe to
  * screenshot into Slack, and /api/stats hands a further-reduced subset to the
- * recruiting bot. Keep it that way: add numbers, never records.
+ * recruiting bot. Keep it that way: add numbers, never records. (The one
+ * deliberate exception: system/team names in `interviews.signupLinks` — those
+ * are staff configuration, not applicants.)
  *
  * History is derived from timestamps already on the data (createdAt,
  * submittedAt, user createdAt) rather than stored snapshots, so there is no
  * cron to keep alive. One consequence: an application that is submitted and
  * later reopened drops out of the "submitted" history entirely.
+ *
+ * The exception to "no stored snapshots": each FORWARD recruiting-step
+ * transition freezes the numbers as they stood at that moment into
+ * `stats_snapshots/{stepBeingLeft}` (captureStatsSnapshot, called by the
+ * step-change route before the step is written and before any sweep runs).
+ * That is what lets /admin/stats show what the world looked like at the end
+ * of a past step after sweeps and releases have moved everyone on.
+ *
+ * The phase sections (review / interviews / decisions / emails) reuse the
+ * exact predicates the operational code runs — systemPending from the
+ * dashboard, closeInterviewsWouldReject from the CLOSE_INTERVIEWS sweep,
+ * STATUS_EMAIL_TRIGGERS + getUserVisibleStatus from the email job — so the
+ * numbers here can never drift from what those features will actually do.
  */
 
 export const STATS_BUCKET_MINUTES = 15;
 const STATS_TTL_MS = 5 * 60 * 1000;
 const SERIES_MAX_DAYS = 90;
 const DEMOGRAPHIC_TOP_N = 15;
+const SNAPSHOT_COLLECTION = "stats_snapshots";
 
 export const STATS_TEAMS: Team[] = [Team.ELECTRIC, Team.SOLAR, Team.COMBUSTION];
 const STATUSES = Object.values(ApplicationStatus) as ApplicationStatus[];
+const EMAIL_TRIGGERS: EmailTrigger[] = ["interview_offered", "trial_offered", "accepted", "rejected", "waitlisted"];
 
 export type TeamCounts = Record<Team, number>;
 export type StatusCounts = Record<ApplicationStatus, number>;
 
+/** A count with its per-team split — the shape most phase numbers share. */
+export interface Tally { total: number; byTeam: TeamCounts }
+
+export interface OfferStatusCounts { pending: number; completed: number; cancelled: number; noShow: number; total: number }
+
 const zeroTeams = (): TeamCounts => ({ [Team.ELECTRIC]: 0, [Team.SOLAR]: 0, [Team.COMBUSTION]: 0 });
 const zeroStatuses = (): StatusCounts =>
   Object.fromEntries(STATUSES.map((s) => [s, 0])) as StatusCounts;
+const zeroTally = (): Tally => ({ total: 0, byTeam: zeroTeams() });
+const zeroOffers = (): OfferStatusCounts => ({ pending: 0, completed: 0, cancelled: 0, noShow: 0, total: 0 });
+const bump = (t: Tally, team: Team) => { t.total++; t.byTeam[team]++; };
 
 export interface StatsSeriesPoint {
   /** Bucket start, ISO. Buckets with nothing in them are omitted. */
@@ -54,6 +83,13 @@ export interface SystemDemand {
   rejectedBy: number;
   interviewOffers: number;
   trialOffers: number;
+  /** Interview offers from this system by outcome. */
+  intPending: number;
+  intCompleted: number;
+  intCancelled: number;
+  intNoShow: number;
+  /** Applicants whose one-way interview pick landed on this system. */
+  picked: number;
 }
 
 export interface RecruitingStats {
@@ -89,7 +125,64 @@ export interface RecruitingStats {
     major: { value: string; count: number }[];
     graduationYear: { value: string; count: number }[];
   };
+  /** Review phase, dashboard-verbatim (same systemPending predicate as the pending-count route). */
+  review: {
+    /** Submitted applications with no review decision — the admin lens. */
+    pendingReview: Tally;
+    /** Submitted-with-no-ranking: invisible to every lead's array-contains query (#131). */
+    unranked: Tally;
+    /** Per ranked (application, system) pair still waiting on that system. */
+    bySystem: Record<Team, { system: string; review: number; decision: number }[]>;
+  };
+  /** Interview phase. Applicant tallies are scoped to real status = interview. */
+  interviews: {
+    offers: OfferStatusCounts;
+    offersByTeam: Record<Team, OfferStatusCounts>;
+    atInterview: Tally;
+    /** Made their one-way system pick. */
+    picked: Tally;
+    /** Multiple live (pending) offers and no pick — who the close sweep is watching. */
+    awaitingPick: Tally;
+    /** Exactly one live offer — never sees the picker; staff mark these completed/no-show by hand. */
+    singleLive: Tally;
+    /** What the CLOSE_INTERVIEWS sweep would reject if it ran right now (same predicate as the sweep). */
+    sweepPreview: Tally;
+    /** Signup-link coverage for systems holding at least one live offer. */
+    signupLinks: { needed: number; withLink: number; missing: { team: Team; system: string }[] };
+  };
+  /** Trial + decision-day phase. */
+  decisions: {
+    /** Trial workday offers extended (offer count, not applicant count). */
+    trialOffers: Tally;
+    trialDecisions: Record<"advanced" | "rejected" | "waitlisted", Tally>;
+    /** Final-offer outcomes by release day (advanced decisions, plus offers that expired unanswered). */
+    byDay: Record<"1" | "2" | "3", { decided: number; committed: number; declined: number; awaiting: number; expired: number }>;
+    committed: Tally;
+    declined: Tally;
+    /** Status ACCEPTED with no commitment response yet. */
+    awaitingResponse: Tally;
+    waitlisted: Tally;
+    autoRejected: { offerExpired: number; committedElsewhere: number };
+    /** Commits that replaced a prior acceptance (waitlist-promotion reneg). */
+    reneged: number;
+  };
+  /** Email coverage per (trigger, team): owed at the current step vs recorded as sent — same trigger derivation as the send job. */
+  emails: { rows: { trigger: EmailTrigger; team: Team; eligible: number; sent: number }[] };
   series: { bucketMinutes: number; from: string; to: string; points: StatsSeriesPoint[] };
+}
+
+/**
+ * A frozen copy of the stats (minus the reconstructible time series) taken at
+ * the moment a forward step transition was saved — before the step was
+ * written and before any sweep ran, so it shows the world as the outgoing
+ * step left it. Doc id = the step being left.
+ */
+export interface StatsSnapshot extends Omit<RecruitingStats, "series"> {
+  snapshotStep: RecruitingStep;
+  nextStep: RecruitingStep;
+  capturedAt: string;
+  /** Staff uid that saved the transition (staff-facing payload only). */
+  capturedBy: string;
 }
 
 /** The subset handed to the recruiting bot. Numbers only, no free text. */
@@ -107,6 +200,8 @@ export interface PublicRecruitingStats {
   velocity: RecruitingStats["velocity"];
   systems: Record<Team, { system: string; any: number; rank1: number; submitted: number }[]>;
   crossTeam: RecruitingStats["crossTeam"]["byTeamCount"];
+  interviews: { atInterview: number; offersPending: number; offersCompleted: number; picked: number; awaitingPick: number };
+  decisions: { committed: number; declined: number; awaitingResponse: number; waitlisted: number };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -156,17 +251,20 @@ class TextTally {
 
 export async function computeRecruitingStats(): Promise<RecruitingStats> {
   const now = Date.now();
-  const [config, appsSnap, usersSnap] = await Promise.all([
+  const [config, appsSnap, usersSnap, interviewConfigsSnap] = await Promise.all([
     getRecruitingConfig(),
     adminDb
       .collection("applications")
       .select(
         "team", "status", "preferredSystems", "createdAt", "submittedAt", "isFakeData", "userId",
         "rejectedBySystems", "interviewOffers", "trialOffers",
+        "reviewDecision", "interviewDecision", "trialDecision", "trialDecisionDay",
+        "selectedInterviewSystem", "emailsSent", "commitment", "autoRejected", "renegedFrom",
         "formData.major", "formData.graduationYear", "formData.resumeUrl", "formData.portfolioUrl"
       )
       .get(),
     adminDb.collection("users").select("role", "createdAt").get(),
+    adminDb.collection("interviewConfigs").select("team", "system", "signupLink").get(),
   ]);
 
   // ---- accounts ----
@@ -189,18 +287,29 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
     STATS_TEAMS.map((t) => [t, { total: 0, submitted: 0, byStatus: zeroStatuses() }])
   ) as RecruitingStats["applications"]["byTeam"];
   let submittedEver = 0;
+  const zeroDemand = (system: string): SystemDemand =>
+    ({ system, any: 0, rank1: 0, rank2: 0, rank3: 0, submitted: 0, rejectedBy: 0, interviewOffers: 0, trialOffers: 0, intPending: 0, intCompleted: 0, intCancelled: 0, intNoShow: 0, picked: 0 });
   const systems = Object.fromEntries(
     STATS_TEAMS.map((t) => [t, new Map<string, SystemDemand>()])
   ) as Record<Team, Map<string, SystemDemand>>;
+  const pendingRows = Object.fromEntries(
+    STATS_TEAMS.map((t) => [t, new Map<string, { system: string; review: number; decision: number }>()])
+  ) as Record<Team, Map<string, { system: string; review: number; decision: number }>>;
   for (const t of STATS_TEAMS) {
     for (const s of TEAM_SYSTEMS[t]) {
-      systems[t].set(s.value, { system: s.value, any: 0, rank1: 0, rank2: 0, rank3: 0, submitted: 0, rejectedBy: 0, interviewOffers: 0, trialOffers: 0 });
+      systems[t].set(s.value, zeroDemand(s.value));
+      pendingRows[t].set(s.value, { system: s.value, review: 0, decision: 0 });
     }
   }
   const demand = (team: Team, system: string): SystemDemand => {
     let d = systems[team].get(system);
-    if (!d) { d = { system, any: 0, rank1: 0, rank2: 0, rank3: 0, submitted: 0, rejectedBy: 0, interviewOffers: 0, trialOffers: 0 }; systems[team].set(system, d); }
+    if (!d) { d = zeroDemand(system); systems[team].set(system, d); }
     return d;
+  };
+  const pendingRow = (team: Team, system: string) => {
+    let r = pendingRows[team].get(system);
+    if (!r) { r = { system, review: 0, decision: 0 }; pendingRows[team].set(system, r); }
+    return r;
   };
 
   const teamsByUser = new Map<string, Set<Team>>();
@@ -211,6 +320,43 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
   const createdEvents: { ms: number; team: Team }[] = [];
   const submittedEvents: { ms: number; team: Team }[] = [];
   let total = 0;
+
+  const review: RecruitingStats["review"] = {
+    pendingReview: zeroTally(),
+    unranked: zeroTally(),
+    bySystem: Object.fromEntries(STATS_TEAMS.map((t) => [t, []])) as RecruitingStats["review"]["bySystem"],
+  };
+  const offersByTeam = Object.fromEntries(
+    STATS_TEAMS.map((t) => [t, zeroOffers()])
+  ) as Record<Team, OfferStatusCounts>;
+  const interviews: RecruitingStats["interviews"] = {
+    offers: zeroOffers(),
+    offersByTeam,
+    atInterview: zeroTally(),
+    picked: zeroTally(),
+    awaitingPick: zeroTally(),
+    singleLive: zeroTally(),
+    sweepPreview: zeroTally(),
+    signupLinks: { needed: 0, withLink: 0, missing: [] },
+  };
+  const decisions: RecruitingStats["decisions"] = {
+    trialOffers: zeroTally(),
+    trialDecisions: { advanced: zeroTally(), rejected: zeroTally(), waitlisted: zeroTally() },
+    byDay: {
+      "1": { decided: 0, committed: 0, declined: 0, awaiting: 0, expired: 0 },
+      "2": { decided: 0, committed: 0, declined: 0, awaiting: 0, expired: 0 },
+      "3": { decided: 0, committed: 0, declined: 0, awaiting: 0, expired: 0 },
+    },
+    committed: zeroTally(),
+    declined: zeroTally(),
+    awaitingResponse: zeroTally(),
+    waitlisted: zeroTally(),
+    autoRejected: { offerExpired: 0, committedElsewhere: 0 },
+    reneged: 0,
+  };
+  const emailCells = new Map<string, { trigger: EmailTrigger; team: Team; eligible: number; sent: number }>();
+  for (const trigger of EMAIL_TRIGGERS) for (const team of STATS_TEAMS) emailCells.set(`${trigger}|${team}`, { trigger, team, eligible: 0, sent: 0 });
+  const neededLinks = new Set<string>();
 
   const HOUR = 3600e3, DAY = 24 * HOUR;
 
@@ -251,11 +397,26 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
     for (const sys of (Array.isArray(a.rejectedBySystems) ? a.rejectedBySystems : [])) {
       if (typeof sys === "string") demand(team, sys).rejectedBy++;
     }
-    for (const o of (Array.isArray(a.interviewOffers) ? a.interviewOffers : [])) {
-      if (o && typeof o.system === "string") demand(team, o.system).interviewOffers++;
+
+    const iOffers = (Array.isArray(a.interviewOffers) ? a.interviewOffers : [])
+      .filter((o: unknown): o is { system: string; status?: unknown } => !!o && typeof (o as { system?: unknown }).system === "string");
+    const iStatuses = iOffers.map((o) => String(o.status ?? ""));
+    for (const o of iOffers) {
+      const dm = demand(team, o.system);
+      dm.interviewOffers++;
+      const tc = offersByTeam[team];
+      tc.total++;
+      const st = String(o.status ?? "");
+      if (st === InterviewEventStatus.PENDING) { dm.intPending++; tc.pending++; }
+      else if (st === InterviewEventStatus.COMPLETED) { dm.intCompleted++; tc.completed++; }
+      else if (st === InterviewEventStatus.CANCELLED) { dm.intCancelled++; tc.cancelled++; }
+      else if (st === InterviewEventStatus.NO_SHOW) { dm.intNoShow++; tc.noShow++; }
     }
-    for (const o of (Array.isArray(a.trialOffers) ? a.trialOffers : [])) {
-      if (o && typeof o.system === "string") demand(team, o.system).trialOffers++;
+    const trialOfferCount = (Array.isArray(a.trialOffers) ? a.trialOffers : [])
+      .filter((o: unknown): o is { system: string } => !!o && typeof (o as { system?: unknown }).system === "string");
+    for (const o of trialOfferCount) {
+      demand(team, o.system).trialOffers++;
+      bump(decisions.trialOffers, team);
     }
 
     if (typeof a.userId === "string") {
@@ -271,11 +432,103 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
       majors.add(fd.major);
       gradYears.add(fd.graduationYear);
     }
+
+    // ---- review lens (dashboard-verbatim) ----
+    if (status === ApplicationStatus.SUBMITTED && !a.reviewDecision) {
+      bump(review.pendingReview, team);
+      if (ranked.length === 0) bump(review.unranked, team);
+    }
+    for (const sys of ranked) {
+      const p = systemPending(a, sys);
+      if (p.review) pendingRow(team, sys).review++;
+      if (p.decision) pendingRow(team, sys).decision++;
+    }
+
+    // ---- interview phase ----
+    const hasPick = typeof a.selectedInterviewSystem === "string" && a.selectedInterviewSystem.length > 0;
+    if (hasPick) demand(team, a.selectedInterviewSystem).picked++;
+    if (status === ApplicationStatus.INTERVIEW) {
+      bump(interviews.atInterview, team);
+      const liveCount = iStatuses.filter((s) => s === InterviewEventStatus.PENDING).length;
+      if (hasPick) bump(interviews.picked, team);
+      else if (liveCount > 1) bump(interviews.awaitingPick, team);
+      else if (liveCount === 1) bump(interviews.singleLive, team);
+      if (closeInterviewsWouldReject(iStatuses, a.selectedInterviewSystem)) bump(interviews.sweepPreview, team);
+      for (const o of iOffers) {
+        if (String(o.status ?? "") === InterviewEventStatus.PENDING) neededLinks.add(`${team}|${o.system}`);
+      }
+    }
+
+    // ---- trial + decision days ----
+    const td = a.trialDecision;
+    if (td === "advanced" || td === "rejected" || td === "waitlisted") bump(decisions.trialDecisions[td], team);
+    if (status === ApplicationStatus.COMMITTED) bump(decisions.committed, team);
+    if (status === ApplicationStatus.DECLINED) bump(decisions.declined, team);
+    if (status === ApplicationStatus.ACCEPTED && !a.commitment) bump(decisions.awaitingResponse, team);
+    if (status === ApplicationStatus.WAITLISTED) bump(decisions.waitlisted, team);
+    const autoReason = a.autoRejected?.reason;
+    if (autoReason === "offer_expired") decisions.autoRejected.offerExpired++;
+    if (autoReason === "committed_elsewhere") decisions.autoRejected.committedElsewhere++;
+    if (typeof a.renegedFrom === "string" && a.renegedFrom) decisions.reneged++;
+
+    // An expired offer's trialDecision was overwritten to "rejected" by the
+    // sweep, so the by-day funnel keys on "was ever a final offer": decision
+    // still advanced, or auto-rejected for letting it lapse.
+    if (td === "advanced" || autoReason === "offer_expired") {
+      const day = String(clampDecisionDay(a.trialDecisionDay)) as "1" | "2" | "3";
+      const row = decisions.byDay[day];
+      row.decided++;
+      if (autoReason === "offer_expired") row.expired++;
+      else if (status === ApplicationStatus.COMMITTED) row.committed++;
+      else if (status === ApplicationStatus.DECLINED) row.declined++;
+      else if (status === ApplicationStatus.ACCEPTED && !a.commitment) row.awaiting++;
+    }
+
+    // ---- email coverage (same derivation as the trigger-emails job) ----
+    const visible = getUserVisibleStatus(a as unknown as Application, config.currentStep);
+    const trigger = STATUS_EMAIL_TRIGGERS[visible];
+    if (trigger) {
+      const cell = emailCells.get(`${trigger}|${team}`)!;
+      cell.eligible++;
+      if (Array.isArray(a.emailsSent) && a.emailsSent.includes(trigger)) cell.sent++;
+    }
   }
 
   for (const ms of accountTimes) {
     if (now - ms < HOUR) velocity.accountsLastHour++;
     if (now - ms < DAY) velocity.accountsLast24h++;
+  }
+
+  // ---- interview offer totals + signup-link coverage ----
+  for (const t of STATS_TEAMS) {
+    const tc = offersByTeam[t];
+    interviews.offers.pending += tc.pending;
+    interviews.offers.completed += tc.completed;
+    interviews.offers.cancelled += tc.cancelled;
+    interviews.offers.noShow += tc.noShow;
+    interviews.offers.total += tc.total;
+  }
+  const linkByKey = new Map<string, string>();
+  for (const d of interviewConfigsSnap.docs) {
+    const c = d.data();
+    if (typeof c.team === "string" && typeof c.system === "string") {
+      linkByKey.set(`${c.team}|${c.system}`, typeof c.signupLink === "string" ? c.signupLink.trim() : "");
+    }
+  }
+  interviews.signupLinks.needed = neededLinks.size;
+  for (const key of neededLinks) {
+    if (linkByKey.get(key)) interviews.signupLinks.withLink++;
+    else {
+      const [team, system] = key.split("|");
+      interviews.signupLinks.missing.push({ team: team as Team, system });
+    }
+  }
+  interviews.signupLinks.missing.sort((a, b) => a.team.localeCompare(b.team) || a.system.localeCompare(b.system));
+
+  for (const t of STATS_TEAMS) {
+    review.bySystem[t] = [...pendingRows[t].values()].sort(
+      (a, b) => (b.review + b.decision) - (a.review + a.decision) || a.system.localeCompare(b.system)
+    );
   }
 
   // ---- cross-team ----
@@ -329,6 +582,10 @@ export async function computeRecruitingStats(): Promise<RecruitingStats> {
     },
     uploads,
     demographics: { major: majors.top(DEMOGRAPHIC_TOP_N), graduationYear: gradYears.top(DEMOGRAPHIC_TOP_N) },
+    review,
+    interviews,
+    decisions,
+    emails: { rows: [...emailCells.values()] },
     series: { bucketMinutes: STATS_BUCKET_MINUTES, from: new Date(fromBucket).toISOString(), to: new Date(now).toISOString(), points },
   };
 }
@@ -350,6 +607,41 @@ export async function getRecruitingStats(opts: { fresh?: boolean } = {}): Promis
 
 export function invalidateRecruitingStats(): void {
   cached = null;
+}
+
+/**
+ * Freeze the numbers as they stand into stats_snapshots/{fromStep}. Called by
+ * the step-change route on every FORWARD transition, BEFORE the step is
+ * written and before any sweep runs — so the snapshot is the world exactly as
+ * the outgoing step left it. Always computes fresh (never the 5-min cache).
+ * A re-run of the same forward transition overwrites the doc: the newest
+ * capture of the actual transition wins.
+ */
+export async function captureStatsSnapshot(
+  fromStep: RecruitingStep,
+  toStep: RecruitingStep,
+  adminUid: string
+): Promise<void> {
+  const { series: _series, ...counts } = await computeRecruitingStats();
+  const snapshot: StatsSnapshot = {
+    ...counts,
+    step: fromStep,
+    snapshotStep: fromStep,
+    nextStep: toStep,
+    capturedAt: new Date().toISOString(),
+    capturedBy: adminUid,
+  };
+  await adminDb.collection(SNAPSHOT_COLLECTION).doc(fromStep).set(snapshot);
+}
+
+/** All stored snapshots in pipeline order. */
+export async function getStatsSnapshots(): Promise<StatsSnapshot[]> {
+  const snap = await adminDb.collection(SNAPSHOT_COLLECTION).get();
+  const rows = snap.docs
+    .map((d) => d.data() as StatsSnapshot)
+    .filter((s) => STEP_ORDER.includes(s.snapshotStep));
+  rows.sort((a, b) => STEP_ORDER.indexOf(a.snapshotStep) - STEP_ORDER.indexOf(b.snapshotStep));
+  return rows;
 }
 
 export function toPublicStats(s: RecruitingStats): PublicRecruitingStats {
@@ -374,5 +666,18 @@ export function toPublicStats(s: RecruitingStats): PublicRecruitingStats {
       STATS_TEAMS.map((t) => [t, s.systems[t].map((d) => ({ system: d.system, any: d.any, rank1: d.rank1, submitted: d.submitted }))])
     ) as PublicRecruitingStats["systems"],
     crossTeam: s.crossTeam.byTeamCount,
+    interviews: {
+      atInterview: s.interviews.atInterview.total,
+      offersPending: s.interviews.offers.pending,
+      offersCompleted: s.interviews.offers.completed,
+      picked: s.interviews.picked.total,
+      awaitingPick: s.interviews.awaitingPick.total,
+    },
+    decisions: {
+      committed: s.decisions.committed.total,
+      declined: s.decisions.declined.total,
+      awaitingResponse: s.decisions.awaitingResponse.total,
+      waitlisted: s.decisions.waitlisted.total,
+    },
   };
 }

--- a/lib/models/EmailTemplate.ts
+++ b/lib/models/EmailTemplate.ts
@@ -3,12 +3,29 @@
  * Templates are stored in Firestore under config/email_templates.
  */
 
+import { ApplicationStatus } from "./Application";
+
 export type EmailTrigger =
   | "interview_offered"
   | "trial_offered"
   | "accepted"
   | "rejected"
   | "waitlisted";
+
+/**
+ * Which email each user-VISIBLE status calls for. The send job derives the
+ * trigger from getUserVisibleStatus(app, step) — never from the raw status —
+ * so an unreleased decision can't leak by email. Shared by the trigger route
+ * and the stats email-coverage numbers so they can never disagree about who
+ * is owed an email.
+ */
+export const STATUS_EMAIL_TRIGGERS: Partial<Record<ApplicationStatus, EmailTrigger>> = {
+  [ApplicationStatus.INTERVIEW]: "interview_offered",
+  [ApplicationStatus.TRIAL]: "trial_offered",
+  [ApplicationStatus.ACCEPTED]: "accepted",
+  [ApplicationStatus.REJECTED]: "rejected",
+  [ApplicationStatus.WAITLISTED]: "waitlisted",
+};
 
 export interface EmailTemplate {
   id: string;

--- a/lib/utils/interviewSweep.ts
+++ b/lib/utils/interviewSweep.ts
@@ -1,0 +1,39 @@
+import { InterviewEventStatus } from "@/lib/models/Application";
+
+/**
+ * The CLOSE_INTERVIEWS sweep verdict for one application, as a pure predicate.
+ *
+ * Booking happens on an external link, so offer status is the only record of
+ * what happened. In order:
+ *  1. An interview that took place is never swept, whatever else is on the
+ *     record — a second offer added afterwards used to get the applicant
+ *     rejected because they never used the picker.
+ *  2. Offers that all ended explicitly (no-show, cancelled) are closed out
+ *     for every team; those applicants otherwise sit at "Interview" with a
+ *     live signup link through decision day 3.
+ *  3. Applicants holding several LIVE (pending) offers who never picked one
+ *     never booked anything (every team picks one system — PM, 2026-08-30).
+ * A lone PENDING offer is ambiguous (never booked, or interviewed and not
+ * yet marked) and is left alone rather than rejected on a guess. Note
+ * [no_show, pending] lands there too (pendingCount 1 → spared): the no-show
+ * at one system says nothing about the OTHER system's interview. Staff
+ * resolve it by marking the pending offer completed/no-show; re-saving the
+ * step re-runs the sweep.
+ *
+ * Shared by the sweep itself (lib/firebase/applications.ts) and the stats
+ * module's sweep preview, so the number staff see before the transition is
+ * computed by the same rule that fires on it.
+ */
+export function closeInterviewsWouldReject(
+  offerStatuses: string[],
+  selectedInterviewSystem: unknown
+): boolean {
+  if (offerStatuses.length === 0) return false;
+  if (offerStatuses.includes(InterviewEventStatus.COMPLETED)) return false;
+  const allEnded = offerStatuses.every(
+    (s) => s === InterviewEventStatus.NO_SHOW || s === InterviewEventStatus.CANCELLED
+  );
+  const pendingCount = offerStatuses.filter((s) => s === InterviewEventStatus.PENDING).length;
+  const neverPicked = pendingCount > 1 && !selectedInterviewSystem;
+  return allEnded || neverPicked;
+}

--- a/lib/utils/systemPending.ts
+++ b/lib/utils/systemPending.ts
@@ -1,0 +1,39 @@
+import { ApplicationStatus, InterviewEventStatus } from "@/lib/models/Application";
+
+/**
+ * What one system still has to decide on an application (#131). The global
+ * status is the applicant's pipeline stage — a per-system rejection leaves it
+ * `submitted` until every ranked system has rejected, and another system's
+ * offer moves it to `interview` — so for a lead or reviewer the count has to
+ * be per-system, the same lens as the applicants list (#126):
+ *  - review pending: the application is still in play (submitted, interview
+ *    or trial stage) and this system has neither rejected it nor extended an
+ *    offer — another system's advance does not review it for us;
+ *  - decision pending: this system's interview offer is out with no
+ *    rejection or trial offer after it, or this system's trial offer is out
+ *    and the final decision has not been made.
+ * A cancelled offer is no offer; completed and no-show offers still stand.
+ *
+ * Shared by the dashboard pending-count route and the stats module so the
+ * numbers a lead sees on the dashboard and the numbers on /admin/stats can
+ * never drift apart (the lesson of #131/#132 — this predicate used to live
+ * inline in one route).
+ */
+export function systemPending(
+  app: FirebaseFirestore.DocumentData,
+  system: string
+): { review: boolean; decision: boolean } {
+  const live = (o: { system?: string; status?: string }) => o.system === system && o.status !== InterviewEventStatus.CANCELLED;
+  const rejected = ((app.rejectedBySystems as string[] | undefined) || []).includes(system);
+  const interviewOffer = ((app.interviewOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
+  const trialOffer = ((app.trialOffers as { system?: string; status?: string }[] | undefined) || []).some(live);
+  const S = ApplicationStatus;
+  const inPlay = app.status === S.SUBMITTED || app.status === S.INTERVIEW || app.status === S.TRIAL;
+  const review = inPlay && !rejected && !interviewOffer && !trialOffer;
+  const decision =
+    !rejected &&
+    ((app.status === S.INTERVIEW && interviewOffer && !trialOffer) ||
+      (app.status === S.TRIAL && trialOffer && !app.trialDecision) ||
+      (app.status === S.TRIAL && interviewOffer && !trialOffer));
+  return { review, decision };
+}

--- a/scripts/qa/stats-regress.mjs
+++ b/scripts/qa/stats-regress.mjs
@@ -1,10 +1,14 @@
 // Stats feature checks against the emulators: token gate, PII-free shape,
-// staff gate, numbers match seeded data.
+// staff gate, numbers match seeded data — including the per-step phase
+// sections (review / interviews / decisions / emails) and the snapshot
+// frozen by a forward step transition.
 //
 // Run against the emulator suite with the dev server started with
 // STATS_API_TOKEN=test-stats-token (README: local development):
 //   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099 node scripts/qa/stats-regress.mjs
 // Refuses to run without both emulator vars, so it can never touch production.
+// Note: drives the recruiting step (ends at `interviewing`) — run it on a
+// freshly seeded emulator, like the other suites.
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const admin = require("firebase-admin");
@@ -38,11 +42,13 @@ const ago = (h) => new Date(Date.now() - h * 3600e3);
 
 // ---- seed a known dataset ----
 await db.doc("applications/st-7").delete(); // left over from a previous run
+for (const s of ["open", "reviewing", "release_interviews", "interviewing"]) await db.doc(`stats_snapshots/${s}`).delete();
 await ensureUser({ uid: "s-lead", email: "lead.stats@utexas.edu", name: "Stats Lead", role: "system_lead", memberProfile: { team: "Electric", system: "Body" } });
 for (let i = 0; i < 6; i++) await ensureUser({ uid: `s-app-${i}`, email: `stats${i}@utexas.edu`, name: `Person ${i} Secretname`, role: "applicant", createdAt: ago(30 - i * 5) });
 await ensureUser({ uid: "s-app-old", email: "old@utexas.edu", name: "No CreatedAt", role: "applicant" }); // no createdAt
 const A = (id, team, userId, status, ranked, createdH, submittedH, { formData = {}, ...extra } = {}) =>
   db.doc(`applications/${id}`).set({ team, userId, userEmail: `${userId}@utexas.edu`, userName: "Hidden Applicant", status, preferredSystems: ranked, createdAt: ago(createdH), ...(submittedH !== null ? { submittedAt: ago(submittedH) } : {}), formData: { major: "  Mechanical   Engineering ", graduationYear: "2028", resumeUrl: "https://x/r.pdf", ...formData }, ...extra });
+const BLANK = { major: "", graduationYear: "", resumeUrl: "" }; // keep demographics/uploads assertions independent of the phase fixtures
 await A("st-1", "Electric", "s-app-0", "submitted", ["Body", "Dynamics"], 30, 28);
 await A("st-2", "Electric", "s-app-1", "submitted", ["Dynamics", "Body", "Powertrain"], 26, 20, { formData: { portfolioUrl: "https://x/p.pdf", major: "mechanical engineering" } });
 await A("st-3", "Electric", "s-app-2", "in_progress", ["Body"], 10, null);
@@ -50,12 +56,28 @@ await A("st-4", "Solar", "s-app-0", "submitted", ["Powertrain"], 25, 0.5, { form
 await A("st-5", "Combustion", "s-app-3", "in_progress", ["Aerodynamics", "Body"], 0.5, null);
 await A("st-6", "Combustion", "s-app-4", "rejected", ["Aerodynamics"], 40, 39, { rejectedBySystems: ["Aerodynamics"], reviewDecision: "rejected" });
 await A("st-fake", "Electric", "s-app-5", "submitted", ["Body"], 5, 4, { isFakeData: true }); // must be excluded
+// Phase fixtures (unique userIds so cross-team counts stay legible):
+await A("st-nr", "Electric", "nx-1", "submitted", [], 12, 11, { formData: BLANK }); // no ranking — invisible to leads
+await A("st-i1", "Electric", "nx-2", "interview", ["Body", "Dynamics"], 20, 19, { formData: BLANK, reviewDecision: "advanced", interviewOffers: [{ system: "Body", status: "pending" }, { system: "Dynamics", status: "pending" }], emailsSent: ["interview_offered"] });
+await A("st-i2", "Electric", "nx-3", "interview", ["Body"], 20, 19, { formData: BLANK, reviewDecision: "advanced", interviewOffers: [{ system: "Body", status: "pending" }, { system: "Powertrain", status: "cancelled" }], selectedInterviewSystem: "Body" });
+await A("st-i3", "Solar", "nx-4", "interview", ["Powertrain", "TrackSim"], 20, 19, { formData: BLANK, reviewDecision: "advanced", interviewOffers: [{ system: "Powertrain", status: "completed" }, { system: "TrackSim", status: "no_show" }], emailsSent: ["interview_offered"] });
+await A("st-d1", "Combustion", "nx-5", "accepted", ["Composites"], 20, 19, { formData: BLANK, reviewDecision: "advanced", interviewOffers: [{ system: "Composites", status: "completed" }], trialOffers: [{ system: "Composites", status: "pending" }], trialDecision: "advanced", trialDecisionDay: 2 });
+await A("st-d2", "Combustion", "nx-6", "committed", ["Composites"], 20, 19, { formData: BLANK, trialDecision: "advanced", trialDecisionDay: 1, commitment: { accepted: true, committedAt: ago(1) }, renegedFrom: "Electric" });
+await A("st-d3", "Combustion", "nx-7", "rejected", ["Body"], 20, 19, { formData: BLANK, trialDecision: "rejected", trialDecisionDay: 1, autoRejected: { reason: "offer_expired", at: ago(1) } });
+await A("st-d4", "Solar", "nx-8", "waitlisted", ["Dynamics"], 20, 19, { formData: BLANK, trialDecision: "waitlisted" });
+// Signup-link coverage: Body configured, Dynamics (live offers via st-i1) not.
+await db.doc("interviewConfigs/electric-body").set({ team: "Electric", system: "Body", signupLink: "https://calendar.example.com/body" });
+await db.doc("interviewConfigs/electric-dynamics").delete();
 
 const adminC = await session("admin@utexas.edu"), leadC = await session("lead.stats@utexas.edu"), appC = await session("stats0@utexas.edu");
+// Park the cycle at release_interviews (typed confirm covers any starting step)
+// so offers are released and email eligibility is deterministic.
+let r = await api("POST", "/api/admin/config/recruiting", { cookie: adminC, body: { step: "release_interviews", confirm: "release_interviews" } });
+if (r.status !== 200) { console.error(`refusing: could not set step (${r.status} ${r.text})`); process.exit(1); }
 await api("POST", "/api/admin/stats", { cookie: adminC }); // drop any cache from a previous run
 
 // ---- /api/stats token gate ----
-let r = await api("GET", "/api/stats");
+r = await api("GET", "/api/stats");
 check("bot API without token -> 401", r.status === 401, `${r.status}`);
 r = await api("GET", "/api/stats", { token: "wrong" });
 check("bot API with wrong token -> 401", r.status === 401, `${r.status}`);
@@ -64,14 +86,16 @@ check("bot API with a staff session but no token -> 401 (sessions don't count)",
 r = await api("GET", "/api/stats", { token: "test-stats-token" });
 check("bot API with token -> 200", r.status === 200, `${r.status}`);
 const pub = r.json;
-check("bot API: no PII anywhere in the payload", !/utexas|Secretname|Hidden|s-app-|@/.test(r.text) && !/email|name|userId|uid/i.test(Object.keys(JSON.stringify(pub)).join("")), r.text.slice(0, 120));
-check("bot API: counts exclude fake data", pub?.applications?.total === 6 && pub.applications.byStatus.submitted === 3, JSON.stringify(pub?.applications?.byStatus));
-check("bot API: per-team submitted is ever-submitted (rejected Combustion app counts)", pub?.applications?.byTeam?.Electric?.submitted === 2 && pub.applications.byTeam.Solar.submitted === 1 && pub.applications.byTeam.Combustion.submitted === 1 && pub.applications.submitted === 4, JSON.stringify(pub?.applications?.byTeam));
+check("bot API: no PII anywhere in the payload", !/utexas|Secretname|Hidden|s-app-|nx-|@/.test(r.text), r.text.slice(0, 120));
+check("bot API: counts exclude fake data", pub?.applications?.total === 14 && pub.applications.byStatus.submitted === 4, JSON.stringify(pub?.applications?.byStatus));
+check("bot API: per-team submitted is ever-submitted", pub?.applications?.byTeam?.Electric?.submitted === 5 && pub.applications.byTeam.Solar.submitted === 3 && pub.applications.byTeam.Combustion.submitted === 4 && pub.applications.submitted === 12, JSON.stringify(pub?.applications?.byTeam));
 check("bot API: applicant accounts counted, staff not", pub?.applicantAccounts === 8, `${pub?.applicantAccounts}`); // seed applicant + 6 + old
 check("bot API: velocity last hour (1 created, 1 submitted)", pub?.velocity?.createdLastHour === 1 && pub.velocity.submittedLastHour === 1, JSON.stringify(pub?.velocity));
-check("bot API: system demand rank1 (Electric Body = 2, Dynamics = 1, Body any = 3)", pub?.systems?.Electric?.find((s) => s.system === "Body")?.rank1 === 2 && pub.systems.Electric.find((s) => s.system === "Dynamics")?.rank1 === 1 && pub.systems.Electric.find((s) => s.system === "Body")?.any === 3, JSON.stringify(pub?.systems?.Electric?.slice(0, 3)));
-check("bot API: cross-team counts (1 applicant on 2 teams)", pub?.crossTeam?.[2] === 1 && pub.crossTeam[1] === 4, JSON.stringify(pub?.crossTeam));
-check("bot API: no demographics or series in the reduced copy", pub && !("demographics" in pub) && !("series" in pub));
+check("bot API: system demand (Electric Body rank1 4 / any 5, Dynamics rank1 1)", pub?.systems?.Electric?.find((s) => s.system === "Body")?.rank1 === 4 && pub.systems.Electric.find((s) => s.system === "Dynamics")?.rank1 === 1 && pub.systems.Electric.find((s) => s.system === "Body")?.any === 5, JSON.stringify(pub?.systems?.Electric?.slice(0, 3)));
+check("bot API: cross-team counts (1 applicant on 2 teams)", pub?.crossTeam?.[2] === 1 && pub.crossTeam[1] === 12, JSON.stringify(pub?.crossTeam));
+check("bot API: no demographics or series in the reduced copy", pub && !("demographics" in pub) && !("series" in pub) && !("emails" in pub));
+check("bot API: interview counts", pub?.interviews?.atInterview === 3 && pub.interviews.offersPending === 3 && pub.interviews.offersCompleted === 2 && pub.interviews.picked === 1 && pub.interviews.awaitingPick === 1, JSON.stringify(pub?.interviews));
+check("bot API: decision counts", pub?.decisions?.committed === 1 && pub.decisions.declined === 0 && pub.decisions.awaitingResponse === 1 && pub.decisions.waitlisted === 1, JSON.stringify(pub?.decisions));
 
 // ---- /api/admin/stats gate + full payload ----
 r = await api("GET", "/api/admin/stats", { cookie: appC });
@@ -81,25 +105,70 @@ check("admin stats unauthenticated -> 401", r.status === 401, `${r.status}`);
 r = await api("GET", "/api/admin/stats", { cookie: leadC });
 check("admin stats as system lead -> 200 (all staff)", r.status === 200, `${r.status}`);
 const full = r.json;
-check("full stats: no PII either", !/utexas|Secretname|Hidden|s-app-|@/.test(r.text));
+check("full stats: no PII either", !/utexas|Secretname|Hidden|s-app-|nx-|@/.test(r.text));
 check("full stats: majors whitespace-normalised and case-folded (3 spellings -> one row, most common spelling shown)", full?.demographics?.major?.length === 2 && full.demographics.major[0].value === "Mechanical Engineering" && full.demographics.major[0].count === 3 && full.demographics.major[1].value === "ECE", JSON.stringify(full?.demographics?.major));
 check("full stats: graduation years", full?.demographics?.graduationYear?.find((g) => g.value === "2028")?.count === 3 && full.demographics.graduationYear.find((g) => g.value === "2027")?.count === 1, JSON.stringify(full?.demographics?.graduationYear));
-check("full stats: uploads among ever-submitted (4 resumes, 1 portfolio of 4)", full?.uploads?.submitted === 4 && full.uploads.resume === 4 && full.uploads.portfolio === 1, JSON.stringify(full?.uploads));
+check("full stats: uploads among ever-submitted (4 resumes, 1 portfolio of 12)", full?.uploads?.submitted === 12 && full.uploads.resume === 4 && full.uploads.portfolio === 1, JSON.stringify(full?.uploads));
 check("full stats: rejectedBy surfaces in system demand", full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")?.rejectedBy === 1, JSON.stringify(full?.systems?.Combustion?.find((s) => s.system === "Aerodynamics")));
-check("full stats: single-team split (Electric 2, Solar 0, Combustion 2)", full?.crossTeam?.singleTeam?.Electric === 2 && full.crossTeam.singleTeam.Solar === 0 && full.crossTeam.singleTeam.Combustion === 2, JSON.stringify(full?.crossTeam?.singleTeam));
+check("full stats: single-team split (Electric 5, Solar 2, Combustion 5)", full?.crossTeam?.singleTeam?.Electric === 5 && full.crossTeam.singleTeam.Solar === 2 && full.crossTeam.singleTeam.Combustion === 5, JSON.stringify(full?.crossTeam?.singleTeam));
 check("full stats: cross-team combo Electric+Solar = 1", full?.crossTeam?.combos?.[0]?.teams?.join("+") === "Electric+Solar" && full.crossTeam.combos[0].count === 1, JSON.stringify(full?.crossTeam?.combos));
 const pts = full?.series?.points || [];
 const sum = (k, team) => pts.reduce((a, p) => a + (team ? p[k][team] : Object.values(p[k]).reduce((x, y) => x + y, 0)), 0);
-check("full stats: series totals reconcile (created 6, submitted 3+1 rejected-was-submitted, accounts 6 w/ createdAt)", sum("created") === 6 && sum("submitted") === 4 && pts.reduce((a, p) => a + p.accounts, 0) === 6, `created=${sum("created")} submitted=${sum("submitted")} accounts=${pts.reduce((a, p) => a + p.accounts, 0)}`);
+check("full stats: series totals reconcile (created 14, submitted 12, accounts 6 w/ createdAt)", sum("created") === 14 && sum("submitted") === 12 && pts.reduce((a, p) => a + p.accounts, 0) === 6, `created=${sum("created")} submitted=${sum("submitted")} accounts=${pts.reduce((a, p) => a + p.accounts, 0)}`);
 check("full stats: series is sparse (fewer points than 15-min buckets over 40h)", pts.length > 0 && pts.length < 40 * 4, `${pts.length} points`);
 check("full stats: accounts createdAt coverage reported (6 of 8)", full?.accounts?.applicantsWithCreatedAt === 6 && full.accounts.applicants === 8, JSON.stringify(full?.accounts));
 
+// ---- phase sections ----
+const rv = full?.review;
+check("review: pending first review (st-1, st-2, st-4, st-nr)", rv?.pendingReview?.total === 4 && rv.pendingReview.byTeam.Electric === 3 && rv.pendingReview.byTeam.Solar === 1, JSON.stringify(rv?.pendingReview));
+check("review: unranked submitted surfaces (st-nr)", rv?.unranked?.total === 1 && rv.unranked.byTeam.Electric === 1, JSON.stringify(rv?.unranked));
+const bodyRow = rv?.bySystem?.Electric?.find((x) => x.system === "Body");
+check("review: per-system pending is dashboard-verbatim (Body: 2 review, 2 decision)", bodyRow?.review === 2 && bodyRow?.decision === 2, JSON.stringify(bodyRow));
+const iv = full?.interviews;
+check("interviews: applicant funnel (3 at interview, 1 picked, 1 awaiting pick, 0 single-live)", iv?.atInterview?.total === 3 && iv.picked.total === 1 && iv.awaitingPick.total === 1 && iv.singleLive.total === 0, JSON.stringify({ at: iv?.atInterview?.total, picked: iv?.picked?.total, awaiting: iv?.awaitingPick?.total, single: iv?.singleLive?.total }));
+check("interviews: offer status counts (3 pending, 2 completed, 1 cancelled, 1 no-show of 7)", iv?.offers?.pending === 3 && iv.offers.completed === 2 && iv.offers.cancelled === 1 && iv.offers.noShow === 1 && iv.offers.total === 7, JSON.stringify(iv?.offers));
+check("interviews: per-team offers (Electric 3 pending / 1 cancelled)", iv?.offersByTeam?.Electric?.pending === 3 && iv.offersByTeam.Electric.cancelled === 1 && iv.offersByTeam.Solar.completed === 1 && iv.offersByTeam.Solar.noShow === 1, JSON.stringify(iv?.offersByTeam));
+check("interviews: sweep preview matches the close-interviews predicate (only st-i1)", iv?.sweepPreview?.total === 1 && iv.sweepPreview.byTeam.Electric === 1, JSON.stringify(iv?.sweepPreview));
+check("interviews: signup-link coverage flags Dynamics (2 needed, 1 with link)", iv?.signupLinks?.needed === 2 && iv.signupLinks.withLink === 1 && iv.signupLinks.missing.length === 1 && iv.signupLinks.missing[0].team === "Electric" && iv.signupLinks.missing[0].system === "Dynamics", JSON.stringify(iv?.signupLinks));
+const bodyDemand = full?.systems?.Electric?.find((x) => x.system === "Body");
+check("interviews: system demand carries offer outcomes + picks (Body: 2 pending, picked by 1)", bodyDemand?.intPending === 2 && bodyDemand?.picked === 1, JSON.stringify({ intPending: bodyDemand?.intPending, picked: bodyDemand?.picked }));
+const dc = full?.decisions;
+check("decisions: tallies (1 committed, 1 awaiting, 1 waitlisted, 0 declined)", dc?.committed?.total === 1 && dc.awaitingResponse.total === 1 && dc.waitlisted.total === 1 && dc.declined.total === 0, JSON.stringify({ c: dc?.committed?.total, a: dc?.awaitingResponse?.total, w: dc?.waitlisted?.total }));
+check("decisions: trial decisions (2 advanced, 1 rejected, 1 waitlisted) + 1 trial offer", dc?.trialDecisions?.advanced?.total === 2 && dc.trialDecisions.rejected.total === 1 && dc.trialDecisions.waitlisted.total === 1 && dc.trialOffers.total === 1, JSON.stringify({ adv: dc?.trialDecisions?.advanced?.total, offers: dc?.trialOffers?.total }));
+check("decisions: by-day funnel (day 1: 2 decided, 1 committed, 1 expired; day 2: 1 awaiting)", dc?.byDay?.["1"]?.decided === 2 && dc.byDay["1"].committed === 1 && dc.byDay["1"].expired === 1 && dc.byDay["2"].decided === 1 && dc.byDay["2"].awaiting === 1, JSON.stringify(dc?.byDay));
+check("decisions: auto-reject reasons + reneg", dc?.autoRejected?.offerExpired === 1 && dc.autoRejected.committedElsewhere === 0 && dc.reneged === 1, JSON.stringify({ ...dc?.autoRejected, reneged: dc?.reneged }));
+const cell = (trig, team) => full?.emails?.rows?.find((x) => x.trigger === trig && x.team === team);
+check("emails: interview-offer coverage per team (E 1/2, S 1/1, C 0/1)", cell("interview_offered", "Electric")?.sent === 1 && cell("interview_offered", "Electric")?.eligible === 2 && cell("interview_offered", "Solar")?.sent === 1 && cell("interview_offered", "Solar")?.eligible === 1 && cell("interview_offered", "Combustion")?.sent === 0 && cell("interview_offered", "Combustion")?.eligible === 1, JSON.stringify(full?.emails?.rows?.filter((x) => x.trigger === "interview_offered")));
+check("emails: released review rejection is owed a rejection email (st-6)", cell("rejected", "Combustion")?.eligible === 1 && cell("rejected", "Combustion")?.sent === 0, JSON.stringify(cell("rejected", "Combustion")));
+check("emails: masked decisions owe nothing (trial rejection day 1 unreleased)", cell("rejected", "Electric")?.eligible === 0 && cell("accepted", "Combustion")?.eligible === 0, JSON.stringify([cell("rejected", "Electric"), cell("accepted", "Combustion")]));
+
+// ---- snapshot on forward transition ----
+r = await api("POST", "/api/admin/config/recruiting", { cookie: adminC, body: { step: "interviewing" } });
+check("forward step change -> 200, no snapshot error", r.status === 200 && !r.json?.snapshotError, `${r.status} ${JSON.stringify(r.json)}`);
+const snapDoc = await db.doc("stats_snapshots/release_interviews").get();
+const snap = snapDoc.data();
+check("snapshot frozen for the step being left", snapDoc.exists && snap?.snapshotStep === "release_interviews" && snap?.nextStep === "interviewing" && typeof snap?.capturedAt === "string" && typeof snap?.capturedBy === "string", JSON.stringify({ exists: snapDoc.exists, from: snap?.snapshotStep, to: snap?.nextStep }));
+check("snapshot carries the counts (14 apps) but not the series", snap?.applications?.total === 14 && !("series" in (snap || {})) && snap?.interviews?.sweepPreview?.total === 1, JSON.stringify({ total: snap?.applications?.total, hasSeries: snap ? "series" in snap : null }));
+r = await api("POST", "/api/admin/config/recruiting", { cookie: adminC, body: { step: "interviewing" } });
+check("re-saving the same step (sweep recovery) captures nothing", r.status === 200 && !(await db.doc("stats_snapshots/interviewing").get()).exists, `${r.status}`);
+
+// ---- snapshots API ----
+r = await api("GET", "/api/admin/stats/snapshots");
+check("snapshots unauthenticated -> 401", r.status === 401, `${r.status}`);
+r = await api("GET", "/api/admin/stats/snapshots", { cookie: appC });
+check("snapshots as applicant -> 403", r.status === 403, `${r.status}`);
+r = await api("GET", "/api/admin/stats/snapshots", { cookie: leadC });
+const listed = r.json?.snapshots?.find((s) => s.snapshotStep === "release_interviews");
+check("snapshots as staff -> 200 with the frozen step", r.status === 200 && !!listed && listed.nextStep === "interviewing", `${r.status}`);
+check("snapshots payload: no PII", !/utexas|Secretname|Hidden|s-app-|nx-|@/.test(r.text));
+
 // ---- cache + refresh ----
+await api("GET", "/api/admin/stats", { cookie: adminC }); // warm the cache (step changes invalidated it)
 await A("st-7", "Solar", "s-app-5", "submitted", ["TrackSim"], 1, 0.2);
 r = await api("GET", "/api/admin/stats", { cookie: adminC });
-check("cached: new app not visible yet on GET", r.json?.applications?.total === 6, `${r.json?.applications?.total}`);
+check("cached: new app not visible yet on GET", r.json?.applications?.total === 14, `${r.json?.applications?.total}`);
 r = await api("POST", "/api/admin/stats", { cookie: adminC });
-check("POST recompute -> 200 and sees the new app", r.status === 200 && r.json?.applications?.total === 7, `${r.status} ${r.json?.applications?.total}`);
+check("POST recompute -> 200 and sees the new app", r.status === 200 && r.json?.applications?.total === 15, `${r.status} ${r.json?.applications?.total}`);
 r = await api("POST", "/api/admin/stats", { cookie: appC });
 check("POST recompute as applicant -> 403", r.status === 403, `${r.status}`);
 


### PR DESCRIPTION
Per-step stats: the admin stats page now covers the whole cycle, not just the open phase.

## What's new

- **Step rail + phase deep-dives** on `/admin/stats`: all 11 steps; selecting one shows its phase panel group — Review (pending per system, unranked apps), Interviews (offer outcomes, picked / awaiting-pick / single-live, close-sweep preview, signup-link coverage), Trial, Decision Days (by-day offer funnel, commit rate, auto-reject reasons, renegs, waitlist).
- **Frozen snapshots**: every *forward* step transition writes a counts-only copy of the stats to `stats_snapshots/{stepBeingLeft}` — captured before the step write and before any sweep, so past steps on the rail show the world exactly as that step ended. Non-fatal by design (failure surfaces as a toast + `snapshotError`), bounded by an 8s race so it can never starve the step write; `maxDuration = 300` on the route. Schema-versioned so a future shape change degrades to live numbers instead of crashing the page.
- **Email coverage** per trigger × team: who is *owed* each email at the current step (same `getUserVisibleStatus` + trigger map as the send job) vs who has it recorded — unsent > 0 glows amber. This is the panel that would have replaced tonight's manual sandbox counting.
- **Needs-attention**: systems with live offers but no signup link (doc-id-first lookup, mirroring the applicant route, so stale identity fields don't false-alarm); close-sweep dry run using the *same predicate* as the sweep.
- **Anti-drift extractions**: `systemPending` (dashboard) → `lib/utils/systemPending.ts`; the close-interviews verdict → `lib/utils/interviewSweep.ts`; visible-status→trigger map → `STATUS_EMAIL_TRIGGERS` in the model. Stats, dashboard, sweep and email job now share one copy each.
- **Bot API** gains counts-only `interviews` and `decisions` blocks.
- Stats cache gets a generation counter so a compute in flight during a step change can't re-cache pre-sweep numbers.

## Privacy

Everything is a count. Two deliberate exceptions, documented in the module header: team/system names in signup-link coverage (staff config), and the capturing admin's uid on a snapshot (also in the audit log). Bot API stays counts-only.

## Verification

- `npm run build` ✓ (exit code checked)
- `stats-regress` extended to **54 checks** (phase sections against hand-computed fixtures, snapshot freeze/no-freeze, gates, PII scans) — 54/54
- `sweeps` 24/24, `transitions` 61/61, `dashboard` 10/10 (the three suites covering the refactored code paths)
- Opus review: no blockers; all 7 should-fixes addressed (cache race, maxDuration + bounded snapshot, snapshotError toast, link-lookup parity, sweep-preview normalization, light-mode overrides for the new amber/emerald classes, snapshot schema version). Consciously accepted: `demographics.major` aggregates now persist in snapshots (staff-only, fine per our internal-stats stance).

Docs note: CLAUDE.md and the pm-changes tracker are updated in #151 (follow-up docs PR), since #148 merged while this was in flight.
