### PR TITLE
docs: cover per-step stats and snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,11 +63,16 @@ CSV export + bulk actions), `stats` (aggregate numbers + trends, all staff), `ac
 audit feed — admin + captain only), `users`, `teams`, `configuration` (the CMS), and
 `settings`.
 
-Stats are computed in `lib/firebase/stats.ts` from timestamps already on the data (no stored
-snapshots, no cron) and cached 5 min. Everything in that payload is a count — never add a
-field that identifies an applicant. `GET /api/stats` serves a reduced copy to the recruiting
-bot, gated by `STATS_API_TOKEN` (a bearer token, not a user session) so the bot never holds a
-staff login.
+Stats are computed in `lib/firebase/stats.ts` on demand (no cron) and cached 5 min; history
+comes from timestamps already on the data, plus `stats_snapshots/{step}` — a counts-only
+freeze written by every FORWARD step transition (before the step write and its sweeps),
+which is how `/admin/stats` shows what a past step looked like. Everything in those payloads
+is a count — never add a field that identifies an applicant. The per-phase sections reuse
+the operational predicates (`lib/utils/systemPending.ts`, `lib/utils/interviewSweep.ts`,
+`STATUS_EMAIL_TRIGGERS` in the email model) so the numbers cannot drift from what the
+dashboard, the close-interviews sweep and the email job actually do — extend those, don't
+fork them. `GET /api/stats` serves a reduced copy to the recruiting bot, gated by
+`STATS_API_TOKEN` (a bearer token, not a user session) so the bot never holds a staff login.
 
 ## Domain model
 
@@ -218,7 +223,8 @@ exports `adminDb` / `adminAuth`). Client components never query Firestore direct
 (a 401 auto-logs-out and redirects).
 
 Collections: `applications` (with `notes`, `tasks`, `scorecards`, `interviewScorecards`
-subcollections), `users`, `config`, `interviewConfigs`, `scorecardConfigs`, `audit_log`.
+subcollections), `users`, `config`, `interviewConfigs`, `scorecardConfigs`, `audit_log`,
+`stats_snapshots` (counts-only per-step freezes, written on forward step transitions).
 (`calendarSlotLocks` and `tokens/google_calendar` still exist in production but nothing
 reads them — orphans of the deleted calendar stack, queued for deletion in the wipe.)
 

--- a/docs/pm-changes.md
+++ b/docs/pm-changes.md
@@ -41,6 +41,10 @@ repo at all — treat their dates as the last time a human looked.
 
 ## Internal code queue (not PM items)
 
+- ~~Per-step stats~~ **done 2026-08-30 (PR #150)**: step rail + phase deep-dives on
+  `/admin/stats`; `stats_snapshots/{step}` frozen on every forward transition; email
+  owed-vs-sent coverage; signup-link warnings; close-sweep dry run. The dashboard/sweep/email
+  predicates were extracted to shared modules so stats can never drift from them.
 - ~~formData whitelist~~ **done 2026-08-05**: `sanitizeIncomingFormData` in `formAnswers.ts`,
   applied in the applicant PATCH route — junk keys can no longer be written.
 - ~~FAQ/About/Teams/Contact server rendering~~ **done 2026-08-05**: all four public content


### PR DESCRIPTION
Follow-up to #150 (and to the just-merged #148): CLAUDE.md's stats paragraph now describes the on-demand compute + `stats_snapshots/{step}` freezes and the shared-predicate rule (extend, don't fork); `stats_snapshots` added to the collections list; pm-changes internal queue gets the stats-wave row. Docs only. Best merged after #150 since it documents that PR's behavior.